### PR TITLE
adds config for pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.12.0
+    hooks:
+      - id: isort
+
+  - repo: https://github.com/psf/black
+    rev: 23.3.0
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: trailing-whitespace

--- a/README.md
+++ b/README.md
@@ -71,6 +71,17 @@ If you need help using the CLI run `assume -h`
 
 Please note that if you have python running on windows that you need to alter the same_process binary in world to True (to be changed). 
 
+
+Development
+-----------
+
+install pre-commit
+
+```
+pip install pre-commit
+pre-commit install
+```
+
 Access to database and dashboards
 ---------------------------------
 To save the simulation results to a database and be able to analyze them using Grafan dashboards, install the docker container:


### PR DESCRIPTION
This adds a pre-commit hook which runs isort, black and checks for trailing spaces in line endings, so that no commit is wasted on such things.

To use it, one has to run

```
pip install pre-commit
pre-commit install
```

This will affect a lot of line endings we currently have in various files, but after this, we do not have trouble with extra commits regarding formatting anymore