### PR TITLE
fix bidding behavior for multiple bids, add day_ahead_market

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -282,23 +282,13 @@ class UnitsOperator(Role):
                 data_dict=self.context.data_dict,
             )
             product = products[0]
-            for i, bid in enumerate(product_bids):
-                order: Order = {
-                    "start_time": product[0],
-                    "end_time": product[1],
-                    "only_hours": product[2],
-                    "agent_id": (self.context.addr, self.context.aid),
-                }
-                price = bid["price"]
-                volume = bid["volume"]
-
+            for i, order in enumerate(product_bids):
+                order["agent_id"] = (self.context.addr, self.context.aid)
                 if market.volume_tick:
-                    volume = round(volume / market.volume_tick)
+                    order["volume"] = round(order["volume"] / market.volume_tick)
                 if market.price_tick:
-                    price = round(price / market.price_tick)
+                    order["price"] = round(order["price"] / market.price_tick)
 
-                order["volume"] = volume
-                order["price"] = price
                 order["bid_id"] = f"{unit_id}_{i+1}"
                 order["product"] = product
                 orderbook.append(order)

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -21,18 +21,25 @@ class OTCStrategy(BaseStrategy):
         Return: volume, price
         """
         bids = []
-        for product_tuple in product_tuples:
-            start = product_tuple[0]
-            end = product_tuple[1]
+        for product in product_tuples:
+            start = product[0]
+            end = product[1]
 
             min_power, max_power = unit.calculate_min_max_power(start, end)
             current_power = unit.outputs["energy"].at[start]
-            min_price = unit.calculate_marginal_cost(start, current_power - min_power)
             max_price = unit.calculate_marginal_cost(start, current_power + max_power)
 
             price = max_price
             volume = max_power
             if "OTC" in market_config.name:
                 volume *= self.scale
-            bids.append({"price": price, "volume": volume})
+            bids.append(
+                {
+                    "start_time": start,
+                    "end_time": end,
+                    "only_hours": product[2],
+                    "price": price,
+                    "volume": volume,
+                }
+            )
         return bids

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -78,8 +78,20 @@ class flexableEOM(BaseStrategy):
             bid_price_flex = (1 - power_loss_ratio) * marginal_cost_flex
 
         bids = [
-            {"price": bid_price_inflex, "volume": bid_quantity_inflex},
-            {"price": bid_price_flex, "volume": bid_quantity_flex},
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": bid_price_inflex,
+                "volume": bid_quantity_inflex,
+            },
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": bid_price_flex,
+                "volume": bid_quantity_flex,
+            },
         ]
 
         return bids
@@ -197,19 +209,23 @@ class flexablePosCRM(BaseStrategy):
         energy_price = marginal_cost
 
         if market_config.product_type == "capacity_pos":
-            bids = [
-                {"price": capacity_price, "volume": bid_quantity},
-            ]
+            price = capacity_price
         elif market_config.product_type == "energy_pos":
-            bids = [
-                {"price": energy_price, "volume": bid_quantity},
-            ]
+            price = energy_price
         else:
             raise ValueError(
                 f"Product {market_config.product_type} is not supported by this strategy."
             )
 
-        return bids
+        return [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": price,
+                "volume": bid_quantity,
+            },
+        ]
 
 
 class flexableNegCRM(BaseStrategy):
@@ -264,19 +280,23 @@ class flexableNegCRM(BaseStrategy):
         energy_price = marginal_cost * (-1)
 
         if market_config.product_type == "capacity_neg":
-            bids = [
-                {"price": capacity_price, "volume": bid_quantity},
-            ]
+            price = capacity_price
         elif market_config.product_type == "energy_neg":
-            bids = [
-                {"price": energy_price, "volume": bid_quantity},
-            ]
+            price = energy_price
         else:
             raise ValueError(
                 f"Product {market_config.product_type} is not supported by this strategy."
             )
 
-        return bids
+        return [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": price,
+                "volume": bid_quantity,
+            },
+        ]
 
 
 def get_specific_revenue(

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -80,7 +80,15 @@ class flexableEOMStorage(BaseStrategy):
             bid_quantity,
         )
 
-        return [{"price": average_price, "volume": bid_quantity.max()}]
+        return [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": average_price,
+                "volume": bid_quantity.max(),
+            },
+        ]
 
 
 class flexablePosCRMStorage(BaseStrategy):
@@ -144,19 +152,23 @@ class flexablePosCRMStorage(BaseStrategy):
         energy_price = capacity_price / unit.current_SOC
 
         if market_config.product_type == "capacity_pos":
-            bids = [
-                {"price": capacity_price, "volume": bid_quantity},
-            ]
+            price = capacity_price
         elif market_config.product_type == "energy_pos":
-            bids = [
-                {"price": energy_price, "volume": bid_quantity},
-            ]
+            price = energy_price
         else:
             raise ValueError(
                 f"Product {market_config.product_type} is not supported by this strategy."
             )
 
-        return bids
+        return [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": price,
+                "volume": bid_quantity.max(),
+            },
+        ]
 
 
 class flexableNegCRMStorage(BaseStrategy):
@@ -198,20 +210,15 @@ class flexableNegCRMStorage(BaseStrategy):
             return []
         # if bid_quantity >= min_bid_volume
 
-        if market_config.product_type == "capacity_neg":
-            bids = [
-                {"price": 0, "volume": bid_quantity},
-            ]
-        elif market_config.product_type == "energy_neg":
-            bids = [
-                {"price": 0, "volume": bid_quantity},
-            ]
-        else:
-            raise ValueError(
-                f"Product {market_config.product_type} is not supported by this strategy."
-            )
-
-        return bids
+        return [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": 0,
+                "volume": bid_quantity.max(),
+            },
+        ]
 
 
 def calculate_price_average(unit, current_time, foresight, price_forecast):

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -116,8 +116,20 @@ class RLStrategy(LearningStrategy):
             bid_price_flex = max(bid_prices)
 
         bids = [
-            {"price": bid_price_inflex, "volume": bid_quantity_inflex},
-            {"price": bid_price_flex, "volume": bid_quantity_flex},
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": bid_price_inflex,
+                "volume": bid_quantity_inflex,
+            },
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": bid_price_flex,
+                "volume": bid_quantity_flex,
+            },
         ]
 
         self.curr_observation = self.next_observation

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -32,7 +32,16 @@ class PowerPlantStrategy(BaseStrategy):
         bids = []
         for product in product_tuples:
             price, volume = self.calculate_simple(unit, product[0], product[1])
-            bids.append({"price": price, "volume": volume})
+            bids.append(
+                {
+                    "start_time": product[0],
+                    "end_time": product[1],
+                    "only_hours": product[2],
+                    "price": price,
+                    "volume": volume,
+                }
+            )
+
         return bids
 
 
@@ -68,7 +77,15 @@ class NaivePosReserveStrategy(PowerPlantStrategy):
             current_power = unit.outputs["energy"].at[start]
             volume = unit.calculate_ramp_up(previous_power, max_power, current_power)
             price = 0
-            bids.append({"price": price, "volume": volume})
+            bids.append(
+                {
+                    "start_time": product[0],
+                    "end_time": product[1],
+                    "only_hours": product[2],
+                    "price": price,
+                    "volume": volume,
+                }
+            )
         return bids
 
 
@@ -100,5 +117,13 @@ class NaiveNegReserveStrategy(PowerPlantStrategy):
             current_power = unit.outputs["energy"].at[start]
             volume = unit.calculate_ramp_down(previous_power, min_power, current_power)
             price = 0
-            bids.append({"price": price, "volume": volume})
+            bids.append(
+                {
+                    "start_time": product[0],
+                    "end_time": product[1],
+                    "only_hours": product[2],
+                    "price": price,
+                    "volume": volume,
+                }
+            )
         return bids

--- a/assume/strategies/storage_strategies.py
+++ b/assume/strategies/storage_strategies.py
@@ -27,8 +27,9 @@ class complexEOMStorage(BaseStrategy):
         Strategy analogue to flexABLE
 
         """
