### PR TITLE
Readd tests for powerplant, demand and bidding_strategies

### DIFF
--- a/assume/common/market_objects.py
+++ b/assume/common/market_objects.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
-from typing import Callable, NamedTuple, TypedDict, Union
+from typing import Callable, NamedTuple, TypedDict
 
 from dateutil import rrule as rr
 from dateutil.relativedelta import relativedelta as rd
@@ -22,8 +22,8 @@ class OnlyHours(NamedTuple):
 # describes an order which can be either generation (volume > 0) or demand (volume < 0)
 class Order(TypedDict):
     bid_id: str
-    start_time: Union[datetime, float]
-    end_time: Union[datetime, float]
+    start_time: datetime
+    end_time: datetime
     volume: int  # positive if generation
     price: int
     only_hours: OnlyHours | None = None
@@ -38,7 +38,7 @@ eligible_lambda = Callable[[Agent], bool]
 # describes the configuration of a market product which is available at a market
 @dataclass
 class MarketProduct:
-    duration: rd  # quarter-hourly, half-hourly, hourly, 4hourly, daily, weekly, monthly, quarter-yearly, yearly
+    duration: rd | rr.rrule  # quarter-hourly, half-hourly, hourly, 4hourly, daily, weekly, monthly, quarter-yearly, yearly
     count: int  # how many future durations can be traded, must be >= 1
     # count can also be given as a rrule with until
     first_delivery: rd = (

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -33,7 +33,7 @@ class MarketRole(Role):
         self.marketconfig.aid = self.context.aid
         self.all_orders: list[Order] = []
         self.market_result: Orderbook = []
-        self.registered_agents: list[str] = []
+        self.registered_agents: list[tuple[str, str]] = []
         self.open_slots = []
 
         def accept_orderbook(content: dict, meta):

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -27,12 +27,11 @@ class OTCStrategy(BaseStrategy):
 
             min_power, max_power = unit.calculate_min_max_power(start, end)
             current_power = unit.outputs["energy"].at[start]
-            max_price = unit.calculate_marginal_cost(start, current_power + max_power)
-
-            price = max_price
-            volume = max_power
+            volume = max_power[start]
             if "OTC" in market_config.name:
                 volume *= self.scale
+            price = unit.calculate_marginal_cost(start, current_power + volume)
+
             bids.append(
                 {
                     "start_time": start,

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -4,10 +4,10 @@ from assume.common.base import BaseStrategy, BaseUnit, SupportsMinMax
 from assume.common.market_objects import MarketConfig, Orderbook, Product
 
 
-class PowerPlantStrategy(BaseStrategy):
+class NaiveStrategy(BaseStrategy):
     def calculate_bids(
         self,
-        unit: BaseUnit,
+        unit: SupportsMinMax,
         market_config: MarketConfig,
         product_tuples: list[Product],
         **kwargs,
@@ -40,17 +40,13 @@ class PowerPlantStrategy(BaseStrategy):
         return bids
 
 
-class NaiveStrategy(PowerPlantStrategy):
-    pass
-
-
-class NaivePosReserveStrategy(PowerPlantStrategy):
+class NaivePosReserveStrategy(BaseStrategy):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def calculate_bids(
         self,
-        unit: BaseUnit,
+        unit: SupportsMinMax,
         market_config: MarketConfig,
         product_tuples: list[Product],
         **kwargs,
@@ -89,13 +85,13 @@ class NaivePosReserveStrategy(PowerPlantStrategy):
         return bids
 
 
-class NaiveNegReserveStrategy(PowerPlantStrategy):
+class NaiveNegReserveStrategy(BaseStrategy):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
     def calculate_bids(
         self,
-        unit: BaseUnit,
+        unit: SupportsMinMax,
         market_config: MarketConfig,
         product_tuples: list[Product],
         **kwargs,

--- a/assume/units/demand.py
+++ b/assume/units/demand.py
@@ -1,3 +1,5 @@
+import numbers
+
 import pandas as pd
 
 from assume.common.base import SupportsMinMax
@@ -47,10 +49,10 @@ class Demand(SupportsMinMax):
             self.min_power = -max_power
         self.ramp_down = max(abs(min_power), abs(max_power))
         self.ramp_up = max(abs(min_power), abs(max_power))
-        if isinstance(volume, float):
+        if isinstance(volume, numbers.Real):
             volume = pd.Series(volume, index=self.index)
         self.volume = -abs(volume)  # demand is negative
-        if isinstance(price, float):
+        if isinstance(price, numbers.Real):
             price = pd.Series(price, index=self.index)
         self.price = price
         self.location = location

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -297,39 +297,6 @@ class PowerPlant(SupportsMinMax):
                 timestep=start,
             )
 
-    def calculate_min_max_price(self, start: pd.Timestamp, end: pd.Timestamp):
-        """
-        calculates prices, checks for ramping too
-        is only valid for single time frame orders
-        """
-        min_power, max_power = self.calculate_min_max_power(start, end)
-        previous_power = self.get_output_before(start)
-
-        # adjust for ramp down speed
-        min_power = max(previous_power - self.ramp_down, min_power)
-        # adjust for ramp up speed
-        max_power = min(previous_power + self.ramp_up, max_power)
-
-        if self.marginal_cost:
-            marginal_cost = (
-                self.marginal_cost[start]
-                if isinstance(self.marginal_cost, dict)
-                else self.marginal_cost
-            )
-
-            max_cost = marginal_cost
-            min_cost = marginal_cost
-        else:
-            min_cost = self.calc_marginal_cost_with_partial_eff(
-                power_output=previous_power + min_power,
-                timestep=start,
-            )
-            max_cost = self.calc_marginal_cost_with_partial_eff(
-                power_output=previous_power + max_power,
-                timestep=start,
-            )
-        return min_power, min_cost, max_power, max_cost
-
     def as_dict(self) -> dict:
         unit_dict = super().as_dict()
         unit_dict.update(

--- a/examples/inputs/example_01a/config.yml
+++ b/examples/inputs/example_01a/config.yml
@@ -20,6 +20,28 @@ example_01a:
       price_unit: EUR/MWh
       market_mechanism: pay_as_clear
 
+tiny_example:
+  start_date: 2019-01-01 00:00
+  end_date: 2019-01-03 00:00
+  time_step: 1h
+  save_frequency_hours: 24
+  markets_config:
+    EOM:
+      operator: EOM_operator
+      product_type: energy
+      products:
+        - duration: 1h
+          count: 1
+          first_delivery: 1h
+      opening_frequency: 1h
+      opening_duration: 1h
+      volume_unit: MWh
+      maximum_bid_volume: 100000
+      maximum_bid_price: 3000
+      minimum_bid_price: -500
+      price_unit: EUR/MWh
+      market_mechanism: pay_as_clear
+
 day_ahead_market:
   start_date: 2019-01-01 00:00
   end_date: 2019-04-01 00:00

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from assume.common.base import SupportsMinMax
+
+
+class MockMarketConfig:
+    product_type = "energy"
+
+
+class MockMinMaxUnit(SupportsMinMax):
+    def __init__(self, index):
+        super().__init__("", "", "", {}, index, None)
+        self.max_power = 1000
+        self.min_power = 0
+        self.ramp_down = 200
+        self.ramp_up = 400
+
+    def calculate_min_max_power(
+        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
+    ) -> tuple[pd.Series, pd.Series]:
+        min = pd.Series(100, self.index).loc[start:start]
+        max = pd.Series(400, self.index).loc[start:start]
+        return min, max
+
+    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
+        return 3
+
+
+@pytest.fixture
+def mock_market_config():
+    return MockMarketConfig()
+
+
+@pytest.fixture
+def mock_supports_minmax():
+    index = pd.date_range(
+        start=datetime(2023, 7, 1),
+        end=datetime(2023, 7, 2),
+        freq="1h",
+    )
+    return MockMinMaxUnit(index)

--- a/tests/test_demand.py
+++ b/tests/test_demand.py
@@ -1,0 +1,120 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+from dateutil import rrule as rr
+
+from assume.common.market_objects import MarketConfig, MarketProduct
+from assume.strategies import NaiveStrategy
+from assume.units.demand import Demand
+
+
+def test_demand():
+    strategies = {"energy": NaiveStrategy()}
+
+    index = pd.date_range(
+        start=datetime(2023, 7, 1),
+        end=datetime(2023, 7, 2),
+        freq="1h",
+    )
+    product_tuple = (
+        datetime(2023, 7, 1, hour=1),
+        datetime(2023, 7, 1, hour=2),
+        None,
+    )
+    dem = Demand(
+        "test01",
+        "UO1",
+        "energy",
+        strategies,
+        index,
+        150,
+        0,
+        150,
+        price=2000,
+    )
+    start = product_tuple[0]
+    end = product_tuple[1]
+    min_power, max_power = dem.calculate_min_max_power(start, end)
+
+    assert max_power.max() == -150
+    assert dem.calculate_marginal_cost(start, max_power.max()) == 2000
+
+    mc = MarketConfig(
+        "Test",
+        rr.rrule(rr.HOURLY),
+        timedelta(hours=1),
+        "not needed",
+        [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
+    )
+
+    bids = dem.calculate_bids(mc, [product_tuple])
+
+    for bid in bids:
+        assert "start_time" in bid.keys()
+        assert "end_time" in bid.keys()
+        assert "price" in bid.keys()
+        assert "volume" in bid.keys()
+    assert len(bids) == 1
+
+
+def test_demand_series():
+    strategies = {"energy": NaiveStrategy()}
+
+    index = pd.date_range(
+        start=datetime(2023, 7, 1),
+        end=datetime(2023, 7, 2),
+        freq="1h",
+    )
+    product_tuple = (
+        datetime(2023, 7, 1, hour=1),
+        datetime(2023, 7, 1, hour=2),
+        None,
+    )
+
+    demand = pd.Series(100, index=index)
+    demand[1] = 80
+    price = pd.Series(1000, index=index)
+    price[1] = 0
+    dem = Demand(
+        "test01",
+        "UO1",
+        "energy",
+        strategies,
+        index,
+        150,
+        0,
+        demand,
+        price=price,
+    )
+    start = product_tuple[0]
+    end = product_tuple[1]
+    min_power, max_power = dem.calculate_min_max_power(start, end)
+
+    # power should be the highest demand which is used throughout the period
+    # in our case 80 MW
+    max_power = max_power.max()
+    assert max_power == -80
+
+    assert dem.calculate_marginal_cost(start, max_power) == 0
+    assert dem.calculate_marginal_cost(end, max_power) == 1000
+
+    mc = MarketConfig(
+        "Test",
+        rr.rrule(rr.HOURLY),
+        timedelta(hours=1),
+        "not needed",
+        [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
+    )
+
+    bids = dem.calculate_bids(mc, [product_tuple])
+
+    for bid in bids:
+        assert "price" in bid.keys()
+        assert "volume" in bid.keys()
+    assert len(bids) == 1
+    assert bids[0]["volume"] == max_power
+    assert bids[0]["price"] == price[1]
+
+
+if __name__ == "__main__":
+    test_demand()

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,0 +1,94 @@
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+from dateutil import rrule as rr
+
+from assume.common.base import SupportsMinMax
+from assume.common.market_objects import MarketConfig, MarketProduct
+from assume.strategies import OTCStrategy
+
+
+class MockUnit(SupportsMinMax):
+    def __init__(self, index):
+        super().__init__("", "", "", {}, index, None)
+        self.max_power = 1000
+        self.min_power = 0
+
+    def calculate_min_max_power(
+        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
+    ) -> tuple[pd.Series, pd.Series]:
+        return 0, 400
+
+    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
+        return 3
+
+
+start = datetime(2023, 7, 1)
+end = datetime(2023, 7, 2)
+
+
+def test_otc_strategy():
+    strategy = OTCStrategy(scale_firm_power_capacity=0.1)
+
+    mc = MarketConfig(
+        "Test",
+        rr.rrule(rr.HOURLY),
+        timedelta(hours=1),
+        "not needed",
+        [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
+    )
+
+    index = pd.date_range(
+        start=datetime(2023, 7, 1),
+        end=datetime(2023, 7, 2),
+        freq="1h",
+    )
+    unit = MockUnit(index)
+    start = datetime(2023, 7, 1)
+    end = datetime(2023, 7, 2)
+    product_tuples = [(start, end, None)]
+
+    bids = strategy.calculate_bids(
+        unit=unit, market_config=mc, product_tuples=product_tuples
+    )
+
+    assert bids[0]["price"] == 3
+    assert bids[0]["volume"] == 400
+
+
+@pytest.mark.parametrize("scale", [0.1, 0.2, 1.0, 0.0])
+def test_otc_strategy_scaled(scale):
+    strategy = OTCStrategy(scale_firm_power_capacity=scale)
+
+    mc = MarketConfig(
+        "OTC",
+        rr.rrule(rr.HOURLY),
+        timedelta(hours=1),
+        "not needed",
+        [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
+    )
+
+    index = pd.date_range(
+        start=datetime(2023, 7, 1),
+        end=datetime(2023, 7, 2),
+        freq="1h",
+    )
+    unit = MockUnit(index)
+    start = datetime(2023, 7, 1)
+    end = datetime(2023, 7, 2)
+    product_tuples = [(start, end, None)]
+
+    bids = strategy.calculate_bids(
+        unit=unit, market_config=mc, product_tuples=product_tuples
+    )
+
+    power = 400 * scale
+
+    assert bids[0]["price"] == 3
+    assert bids[0]["volume"] == power
+
+
+if __name__ == "__main__":
+    test_otc_strategy()
+    test_otc_strategy_scaled()

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -1,34 +1,16 @@
 from datetime import datetime, timedelta
 
-import pandas as pd
 import pytest
 from dateutil import rrule as rr
 
-from assume.common.base import SupportsMinMax
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.strategies import OTCStrategy
-
-
-class MockUnit(SupportsMinMax):
-    def __init__(self, index):
-        super().__init__("", "", "", {}, index, None)
-        self.max_power = 1000
-        self.min_power = 0
-
-    def calculate_min_max_power(
-        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
-    ) -> tuple[pd.Series, pd.Series]:
-        return 0, 400
-
-    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
-        return 3
-
 
 start = datetime(2023, 7, 1)
 end = datetime(2023, 7, 2)
 
 
-def test_otc_strategy():
+def test_otc_strategy(mock_supports_minmax):
     strategy = OTCStrategy(scale_firm_power_capacity=0.1)
 
     mc = MarketConfig(
@@ -39,12 +21,7 @@ def test_otc_strategy():
         [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
     )
 
-    index = pd.date_range(
-        start=datetime(2023, 7, 1),
-        end=datetime(2023, 7, 2),
-        freq="1h",
-    )
-    unit = MockUnit(index)
+    unit = mock_supports_minmax
     start = datetime(2023, 7, 1)
     end = datetime(2023, 7, 2)
     product_tuples = [(start, end, None)]
@@ -58,7 +35,7 @@ def test_otc_strategy():
 
 
 @pytest.mark.parametrize("scale", [0.1, 0.2, 1.0, 0.0])
-def test_otc_strategy_scaled(scale):
+def test_otc_strategy_scaled(scale, mock_supports_minmax):
     strategy = OTCStrategy(scale_firm_power_capacity=scale)
 
     mc = MarketConfig(
@@ -69,12 +46,7 @@ def test_otc_strategy_scaled(scale):
         [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
     )
 
-    index = pd.date_range(
-        start=datetime(2023, 7, 1),
-        end=datetime(2023, 7, 2),
-        freq="1h",
-    )
-    unit = MockUnit(index)
+    unit = mock_supports_minmax
     start = datetime(2023, 7, 1)
     end = datetime(2023, 7, 2)
     product_tuples = [(start, end, None)]

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -1,0 +1,8 @@
+from assume.cli import cli
+
+
+def test_cli():
+    args = (
+        "-s example_01a -c tiny_example -db sqlite:///./examples/local_db/test_mini.db"
+    )
+    cli(args.split(" "))

--- a/tests/test_naive_strategies.py
+++ b/tests/test_naive_strategies.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+
+import pandas as pd
+
+from assume.common.base import SupportsMinMax
+from assume.strategies import (
+    NaiveNegReserveStrategy,
+    NaivePosReserveStrategy,
+    NaiveStrategy,
+)
+
+
+class MockMarketConfig:
+    product_type = "energy"
+
+
+class MockUnit(SupportsMinMax):
+    def __init__(self, index):
+        super().__init__("", "", "", {}, index, None)
+        self.max_power = 1000
+        self.min_power = 0
+        self.ramp_down = 200
+        self.ramp_up = 400
+
+    def calculate_min_max_power(
+        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
+    ) -> tuple[pd.Series, pd.Series]:
+        min = pd.Series(100, self.index).loc[start:start]
+        max = pd.Series(400, self.index).loc[start:start]
+        return min, max
+
+    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
+        return 3
+
+
+start = datetime(2023, 7, 1)
+end = datetime(2023, 7, 2)
+index = pd.date_range(
+    start=datetime(2023, 7, 1),
+    end=datetime(2023, 7, 2),
+    freq="1h",
+)
+unit = MockUnit(index)
+
+
+def test_naive_strategy():
+    strategy = NaiveStrategy()
+    mc = MockMarketConfig()
+    product_tuples = [(start, end, None)]
+    bids = strategy.calculate_bids(unit, mc, product_tuples=product_tuples)
+    assert bids[0]["price"] == 3
+    assert bids[0]["volume"] == 400
+
+
+def test_naive_pos_strategy():
+    """
+    calculates bids for
+    """
+    strategy = NaivePosReserveStrategy()
+    mc = MockMarketConfig()
+    product_tuples = [(start, end, None)]
+    bids = strategy.calculate_bids(unit, mc, product_tuples=product_tuples)
+    assert bids[0]["price"] == 0
+    assert bids[0]["volume"] == 400
+    assert len(bids) == 1
+
+
+def test_naive_neg_strategy():
+    strategy = NaiveNegReserveStrategy()
+    mc = MockMarketConfig()
+    product_tuples = [(start, end, None)]
+    bids = strategy.calculate_bids(unit, mc, product_tuples=product_tuples)
+    assert bids[0]["price"] == 0
+    assert bids[0]["volume"] == 100
+    assert len(bids) == 1
+
+
+if __name__ == "__main__":
+    # run pytest and enable prints
+    import pytest
+
+    pytest.main(["-s", __file__])

--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -1,0 +1,277 @@
+from datetime import datetime
+
+import pandas as pd
+import pytest
+
+from assume.strategies.naive_strategies import NaiveStrategy
+from assume.units import PowerPlant
+
+
+class MockMarketConfig:
+    product_type = "energy"
+
+
+@pytest.fixture
+def power_plant_1() -> PowerPlant:
+    # Create a PowerPlant instance with some example parameters
+    return PowerPlant(
+        id="test_pp",
+        unit_operator="test_operator",
+        technology="coal",
+        bidding_strategies={"energy": NaiveStrategy()},
+        index=pd.date_range("2022-01-01", periods=4, freq="H"),
+        max_power=1000,
+        min_power=200,
+        efficiency=0.5,
+        fixed_cost=10,
+        fuel_type="lignite",
+        emission_factor=0.5,
+        fuel_price=pd.Series(
+            [10, 11, 12, 13], index=pd.date_range("2022-01-01", periods=4, freq="H")
+        ),
+        co2_price=pd.Series(
+            [10, 20, 30, 30], index=pd.date_range("2022-01-01", periods=4, freq="H")
+        ),
+    )
+
+
+@pytest.fixture
+def power_plant_2() -> PowerPlant:
+    # Create a PowerPlant instance with some example parameters
+    return PowerPlant(
+        id="test_pp",
+        unit_operator="test_operator",
+        technology="coal",
+        bidding_strategies={"energy": NaiveStrategy()},
+        index=pd.date_range("2022-01-01", periods=4, freq="H"),
+        max_power=1000,
+        min_power=0,
+        efficiency=0.5,
+        fixed_cost=10,
+        fuel_type="lignite",
+        emission_factor=0.5,
+        fuel_price=10,
+        co2_price=10,
+    )
+
+
+@pytest.fixture
+def power_plant_3() -> PowerPlant:
+    # Create a PowerPlant instance with some example parameters
+    return PowerPlant(
+        id="test_pp",
+        unit_operator="test_operator",
+        technology="coal",
+        bidding_strategies={"energy": NaiveStrategy()},
+        index=pd.date_range("2022-01-01", periods=4, freq="H"),
+        max_power=1000,
+        min_power=0,
+        efficiency=0.5,
+        fixed_cost=10,
+        fuel_type="lignite",
+        emission_factor=0.5,
+        fuel_price=10,
+        co2_price=10,
+        partial_load_eff=True,
+    )
+
+
+def test_init_function(power_plant_1, power_plant_2, power_plant_3):
+    assert power_plant_1.id == "test_pp"
+    assert power_plant_1.unit_operator == "test_operator"
+    assert power_plant_1.technology == "coal"
+    assert power_plant_1.max_power == 1000
+    assert power_plant_1.min_power == 200
+    assert power_plant_1.efficiency == 0.5
+    assert power_plant_1.fixed_cost == 10
+    assert power_plant_1.fuel_type == "lignite"
+    assert power_plant_1.emission_factor == 0.5
+    assert power_plant_1.ramp_up == 1000
+    assert power_plant_1.ramp_down == 1000
+
+    assert (
+        power_plant_1.marginal_cost
+        == pd.Series(
+            [40.0, 52.0, 64.0, 66.0],
+            index=pd.date_range("2022-01-01", periods=4, freq="H"),
+        ).to_dict()
+    )
+
+    assert power_plant_2.marginal_cost == 40.0
+
+    assert power_plant_3.marginal_cost is None
+
+
+def test_reset_function(power_plant_1):
+    power_plant_1.current_status = 0
+    assert power_plant_1.current_status == 0
+
+    power_plant_1.reset()
+    assert power_plant_1.current_status == 1
+
+    # check if total_power_output is reset
+    assert power_plant_1.outputs["power"].equals(
+        pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
+    )
+    # the same for pos and neg capacity reserve
+    assert power_plant_1.outputs["pos_capacity"].equals(
+        pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
+    )
+    assert power_plant_1.outputs["neg_capacity"].equals(
+        pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
+    )
+
+    # the same for total_heat_output and power_loss_chp
+    assert power_plant_1.outputs["heat"].equals(
+        pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
+    )
+    assert power_plant_1.outputs["power_loss"].equals(
+        pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
+    )
+
+
+def test_calculate_operational_window(power_plant_1):
+    power_plant_1.reset()
+
+    product_tuple = (
+        pd.Timestamp("2022-01-01 00:00:00"),
+        pd.Timestamp("2022-01-01 01:00:00"),
+        None,
+    )
+    start = product_tuple[0]
+    end = product_tuple[1]
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+
+    min_cost = power_plant_1.calculate_marginal_cost(start, min_power[start])
+    max_cost = power_plant_1.calculate_marginal_cost(start, max_power[start])
+
+    assert min_power[start] == 200
+    assert min_cost == 40.0
+
+    assert max_power[start] == 1000
+    assert max_cost == 40
+
+    assert power_plant_1.outputs["energy"].at[start] == 0
+
+
+def test_powerplant_feedback(power_plant_1):
+    power_plant_1.reset()
+
+    product_tuple = (
+        pd.Timestamp("2022-01-01 00:00:00"),
+        pd.Timestamp("2022-01-01 01:00:00"),
+        None,
+    )
+    product_type = "energy"
+    start = product_tuple[0]
+    end = product_tuple[1]
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+    min_cost = power_plant_1.calculate_marginal_cost(start, min_power[start])
+    max_cost = power_plant_1.calculate_marginal_cost(start, max_power[start])
+
+    assert min_power[start] == 200
+    assert min_cost == 40.0
+
+    assert max_power[start] == 1000
+    assert max_cost == 40
+    assert power_plant_1.outputs["energy"].at[start] == 0
+
+    orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": min_cost,
+            "volume": min_power[start],
+        }
+    ]
+
+    # min_power gets accepted
+    mc = MockMarketConfig()
+    power_plant_1.set_dispatch_plan(mc, orderbook)
+
+    # second market request for same interval
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+
+    # we do not need additional min_power, as our runtime requirement is fulfilled
+    assert min_power[start] == 0
+    # we can not bid the maximum anymore, because we already provide energy on the other market
+    assert max_power[start] == 800
+
+    # second market request for next interval
+    start = pd.Timestamp("2022-01-01 01:00:00")
+    end = pd.Timestamp("2022-01-01 02:00:00")
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+
+    # now we can bid max_power and need min_power again
+    assert min_power[start] == 200
+    assert max_power[start] == 1000
+
+
+def test_powerplant_ramping(power_plant_1):
+    power_plant_1.ramp_down = 100
+    power_plant_1.ramp_up = 200
+    power_plant_1.reset()
+
+    start = datetime(2022, 1, 1, 0)
+    end = datetime(2022, 1, 1, 1)
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+
+    min_cost = power_plant_1.calculate_marginal_cost(start, min_power[start])
+    max_cost = power_plant_1.calculate_marginal_cost(start, max_power[start])
+    max_ramp = power_plant_1.calculate_ramp(0, max_power[start])
+
+    assert min_power[start] == 200
+    assert min_cost == 40.0
+
+    assert max_ramp == 200
+    assert max_cost == 40
+
+    # min_power gets accepted
+    end_excl = end - power_plant_1.index.freq
+    power_plant_1.outputs["energy"].loc[start:end_excl] += 200
+
+    # next hour
+    start = datetime(2022, 1, 1, 1)
+    end = datetime(2022, 1, 1, 2)
+
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+    min_ramp = power_plant_1.calculate_ramp(200, min_power[start])
+    max_ramp = power_plant_1.calculate_ramp(200, max_power[start])
+
+    assert min_ramp == 200
+    assert max_ramp == 400
+
+    # accept max_power
+    power_plant_1.outputs["energy"].loc[start:end_excl] += 400
+
+    # next hour
+    start = datetime(2022, 1, 1, 2)
+    end = datetime(2022, 1, 1, 3)
+
+    min_power, max_power = power_plant_1.calculate_min_max_power(
+        start, end, product_type="energy"
+    )
+
+    min_ramp = power_plant_1.calculate_ramp(400, min_power[start])
+    max_ramp = power_plant_1.calculate_ramp(400, max_power[start])
+
+    assert min_ramp == 300
+    assert max_ramp == 600
+
+
+if __name__ == "__main__":
+    # run pytest and enable prints
+    pytest.main(["-s", __file__])

--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -7,10 +7,6 @@ from assume.strategies.naive_strategies import NaiveStrategy
 from assume.units import PowerPlant
 
 
-class MockMarketConfig:
-    product_type = "energy"
-
-
 @pytest.fixture
 def power_plant_1() -> PowerPlant:
     # Create a PowerPlant instance with some example parameters
@@ -156,7 +152,7 @@ def test_calculate_operational_window(power_plant_1):
     assert power_plant_1.outputs["energy"].at[start] == 0
 
 
-def test_powerplant_feedback(power_plant_1):
+def test_powerplant_feedback(power_plant_1, mock_market_config):
     power_plant_1.reset()
 
     product_tuple = (
@@ -191,7 +187,7 @@ def test_powerplant_feedback(power_plant_1):
     ]
 
     # min_power gets accepted
-    mc = MockMarketConfig()
+    mc = mock_market_config
     power_plant_1.set_dispatch_plan(mc, orderbook)
 
     # second market request for same interval


### PR DESCRIPTION
Those tests existed when we had the operational_window and are now adjusted

As a Marketconfig and a Unit is required for some operations on BiddingStrategies, we now have MockObjects in the `conftest.py`