### PR TITLE
dispatch is now written exactly when it is time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,7 @@ dmypy.json
 
 .DS_Store
 *.orig
+.idea
 .vscode
 examples/outputs
 examples/local_db/

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from pathlib import Path
 
 import pandas as pd
@@ -12,6 +13,7 @@ from assume.common.market_objects import (
     Order,
     Orderbook,
 )
+from assume.common.utils import aggregate_step_amount
 from assume.strategies import BaseStrategy
 from assume.units import BaseUnit
 
@@ -29,6 +31,7 @@ class UnitsOperator(Role):
         self.bids_map = {}
         self.available_markets = available_markets
         self.registered_markets: dict[str, MarketConfig] = {}
+        self.last_sent_dispatch = 0
 
         if opt_portfolio is None:
             self.use_portfolio_opt = False
@@ -37,7 +40,7 @@ class UnitsOperator(Role):
             self.use_portfolio_opt = opt_portfolio[0]
             self.portfolio_strategy = opt_portfolio[1]
 
-        self.valid_orders = {}
+        self.valid_orders = []
         self.units: dict[str, BaseUnit] = {}
 
     def setup(self):
@@ -119,16 +122,26 @@ class UnitsOperator(Role):
     def handle_market_feedback(self, content: ClearingMessage, meta: dict[str, str]):
         logger.debug(f"got market result: {content}")
         orderbook: Orderbook = content["orderbook"]
-        self.valid_orders = {unit_id: [] for unit_id in self.units.keys()}
-        for bid in orderbook:
-            self.valid_orders[self.bids_map[bid["bid_id"]]].append(bid)
-        self.send_dispatch_plan(orderbook)
+        for order in orderbook:
+            order["market_id"] = content["market_id"]
+        self.valid_orders.extend(orderbook)
+        self.write_actual_dispatch()
+        self.send_unit_dispatch(orderbook)
 
-    def send_dispatch_plan(self, orderbook):
+    def send_unit_dispatch(self, orderbook):
+        """
+        feeds the current market result back to the units
+        this does not respect bids from multiple markets
+        for the same time period
+        """
         time_period = [orderbook[0]["start_time"], orderbook[0]["end_time"]]
+
+        unit_orders = {unit_id: [] for unit_id in self.units.keys()}
+        for bid in orderbook:
+            unit_orders[self.bids_map[bid["bid_id"]]].append(bid)
         for unit_id in self.units.keys():
             total_power = 0.0
-            for bid in self.valid_orders[unit_id]:
+            for bid in unit_orders[unit_id]:
                 total_power += bid["volume"]
 
             dispatch_plan = {"total_power": total_power}
@@ -137,29 +150,37 @@ class UnitsOperator(Role):
                 time_period=time_period,
             )
 
