### PR TITLE
remove current_time from strategies

### DIFF
--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta
+
 import pandas as pd
 
 from assume.common.base import BaseStrategy, SupportsMinMax
@@ -148,7 +150,7 @@ class flexableEOM(BaseStrategy):
         possible_revenue = get_specific_revenue(
             unit=unit,
             marginal_cost=marginal_cost_flex,
-            current_time=start,
+            t=start,
             foresight=self.foresight,
         )
         if possible_revenue >= 0 and unit.price_forecast[t] < marginal_cost_flex:
@@ -215,7 +217,7 @@ class flexablePosCRM(BaseStrategy):
             specific_revenue = get_specific_revenue(
                 unit=unit,
                 marginal_cost=marginal_cost,
-                current_time=start,
+                t=start,
                 foresight=self.foresight,
             )
 
@@ -291,7 +293,7 @@ class flexableNegCRM(BaseStrategy):
             specific_revenue = get_specific_revenue(
                 unit=unit,
                 marginal_cost=marginal_cost,
-                current_time=start,
+                t=start,
                 foresight=self.foresight,
             )
 
@@ -329,12 +331,11 @@ class flexableNegCRM(BaseStrategy):
 
 
 def get_specific_revenue(
-    unit,
-    marginal_cost,
-    current_time,
-    foresight,
+    unit: SupportsMinMax,
+    marginal_cost: float,
+    t: datetime,
+    foresight: timedelta,
 ):
-    t = current_time
     price_forecast = []
 
     if t + foresight > unit.price_forecast.index[-1]:

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -151,7 +151,7 @@ class flexablePosCRMStorage(BaseStrategy):
             energy_price = capacity_price / unit.current_SOC
 
             if market_config.product_type == "capacity_pos":
-                bids.appen(
+                bids.append(
                     {
                         "start_time": start,
                         "end_time": end,

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -101,8 +101,6 @@ class flexablePosCRMStorage(BaseStrategy):
         # check if kwargs contains crm_foresight argument
         self.foresight = pd.Timedelta(kwargs.get("crm_foresight", "4h"))
 
-        self.current_time = None
-
     def calculate_bids(
         self,
         unit: SupportsMinMaxCharge,
@@ -138,7 +136,7 @@ class flexablePosCRMStorage(BaseStrategy):
             specific_revenue = get_specific_revenue(
                 unit=unit,
                 marginal_cost=marginal_cost,
-                current_time=self.current_time,
+                current_time=start,
                 foresight=self.foresight,
                 price_forecast=data_dict["price_forecast"],
             )
@@ -186,7 +184,6 @@ class flexableNegCRMStorage(BaseStrategy):
         super().__init__(*args, **kwargs)
 
         self.foresight = pd.Timedelta(kwargs.get("crm_foresight", "4h"))
-        self.current_time = None
 
     def calculate_bids(
         self,

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -14,7 +14,6 @@ class RLStrategy(LearningStrategy):
         super().__init__(*args, **kwargs)
 
         self.foresight = kwargs.get("foresight", 24)
-        self.current_time = None
 
         # RL agent parameters
         self.obs_dim = kwargs.get("observation_dimension", 50)

--- a/assume/units/heatpump.py
+++ b/assume/units/heatpump.py
@@ -191,7 +191,7 @@ class HeatPump(SupportsMinMax):
 
         Parameters
         ----------
-        current_time : pd.Timestamp
+        timestep : pd.Timestamp
             The current time step.
 
         Returns


### PR DESCRIPTION
There were some leftovers from removing the current_time which is cleaned up in this pull request.
The start time should always be taken from the current product tuples