### PR TITLE
add cli for better configuration without a lot of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ After these steps you can also run the example simulation:
 python examples/example_01a_sqlite.py
 ```
 
+You can also use the cli to run simulations:
+
+```
+assume -s example_01b -db "postgresql://assume:assume@localhost:5432/assume"
+```
+
+If you need help using the CLI run `assume -h`
+
+
 Please note that if you have python running on windows that you need to alter the same_process binary in world to True (to be changed). 
 
 Access to database and dashboards

--- a/assume/cli.py
+++ b/assume/cli.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+import sys
+
+from assume import World
+
+os.makedirs("./examples/outputs", exist_ok=True)
+os.makedirs("./examples/local_db", exist_ok=True)
+
+
+def cli(args=None):
+    if not args:
+        args = sys.argv[1:]
+    parser = argparse.ArgumentParser(
+        description="Command Line Interface for ASSUME simulations"
+    )
+    parser.add_argument(
+        "-s",
+        "--scenario",
+        help="name of the scenario file which should be used",
+        default="example_01a",
+        type=str,
+    )
+    parser.add_argument(
+        "-c",
+        "--case-study",
+        help="name of the case in that scenario which should be simulated",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "-csv",
+        "--csv-export-path",
+        help="optional path to the csv export",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "-db",
+        "--db-uri",
+        help="uri string for a database",
+        default="",
+        type=str,
+    )
+    parser.add_argument(
+        "-input",
+        "--input-path",
+        help="path to the input folder",
+        default="examples/inputs",
+        type=str,
+    )
+
+    args = parser.parse_args(args)
+    print(args)
+    name = args.scenario
+    if args.db_uri:
+        db_uri = args.db_uri
+    else:
+        db_uri = f"sqlite:///./examples/local_db/{name}.db"
+
+    world = World(database_uri=db_uri, export_csv_path=args.csv_export_path)
+    world.load_scenario(
+        inputs_path=args.input_path,
+        scenario=args.scenario,
+        study_case=args.case_study,
+    )
+    world.run()
+
+
+if __name__ == "__main__":
+    cli()

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -85,6 +85,9 @@ class MarketRole(Role):
         products = get_available_products(
             self.marketconfig.market_products, market_open
         )
+        if market_closing > self.marketconfig.opening_hours._until:
+            # this market should not open, as the clearing is after the markets end time
+            return
 
         opening_message = {
             "context": "opening",

--- a/assume/world.py
+++ b/assume/world.py
@@ -118,7 +118,12 @@ class World:
         path = f"{inputs_path}/{scenario}"
         with open(f"{path}/config.yml", "r") as f:
             config = yaml.safe_load(f)
+            if not study_case:
+                study_case = list(config.keys())[0]
             config = config[study_case]
+        self.logger.info(
+            f"Starting Scenario {scenario}/{study_case} from {inputs_path}"
+        )
 
         self.start = pd.Timestamp(config["start_date"])
         self.end = pd.Timestamp(config["end_date"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ isort = "^5.12.0"
 pytest = "^7.2.2"
 mypy = "^1.1.1"
 
+[tool.poetry.scripts]
+assume = "assume.cli:cli"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
- don't open market on last simulation timestamp, as clearing won't happen
- docs are also added to the readme, one has to reinstall assume using:
`pip install -e .` to make use of this feature

After this, one can run for example:
`assume -s example_01a -c example_01a -db "postgresql://assume:assume@localhost:5432/assume"`