-            logger.debug("Got Dispatch Plan: %s", dispatch_plan)
-            db_aid = self.context.data_dict.get("output_agent_id")
-            db_addr = self.context.data_dict.get("output_agent_addr")
-            if db_aid and db_addr and total_power != 0.0:
-                start = bid["start_time"]
-                end = bid["end_time"]
-                # send unit data to db agent to store it
-                message = {
+    def write_actual_dispatch(self):
+        """
+        sends the actual aggregated dispatch curve
+        works across multiple markets
+        sends dispatch at or after it actually happens
+        """
+        last = self.last_sent_dispatch
+        self.last_sent_dispatch = self.context.current_timestamp
+        now = datetime.fromtimestamp(self.context.current_timestamp)
+        start = datetime.fromtimestamp(last)
+
+        actual_dispatch = aggregate_step_amount(
+            self.valid_orders, start, now, groupby=["market_id", "bid_id"]
+        )
+
+        db_aid = self.context.data_dict.get("output_agent_id")
+        db_addr = self.context.data_dict.get("output_agent_addr")
+        if db_aid and db_addr:
+            self.context.schedule_instant_acl_message(
+                receiver_id=db_aid,
+                receiver_addr=db_addr,
+                content={
                     "context": "write_results",
                     "type": "store_dispatch",
-                    "data": {
-                        "technology": self.units[unit_id].technology,
-                        "unit_id": unit_id,
-                        "power": total_power,
-                        "start_time": start,
-                        "end_time": end,
-                    },
-                }
-                self.context.schedule_instant_acl_message(
-                    receiver_id=db_aid,
-                    receiver_addr=db_addr,
-                    content=message,
-                )
+                    "data": actual_dispatch,
+                },
+            )
+
+        self.valid_orders = list(
+            filter(lambda x: x["end_time"] >= now, self.valid_orders)
+        )
 
     async def submit_bids(self, opening: OpeningMessage):
         """

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -277,3 +277,67 @@ def plot_orderbook(orderbook: Orderbook, results):
     plt.subplots_adjust(wspace=0.3)
 
     return fig, ax
+
+
+def aggregate_step_amount(orderbook: Orderbook, begin=None, end=None, groupby=[]):
+    """
+    step function with bought volume
+    allows setting timeframe through begin and end
+    and group by columns in groupby.
+    This allows to have separate time series per market and bid_id/unit_id.
+    The orderbook must contain all relevant orders.
+    E.g. to calculate the current volume from 01.06 to 02.06, a yearly base
+    order from 01.01-31.12 must also be given, to be considered.
+
+    If called without groupby, this returns the aggregated orderbook timeseries
+    """
+    deltas = []
+
+    # first we are creating a list of tuples with the following form:
+    # start, delta_volume, bid_id, market_id
+    for bid in orderbook:
+        add = ()
+        for field in groupby:
+            add += (bid[field],)
+        if bid["only_hours"] is None:
+            deltas.append((bid["start_time"], bid["volume"]) + add)
+            deltas.append((bid["end_time"], -bid["volume"]) + add)
+        else:
+            # only_hours allows to have peak or off-peak bids
+            start_hour, end_hour = bid["only_hours"]
+            duration_hours = end_hour - start_hour
+            if duration_hours <= 0:
+                duration_hours += 24
+
+            starts = rr.rrule(
+                rr.DAILY,
+                dtstart=bid["start_time"],
+                byhour=start_hour,
+                until=bid["end_time"],
+            )
+            for date in starts:
+                deltas.append((date, bid["volume"]) + add)
+                deltas.append(
+                    (date + timedelta(hours=duration_hours), -bid["volume"]) + add
+                )
+
+    aggregation = []
+    # current_power is separated by group
+    current_power = defaultdict(lambda: 0)
+    for d_tuple in sorted(deltas, key=lambda i: i[0]):
+        time, delta, *groupdata = d_tuple
+        groupdata = "_".join(groupdata)
+        current_power[groupdata] += delta
+        # we don't know what the power will be at "end" yet
+        # as a new order with this start point might be added
+        # afterwards - so the end is excluded here
+        # this also makes sure that each timestamp is only written
+        # once when iterativley calling this function
+        if (not begin or time >= begin) and (not end or time < end):
+            if len(aggregation) > 0 and aggregation[-1][0] == time:
+                aggregation[-1][1] = current_power[groupdata]
+            else:
+                d_list = list(d_tuple)
+                d_list[1] = current_power[groupdata]
+                aggregation.append(d_list)
+    return aggregation

--- a/assume/world.py
+++ b/assume/world.py
@@ -153,7 +153,7 @@ class World:
         await self.setup(self.start)
 
         # read writing properties form config
-        simulation_id = config["id"]
+        simulation_id = study_case
         save_frequency_hours = config.get("save_frequency_hours", None)
 
         # Add output agent to world

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -1136,7 +1136,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(start_time,$__interval),\n  power AS \"power\",\n  unit_id\nFROM unit_dispatch\nWHERE\n  $__timeFilter(start_time) AND\n  simulation = '$simulation' AND\n  unit_id = $unit_id\nGROUP BY 1, unit_id, power\nORDER BY 1",
+          "rawSql": "SELECT\n  $__timeGroupAlias(datetime,$__interval),\n  power AS \"power\",\n  bid_id\nFROM unit_dispatch\nWHERE\n  $__timeFilter(datetime) AND\n  simulation = '$simulation' AND\n  bid_id = $unit_id\nGROUP BY 1, bid_id, power\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -1294,15 +1294,15 @@
           "type": "postgres",
           "uid": "P7B13B9DF907EC40C"
         },
-        "definition": "SELECT \n  unit_id\nFROM unit_dispatch\nwhere simulation = '$simulation' group by unit_id;",
-        "description": "Can choose which unit we want to display ",
+        "definition": "SELECT \n  distinct bid_id\nFROM unit_dispatch\nwhere simulation = '$simulation' group by bid_id;",
+        "description": "Can choose which units we want to display ",
         "hide": 0,
         "includeAll": false,
         "label": "",
         "multi": true,
         "name": "unit_id",
         "options": [],
-        "query": "SELECT \n  unit_id\nFROM unit_dispatch\nwhere simulation = '$simulation' group by unit_id;",
+        "query": "SELECT \n  distinct bid_id\nFROM unit_dispatch\nwhere simulation = '$simulation' group by bid_id;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,

--- a/examples/example_01_timescale.py
+++ b/examples/example_01_timescale.py
@@ -17,6 +17,6 @@ DATABASE_URI = getenv(
 if __name__ == "__main__":
     world = World(database_uri=DATABASE_URI, export_csv_path=EXPORT_CSV_PATH)
     world.load_scenario(
-        inputs_path="examples/inputs", scenario="example_01a", study_case="base_case"
+        inputs_path="examples/inputs", scenario="example_01a", study_case="example_01a"
     )
     world.run()

--- a/examples/example_01a_sqlite.py
+++ b/examples/example_01a_sqlite.py
@@ -15,7 +15,7 @@ DATABASE_URI = getenv("DATABASE_URI", "sqlite:///./examples/local_db/assume_db_0
 # %%
 if __name__ == "__main__":
     scenario = "example_01a"
-    study_case = "base_case"
+    study_case = "example_01a"
 
     world = World(database_uri=DATABASE_URI, export_csv_path=EXPORT_CSV_PATH)
     world.load_scenario(

--- a/examples/example_01b_sqlite.py
+++ b/examples/example_01b_sqlite.py
@@ -15,7 +15,7 @@ DATABASE_URI = getenv("DATABASE_URI", "sqlite:///./examples/local_db/assume_db_0
 # %%
 if __name__ == "__main__":
     scenario = "example_01b"
-    study_case = "base_case"
+    study_case = "example_01b"
 
     world = World(database_uri=DATABASE_URI, export_csv_path=EXPORT_CSV_PATH)
     world.load_scenario(

--- a/examples/example_02_timescale.py
+++ b/examples/example_02_timescale.py
@@ -25,3 +25,12 @@ if __name__ == "__main__":
         study_case=study_case,
     )
     world.run()
+
+    study_case = "crm_case"
+    world = World(database_uri=DATABASE_URI, export_csv_path=EXPORT_CSV_PATH)
+    world.load_scenario(
+        inputs_path="examples/inputs",
+        scenario=scenario,
+        study_case=study_case,
+    )
+    world.run()

--- a/examples/inputs/example_01a/config.yml
+++ b/examples/inputs/example_01a/config.yml
@@ -1,5 +1,4 @@
-base_case:
-  id: example_01
+example_01a:
   start_date: 2019-01-01 00:00
   end_date: 2019-01-11 00:00
   time_step: 1h

--- a/examples/inputs/example_01b/config.yml
+++ b/examples/inputs/example_01b/config.yml
@@ -1,5 +1,4 @@
-base_case:
-  id: example_01a
+example_1b:
   start_date: 2019-01-01 00:00
   end_date: 2019-01-10 23:00
   time_step: 1h

--- a/examples/inputs/example_02/config.yml
+++ b/examples/inputs/example_02/config.yml
@@ -1,5 +1,30 @@
 base_case:
-  id: case_2019
+  start_date: 2018-12-31 20:00
+  end_date: 2019-01-11 00:00
+  time_step: 1h
+  powerplants: powerplants.csv
+  powerplants_strategy: simple
+  storage_units: storage_units.csv
+  demand: inflex_demand.csv
+  demand_strategy: simple
+  renewable_generation: renewable_generation.csv
+  fuel_prices: fuel_prices.csv
+  markets_config:
+    EOM:
+      operator: EOM_operator
+      product_type: energy
+      start_date: 2018-12-31 23:00
+      products:
+        - duration: 1h
+          count: 1
+          first_delivery: 1h
+      opening_frequency: 1h
+      opening_duration: 1h
+      volume_unit: MWh
+      maximum_volume: 1000000
+      price_unit: EUR/MWh
+      market_mechanism: pay_as_clear
+crm_case:
   start_date: 2018-12-31 20:00
   end_date: 2019-01-11 00:00
   time_step: 1h
@@ -40,7 +65,6 @@ base_case:
       price_unit: EUR/MW
       market_mechanism: pay_as_bid
 policy_case:
-  id: policy_case
   start_date: 2018-12-31 20:00
   end_date: 2019-01-11 00:00
   time_step: 1h

--- a/tests/test_market_mechanisms.py
+++ b/tests/test_market_mechanisms.py
@@ -86,8 +86,8 @@ def test_market():
     assert meta[0]["price"] > 0
     import pandas as pd
 
-    print(pd.DataFrame.from_dict(mr.all_orders))
-    print(pd.DataFrame.from_dict(clearing_result))
+    print(pd.DataFrame(mr.all_orders))
+    print(pd.DataFrame(clearing_result))
     print(meta)
 
 
@@ -150,8 +150,8 @@ def test_market_mechanism():
         assert meta[0]["supply_volume"] > 0
         assert meta[0]["price"] > 0
         # import pandas as pd
-        # print(pd.DataFrame.from_dict(mr.all_orders))
-        # print(pd.DataFrame.from_dict(clearing_result))
+        # print(pd.DataFrame(mr.all_orders))
+        # print(pd.DataFrame(clearing_result))
         print(meta)
 
     return mr.all_orders, meta


### PR DESCRIPTION
- dispatch was written after each market feedback, this does not work with multiple markets
- fix for deletion of previous data using a DBMS with transactions
- calculate the cumulated timeseries from given orderbook
- dispatch table contains market_id and bid_id
- closes #49