### PR TITLE
Refactor outputs and results to be more generic

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -67,7 +67,6 @@ class UnitsOperator(Role):
     async def add_unit(
         self,
         id: str,
-        unit_type: str,
         unit_class: type[BaseUnit],
         unit_params: dict,
         index: pd.DatetimeIndex,
@@ -86,7 +85,6 @@ class UnitsOperator(Role):
             message = {
                 "context": "write_results",
                 "type": "store_units",
-                "unit_type": unit_type,
                 "data": self.units[id],
             }
             await self.context.send_acl_message(

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -42,6 +42,7 @@ class UnitsOperator(Role):
             self.use_portfolio_opt = opt_portfolio[0]
             self.portfolio_strategy = opt_portfolio[1]
 
+        # should be a list per product_type
         self.valid_orders = []
         self.units: dict[str, BaseUnit] = {}
 
@@ -295,13 +296,3 @@ class UnitsOperator(Role):
                         self.bids_map[order_c["bid_id"]] = unit_id
 
         return orderbook
-
-    # async def on_stop(self):
-    #     series = aggregate_step_amount(self.valid_orders)
-    #     df = pd.DataFrame(series)
-
-    #     if not df.empty:
-    #         import matplotlib.pyplot as plt
-    #         plt.plot(df[0], df[1])
-    #         plt.title(self.id)
-    #         plt.show()

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -41,10 +41,10 @@ class flexableEOM(BaseStrategy):
                 unit, marginal_cost_flex, bid_quantity_inflex
             )
 
-        if unit.total_heat_output[self.current_time] > 0:
+        if unit.outputs["heat"][self.current_time] > 0:
             power_loss_ratio = (
                 unit.power_loss_chp[self.current_time]
-                / unit.total_heat_output[self.current_time]
+                / unit.outputs["heat"][self.current_time]
             )
         else:
             power_loss_ratio = 0.0
@@ -95,9 +95,9 @@ class flexableEOM(BaseStrategy):
 
         price_reduction_restart = starting_cost / min_down_time / bid_quantity_inflex
 
-        if unit.total_heat_output[t] > 0:
+        if unit.outputs["heat"][t] > 0:
             heat_gen_cost = (
-                unit.total_heat_output[t] * (unit.fuel_price["natural gas"][t] / 0.9)
+                unit.outputs["heat"][t] * (unit.fuel_price["natural gas"][t] / 0.9)
             ) / bid_quantity_inflex
         else:
             heat_gen_cost = 0.0

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -43,7 +43,7 @@ class flexableEOMStorage(BaseStrategy):
                     max(
                         (
                             (unit.current_SOC - unit.min_SOC)
-                            - unit.pos_capacity_reserve[self.current_time]
+                            - unit.outputs["pos_capacity"][self.current_time]
                         )
                         * unit.efficiency_discharge,
                         0,

--- a/assume/strategies/rl_strategies.py
+++ b/assume/strategies/rl_strategies.py
@@ -42,10 +42,10 @@ class RLStrategy(BaseStrategy):
                     unit, marginal_cost_flex, bid_quantity_inflex
                 )
 
-            if unit.total_heat_output[self.current_time] > 0:
+            if unit.outputs["heat"][self.current_time] > 0:
                 power_loss_ratio = (
                     unit.power_loss_chp[self.current_time]
-                    / unit.total_heat_output[self.current_time]
+                    / unit.outputs["heat"][self.current_time]
                 )
             else:
                 power_loss_ratio = 0.0
@@ -93,9 +93,9 @@ class RLStrategy(BaseStrategy):
             starting_cost / unit.min_down_time / bid_quantity_inflex
         )
 
-        if unit.total_heat_output[t] > 0:
+        if unit.outputs["heat"][t] > 0:
             heat_gen_cost = (
-                unit.total_heat_output[t] * (unit.fuel_price["natural gas"][t] / 0.9)
+                unit.outputs["heat"][t] * (unit.fuel_price["natural gas"][t] / 0.9)
             ) / bid_quantity_inflex
         else:
             heat_gen_cost = 0.0

--- a/assume/units/base_unit.py
+++ b/assume/units/base_unit.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 import pandas as pd
 
 from assume.strategies import BaseStrategy
@@ -36,7 +38,7 @@ class BaseUnit:
         self.node = node
         self.bidding_strategies: dict[str, BaseStrategy] = bidding_strategies
         self.index = index
