### PR TITLE
change type checks to isinstance

### DIFF
--- a/assume/common/forecasts.py
+++ b/assume/common/forecasts.py
@@ -127,7 +127,7 @@ class ForecastProvider(Role):
             pp_df = powerplants.copy()
             pp_df["marginal_cost"] = (
                 marginal_costs.iloc[i]
-                if type(marginal_costs) == pd.DataFrame
+                if isinstance(marginal_costs, pd.DataFrame)
                 else marginal_costs
             )
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -254,7 +254,7 @@ class RLStrategy(LearningStrategy):
         if unit.marginal_cost is not None:
             marginal_cost = (
                 unit.marginal_cost[start]
-                if type(unit.marginal_cost) is dict
+                if isinstance(self.marginal_cost, dict)
                 else unit.marginal_cost
             )
         else:

--- a/assume/units/electrolyser.py
+++ b/assume/units/electrolyser.py
@@ -139,7 +139,7 @@ class Electrolyser(BaseUnit):
         """
         efficiency_t = self.efficiency.loc[timestep]
 
-        if type(self.electricity_price) == pd.Series:
+        if isinstance(self.electricity_price, pd.Series):
             bid_price = self.electricity_price.at[timestep] / efficiency_t
         else:
             bid_price = self.electricity_price / efficiency_t

--- a/assume/units/heatpump.py
+++ b/assume/units/heatpump.py
@@ -128,14 +128,14 @@ class HeatPump(SupportsMinMax):
         # check if min_power is a series or a float
         min_power = (
             self.min_power.at[start]
-            if type(self.min_power) is pd.Series
+            if isinstance(self.min_power, pd.Series)
             else self.min_power
         )
 
         # check if max_power is a series or a float
         max_power = (
             self.max_power.at[start]
-            if type(self.max_power) is pd.Series
+            if isinstance(self.max_power, pd.Series)
             else self.max_power
         )
 
@@ -202,7 +202,7 @@ class HeatPump(SupportsMinMax):
         cop = self.calculate_cop()
         cop_t = cop.loc[timestep]
 
-        if type(self.electricity_price) == pd.Series:
+        if isinstance(self.electricity_price, pd.Series):
             bid_price = self.electricity_price.at[timestep] / cop_t
         else:
             bid_price = self.electricity_price / cop_t

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -59,10 +59,10 @@ class PowerPlant(SupportsMinMax):
         self.efficiency = efficiency
         self.partial_load_eff = partial_load_eff
         self.fuel_type = fuel_type
-        if type(fuel_price) is pd.Series and len(fuel_price) == 1:
+        if isinstance(fuel_price, pd.Series) and len(fuel_price) == 1:
             fuel_price = fuel_price.item()
         self.fuel_price = fuel_price
-        if type(co2_price) is pd.Series and len(co2_price) == 1:
+        if isinstance(co2_price, pd.Series) and len(co2_price) == 1:
             co2_price = co2_price.item()
         self.co2_price = co2_price
         self.price_forecast = (
@@ -98,7 +98,7 @@ class PowerPlant(SupportsMinMax):
         self.init_marginal_cost()
 
     def init_marginal_cost(self):
-        if not self.partial_load_eff and type(self.fuel_price) is not pd.Series:
+        if not self.partial_load_eff and not isinstance(self.fuel_price, pd.Series):
             fuel_prices = {self.fuel_type: self.fuel_price, "co2": self.co2_price}
             self.marginal_cost = self.calc_simple_marginal_cost(fuel_prices)
         elif not self.partial_load_eff:
@@ -200,12 +200,12 @@ class PowerPlant(SupportsMinMax):
     ) -> float or pd.Series:
         fuel_price = (
             self.fuel_price.at[timestep]
-            if type(self.fuel_price) is pd.Series
+            if isinstance(self.fuel_price, pd.Series)
             else self.fuel_price
         )
         co2_price = (
             self.co2_price.at[timestep]
-            if type(self.co2_price) is pd.Series
+            if isinstance(self.co2_price, pd.Series)
             else self.co2_price
         )
 
@@ -313,7 +313,7 @@ class PowerPlant(SupportsMinMax):
         if self.marginal_cost:
             marginal_cost = (
                 self.marginal_cost[start]
-                if type(self.marginal_cost) is dict
+                if isinstance(self.marginal_cost, dict)
                 else self.marginal_cost
             )
 

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -318,7 +318,7 @@ class Storage(SupportsMinMaxCharge):
         if discharge:
             variable_cost = (
                 self.variable_cost_discharge.at[timestep]
-                if type(self.variable_cost_discharge) is pd.Series
+                if isinstance(self.variable_cost_discharge, pd.Series)
                 else self.variable_cost_discharge
             )
             efficiency = self.efficiency_discharge
@@ -326,7 +326,7 @@ class Storage(SupportsMinMaxCharge):
         else:
             variable_cost = (
                 self.variable_cost_charge.at[timestep]
-                if type(self.variable_cost_charge) is pd.Series
+                if isinstance(self.variable_cost_charge, pd.Series)
                 else self.variable_cost_charge
             )
             efficiency = self.efficiency_charge
@@ -365,7 +365,7 @@ class Storage(SupportsMinMaxCharge):
 
         min_power_charge = (
             self.min_power_charge[start:end_excl]
-            if type(self.min_power_charge) is pd.Series
+            if isinstance(self.min_power_charge, pd.Series)
             else self.min_power_charge
         )
         min_power_charge -= base_load
@@ -373,7 +373,7 @@ class Storage(SupportsMinMaxCharge):
 
         max_power_charge = (
             self.max_power_charge[start:end_excl]
-            if type(self.max_power_charge) is pd.Series
+            if isinstance(self.max_power_charge, pd.Series)
             else self.max_power_charge
         )
         max_power_charge -= base_load + capacity_neg
@@ -412,7 +412,7 @@ class Storage(SupportsMinMaxCharge):
 
         min_power_discharge = (
             self.min_power_discharge[start:end_excl]
-            if type(self.min_power_discharge) is pd.Series
+            if isinstance(self.min_power_discharge, pd.Series)
             else self.min_power_discharge
         )
         min_power_discharge -= base_load
@@ -420,7 +420,7 @@ class Storage(SupportsMinMaxCharge):
 
         max_power_discharge = (
             self.max_power_discharge[start:end_excl]
-            if type(self.max_power_discharge) is pd.Series
+            if isinstance(self.max_power_discharge, pd.Series)
             else self.max_power_discharge
         )
         max_power_discharge -= base_load + capacity_pos


### PR DESCRIPTION
fixes #107

type checks for the actual type but does not allow subtyping for example:

```python
from collections import defaultdict
>>> dd = defaultdict(list)
>>> type(dd) == dict
False
>>> isinstance(dd, dict)
True
```

We are switching therefore to type checking with to `isinstance`