-        start = product_tuples[0][0]
-        end = product_tuples[0][1]
+        product = product_tuples[0]
+        start = product[0]
+        end = product[1]
 
         price_forecast = data_dict["price_forecast"]
         self.price_forecast = price_forecast
@@ -123,10 +124,21 @@ class complexEOMStorage(BaseStrategy):
             bid_quantity_flex = 0
 
         bids = [
-            {"price": bid_price_mr, "volume": bid_quantity_mr},
-            {"price": bid_price_flex, "volume": bid_quantity_flex},
+            {
+                "start_time": product[0],
+                "end_time": product[1],
+                "only_hours": product[2],
+                "price": bid_price_mr,
+                "volume": bid_quantity_mr,
+            },
+            {
+                "start_time": product[0],
+                "end_time": product[1],
+                "only_hours": product[2],
+                "price": bid_price_flex,
+                "volume": bid_quantity_flex,
+            },
         ]
-
         return bids
 
     def calculate_price_average(self, unit):

--- a/examples/inputs/example_01a/config.yml
+++ b/examples/inputs/example_01a/config.yml
@@ -19,3 +19,25 @@ example_01a:
       minimum_bid_price: -500
       price_unit: EUR/MWh
       market_mechanism: pay_as_clear
+
+day_ahead_market:
+  start_date: 2019-01-01 00:00
+  end_date: 2019-04-01 00:00
+  time_step: 1h
+  save_frequency_hours: 24
+  markets_config:
+    EOM:
+      operator: EOM_operator
+      product_type: energy
+      products:
+        - duration: 1h
+          count: 24
+          first_delivery: 1h
+      opening_frequency: 24h
+      opening_duration: 24h
+      volume_unit: MWh
+      maximum_bid_volume: 100000
+      maximum_bid_price: 3000
+      minimum_bid_price: -500
+      price_unit: EUR/MWh
+      market_mechanism: pay_as_clear


### PR DESCRIPTION
to test, run the 24h bidding day-ahead market:
`assume -s example_01a -c day_ahead_market -db "postgresql://assume:assume@localhost:5432/assume"`
and the hourly market:
`assume -s example_01a -db "postgresql://assume:assume@localhost:5432/assume"`

and visit http://localhost:3000/d/vP8U8-q4k/assume-comparison