-        self.total_power_output = pd.Series(0.0, index=self.index)
+        self.outputs = defaultdict(lambda: pd.Series(0.0, index=self.index))
 
     def calculate_operational_window(
         self,
@@ -87,7 +89,8 @@ class BaseUnit:
         """
         adds dispatch plan from current market result to total dispatch plan
         """
-        pass
+        end_excl = end - self.index.freq
+        self.outputs[product_type].loc[start:end_excl] += dispatch_plan["total_power"]
 
     def execute_current_dispatch(
         self,
@@ -98,10 +101,10 @@ class BaseUnit:
         check if the total dispatch plan is feasible
         This checks if the market feedback is feasible for the given unit.
         And sets the closest dispatch if not.
-        The end date is inclusive.
+        The end param should be inclusive.
         """
         end_excl = end - self.index.freq
-        return self.total_power_output[start:end_excl]
+        return self.outputs["energy"][start:end_excl]
 
     def as_dict(self) -> dict:
         return {

--- a/assume/units/base_unit.py
+++ b/assume/units/base_unit.py
@@ -102,3 +102,10 @@ class BaseUnit:
         """
         end_excl = end - self.index.freq
         return self.total_power_output[start:end_excl]
+
+    def as_dict(self) -> dict:
+        return {
+            "technology": self.technology,
+            "unit_operator": self.unit_operator,
+            "unit_type": "base_unit",
+        }

--- a/assume/units/demand.py
+++ b/assume/units/demand.py
@@ -51,10 +51,9 @@ class Demand(BaseUnit):
         self.volume = -volume  # demand is negative
         self.price = price
         self.location = location
-        self.total_power_output = []
 
     def reset(self):
-        self.total_power_output = pd.Series(0, index=self.index)
+        self.outputs["energy"] = pd.Series(0, index=self.index)
 
     def calculate_operational_window(
         self,
@@ -65,7 +64,7 @@ class Demand(BaseUnit):
         start = pd.Timestamp(start)
         end = pd.Timestamp(end)
         """Calculate the operation window for the next time step."""
-        bid_volume = (self.volume - self.total_power_output).loc[start:end].max()
+        bid_volume = (self.volume - self.outputs[product_type]).loc[start:end].max()
 
         if type(self.price) == pd.Series:
             bid_price = self.price.loc[start:end].mean()
@@ -73,12 +72,6 @@ class Demand(BaseUnit):
             bid_price = self.price
 
         return {"max_power": {"power": bid_volume, "marginal_cost": bid_price}}
-
-    def set_dispatch_plan(
-        self, dispatch_plan, start: pd.Timestamp, end: pd.Timestamp, product_type: str
-    ):
-        end_excl = end - self.index.freq
-        self.total_power_output.loc[start:end_excl] += dispatch_plan["total_power"]
 
     def as_dict(self) -> dict:
         unit_dict = super().as_dict()

--- a/assume/units/demand.py
+++ b/assume/units/demand.py
@@ -79,3 +79,15 @@ class Demand(BaseUnit):
     ):
         end_excl = end - self.index.freq
         self.total_power_output.loc[start:end_excl] += dispatch_plan["total_power"]
+
+    def as_dict(self) -> dict:
+        unit_dict = super().as_dict()
+        unit_dict.update(
+            {
+                "max_power": self.max_power,
+                "min_power": self.min_power,
+                "unit_type": "demand",
+            }
+        )
+
+        return unit_dict

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -443,3 +443,17 @@ class PowerPlant(BaseUnit):
         max_delta = max_power - base_load.max()
 
         return min_delta, max_delta
+
+    def as_dict(self) -> dict:
+        unit_dict = super().as_dict()
+        unit_dict.update(
+            {
+                "max_power": self.max_power,
+                "min_power": self.min_power,
+                "emission_factor": self.emission_factor,
+                "efficiency": self.efficiency,
+                "unit_type": "power_plant",
+            }
+        )
+
+        return unit_dict

--- a/assume/units/storage_unit.py
+++ b/assume/units/storage_unit.py
@@ -470,3 +470,18 @@ class StorageUnit(BaseUnit):
         marginal_cost = variable_cost / efficiency + self.fixed_cost
 
         return marginal_cost
+
+    def as_dict(self) -> dict:
+        unit_dict = super().as_dict()
+        unit_dict.update(
+            {
+                "max_power_charge": self.max_power_charge,
+                "max_power_discharge": self.max_power_discharge,
+                "min_power_charge": self.min_power_charge,
+                "min_power_discharge": self.min_power_discharge,
+                "efficiency_charge": self.efficiency_discharge,
+                "unit_type": "storage",
+            }
+        )
+
+        return unit_dict

--- a/assume/world.py
+++ b/assume/world.py
@@ -80,7 +80,7 @@ class World:
             "power_plant": PowerPlant,
             "heatpump": HeatPump,
             "demand": Demand,
-            "storage_unit": StorageUnit,
+            "storage": StorageUnit,
         }
         self.bidding_types = {
             "naive": NaiveStrategy,
@@ -436,7 +436,7 @@ class World:
 
                 await self.add_unit(
                     id=storage_name,
-                    unit_type="storage_unit",
+                    unit_type="storage",
                     unit_operator_id=unit_params["unit_operator"],
                     unit_params=unit_params,
                 )
@@ -541,7 +541,6 @@ class World:
         # create unit within the unit operator its associated with
         await self.unit_operators[unit_operator_id].add_unit(
             id=id,
-            unit_type=unit_type,
             unit_class=unit_class,
             unit_params=unit_params,
             index=self.index,

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -1016,7 +1016,7 @@
               "hide": false,
               "metricColumn": "none",
               "rawQuery": true,
-              "rawSql": "SELECT \n  NOW() as time_sec,\n  SUM(max_power),\n  technology\nFROM unit_meta\nWHERE \"simulation\" LIKE '$simulation'\nGROUP BY technology, simulation;\n\n\n",
+              "rawSql": "SELECT \n  NOW() as time_sec,\n  SUM(max_power),\n  technology\nFROM power_plant_meta\nWHERE \"simulation\" LIKE '$simulation'\nGROUP BY technology, simulation;\n\n\n",
               "refId": "Generation",
               "select": [
                 [
@@ -1040,7 +1040,7 @@
                   }
                 ]
               ],
-              "table": "unit_meta",
+              "table": "power_plant_meta",
               "timeColumn": "fuel_type",
               "timeColumnType": "text",
               "where": [
@@ -1314,7 +1314,7 @@
               "group": [],
               "metricColumn": "none",
               "rawQuery": true,
-              "rawSql": "SELECT * FROM unit_meta\nWHERE index in ($Gen_Units) and simulation = '$simulation'\n",
+              "rawSql": "SELECT * FROM power_plant_meta\nWHERE index in ($Gen_Units) and simulation = '$simulation'\n",
               "refId": "A",
               "select": [
                 [
@@ -2116,14 +2116,14 @@
           "type": "postgres",
           "uid": "P7B13B9DF907EC40C"
         },
-        "definition": "SELECT \n  simulation\nFROM unit_meta\ngroup by simulation;",
+        "definition": "SELECT \n  simulation\nFROM power_plant_meta\ngroup by simulation;",
         "description": "Can choose which simulation we want to show ",
         "hide": 0,
         "includeAll": false,
         "multi": false,
         "name": "simulation",
         "options": [],
-        "query": "SELECT \n  simulation\nFROM unit_meta\ngroup by simulation;",
+        "query": "SELECT \n  simulation\nFROM power_plant_meta\ngroup by simulation;",
         "refresh": 1,
         "regex": "",
         "skipUrlSync": false,
@@ -2170,7 +2170,7 @@
           "type": "postgres",
           "uid": "P7B13B9DF907EC40C"
         },
-        "definition": "SELECT index\nFROM unit_meta\nwhere simulation = '$simulation';",
+        "definition": "SELECT index\nFROM power_plant_meta\nwhere simulation = '$simulation';",
         "description": "Can choose which units we want to display ",
         "hide": 0,
         "includeAll": false,
@@ -2178,7 +2178,7 @@
         "multi": true,
         "name": "Gen_Units",
         "options": [],
-        "query": "SELECT index\nFROM unit_meta\nwhere simulation = '$simulation';",
+        "query": "SELECT index\nFROM power_plant_meta\nwhere simulation = '$simulation';",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,


### PR DESCRIPTION
This moves the code used to determine which params are added to which output table into the units which gives a cleaner implementation of the outputs.py

Furthermore, instead of having self.total_whatever_output, we switch to self.outputs["whatever"] which gives an according series by default (through defaultdict)