### PR TITLE
World improvements

### DIFF
--- a/.github/workflows/lint-pytest.yml
+++ b/.github/workflows/lint-pytest.yml
@@ -40,6 +40,12 @@ jobs:
     - name: Test with pytest
       run: |
         pytest --cov --cov-report=xml --junitxml="result.xml"
+    - name: Install torch dependencies
+      run: |
+        python -m pip install -e .[learning]
+    - name: Run Learning with assume cli in in-memory db
+      run: |
+        assume -s example_01_rl -db "sqlite:///"
 
     - name: Upload tests results
       uses: actions/upload-artifact@v3

--- a/assume/cli.py
+++ b/assume/cli.py
@@ -75,13 +75,10 @@ def cli(args=None):
         scenario=args.scenario,
         study_case=args.case_study,
     )
-    try:
-        world.run()
-    except KeyboardInterrupt:
-        pass
+    world.run()
 
 
 if __name__ == "__main__":
     # cli()
-    args = "-s example_01_rl -db postgresql://assume:assume@localhost:5432/assume"
+    args = "-s example_01a -db postgresql://assume:assume@localhost:5432/assume"
     cli(args.split(" "))

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -157,6 +157,8 @@ class SupportsMinMax(BaseUnit):
         self, previous_power: float, power: float, current_power: float = 0
     ) -> float:
         if power == 0:
+            # if less than min_power is required, we run min_power
+            # we could also split at self.min_power/2
             return power
         # ramp up constraint
         # max_power + current_power < previous_power + unit.ramp_up

--- a/assume/common/forecasts.py
+++ b/assume/common/forecasts.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import datetime
 
 import numpy as np
 import pandas as pd

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -20,7 +20,7 @@ class WriteOutput(Role):
         end: datetime,
         db_engine=None,
         export_csv_path: str = "",
-        save_frequency_hours: int | None = None,
+        save_frequency_hours: int = 24,
     ):
         """
         Initializes an instance of the WriteOutput class.
@@ -31,14 +31,14 @@ class WriteOutput(Role):
             end (datetime): The end datetime of the simulation run.
             db_engine (optional): The database engine. Defaults to None.
             export_csv_path (str, optional): The path for exporting CSV files, no path results in not writing the csv. Defaults to "".
-            save_frequency_hours (int | None, optional): The frequency in hours for storeing data in the db and/or csv files. Defaults to None.
+            save_frequency_hours (int): The frequency in hours for storing data in the db and/or csv files. Defaults to None.
         """
 
         super().__init__()
 
         # store needed date
         self.simulation_id = simulation_id
-        self.save_frequency_hours: int = save_frequency_hours or 1
+        self.save_frequency_hours = save_frequency_hours
 
         # make directory if not already present
         self.export_csv_path = export_csv_path
@@ -257,6 +257,8 @@ class WriteOutput(Role):
 
         # insert left records into db
         await self.store_dfs()
+        if self.db is None:
+            return
         queries = [
             f"select market_id as name, avg(price) as avg_price from market_meta where simulation = '{self.simulation_id}' group by market_id",
             f"select market_id as name, sum(price*demand_volume_energy) as total_cost from market_meta where simulation = '{self.simulation_id}' group by market_id",

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -9,8 +9,6 @@ from dateutil import rrule as rr
 from mango import Role
 from sqlalchemy import inspect, text
 
-from assume.common.base import BaseUnit
-
 logger = logging.getLogger(__name__)
 
 

--- a/assume/common/scenario_loader.py
+++ b/assume/common/scenario_loader.py
@@ -1,4 +1,3 @@
-import calendar
 import logging
 from datetime import datetime
 
@@ -145,7 +144,7 @@ def make_market_config(
     return market_config
 
 
-async def add_units(
+def add_units(
     units_df: pd.DataFrame,
     unit_type: str,
     world: World,
@@ -168,11 +167,12 @@ async def add_units(
             if key.startswith("bidding_")
         }
         unit_params["bidding_strategies"] = bidding_strategies
-
-        await world.add_unit(
+        operator_id = unit_params["unit_operator"]
+        del unit_params["unit_operator"]
+        world.add_unit(
             id=unit_name,
             unit_type=unit_type,
-            unit_operator_id=unit_params["unit_operator"],
+            unit_operator_id=operator_id,
             unit_params=unit_params,
             forecaster=forecaster,
         )
@@ -381,21 +381,21 @@ async def load_scenario_folder_async(
     def empty_callback(unit_name, unit_params):
         return unit_params
 
-    await add_units(
+    add_units(
         powerplant_units,
         "power_plant",
         world,
         forecaster,
     )
 
-    await add_units(
+    add_units(
         heatpump_units,
         "heatpump",
         world,
         forecaster,
     )
 
-    await add_units(
+    add_units(
         storage_units,
         "storage",
         world,
@@ -408,7 +408,7 @@ async def load_scenario_folder_async(
 
         return unit_params
 
-    await add_units(
+    add_units(
         demand_units,
         "demand",
         world,
@@ -435,11 +435,8 @@ def load_scenario_folder(
         )
     )
 
+    # check if learning mode
     if world.learning_config.get("learning_mode"):
-        start_ts = calendar.timegm(world.start.utctimetuple())
-        end_ts = calendar.timegm(world.end.utctimetuple())
-        # we are in learning mode
-
         # initiate buffer for rl agent
         from assume.reinforcement_learning.buffer import ReplayBuffer
 
@@ -462,9 +459,7 @@ def load_scenario_folder(
                 0
             ].simulation_id = f"{world.output_agent.roles[0].simulation_id}_{episode}"
 
-            world.loop.run_until_complete(
-                world.run_async(start_ts=start_ts, end_ts=end_ts)
-            )
+            world.run()
             world.reset()
 
             world.rl_agent.roles[0].episodes_done = +1

--- a/assume/common/scenario_loader.py
+++ b/assume/common/scenario_loader.py
@@ -1,16 +1,14 @@
 import calendar
 import logging
 from datetime import datetime
-from typing import Callable
 
 import dateutil.rrule as rr
 import numpy as np
 import pandas as pd
 import yaml
-from mango import RoleAgent
 from tqdm import tqdm
 
-from assume.common.forecasts import CsvForecaster, Forecaster, RandomForecaster
+from assume.common.forecasts import CsvForecaster, Forecaster
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.world import World
 

--- a/assume/common/scenario_loader.py
+++ b/assume/common/scenario_loader.py
@@ -442,27 +442,27 @@ def load_scenario_folder(
 
         buffer = ReplayBuffer(
             buffer_size=1000000,
-            obs_dim=world.rl_agent.roles[0].obs_dim,
-            act_dim=world.rl_agent.roles[0].act_dim,
-            n_rl_units=world.learning_agent_count,
-            device=world.rl_agent.roles[0].device,
+            obs_dim=world.learning_role.obs_dim,
+            act_dim=world.learning_role.act_dim,
+            n_rl_units=world.learning_role.n_rl_units,
+            device=world.learning_role.device,
         )
 
-        world.rl_agent.roles[0].buffer = buffer
+        world.learning_role.buffer = buffer
 
         for episode in tqdm(
-            range(world.rl_agent.roles[0].training_episodes),
+            range(world.learning_role.training_episodes),
             desc="Training Episodes",
         ):
             # change simulation id of output agent to include the episode number
-            world.output_agent.roles[
-                0
-            ].simulation_id = f"{world.output_agent.roles[0].simulation_id}_{episode}"
+            world.output_role.simulation_id = (
+                f"{world.output_role.simulation_id}_{episode}"
+            )
 
             world.run()
             world.reset()
 
-            world.rl_agent.roles[0].episodes_done = +1
+            world.learning_role.episodes_done = +1
 
             # in load_scenario_folder_async, we initiate new container and kill old if present
             # as long as we do not skip setup container should be handled correctly
@@ -475,11 +475,11 @@ def load_scenario_folder(
                 )
             )
             # give the newly created rl_agent the buffer that we stored from the beginning
-            world.rl_agent.roles[0].buffer = buffer
+            world.learning_role.buffer = buffer
 
             # container shutdown implicitly with new initialisation
 
         world.logger.info("################")
         world.logger.info(f"Training finished, Start evaluation run")
 
-        world.rl_agent.roles[0].learning_mode = False
+        world.learning_role.learning_mode = False

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -185,7 +185,7 @@ class MarketRole(Role):
                 if self.marketconfig.volume_tick:
                     assert isinstance(order["volume"], int)
                 for field in self.marketconfig.additional_fields:
-                    assert order[field], f"missing field: {field}"
+                    assert field in order.keys(), f"missing field: {field}"
                 self.all_orders.append(order)
         except Exception as e:
             logger.error(f"error handling message from {agent_id} - {e}")

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -102,7 +102,8 @@ class MarketRole(Role):
         products = get_available_products(
             self.marketconfig.market_products, market_open
         )
-        if market_closing > self.marketconfig.opening_hours._until:
+        until = self.marketconfig.opening_hours._until
+        if until and market_closing > until:
             # this market should not open, as the clearing is after the markets end time
             return
 

--- a/assume/markets/clearing_algorithms/simple.py
+++ b/assume/markets/clearing_algorithms/simple.py
@@ -2,7 +2,7 @@ import logging
 from itertools import groupby
 from operator import itemgetter
 
-from assume.common.market_objects import MarketProduct, Order, Orderbook
+from assume.common.market_objects import MarketProduct, Orderbook
 from assume.markets.base_market import MarketRole
 
 log = logging.getLogger(__name__)

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -17,6 +17,8 @@ class Learning(Role):
         self.obs_dim = learning_config["observation_dimension"]
         self.act_dim = learning_config["action_dimension"]
         self.episodes_done = 0
+        self.n_rl_units = 0
+        self.rl_units = []
         self.rl_algorithm = learning_config["algorithm"]
 
         # define wheter we train model or evaluate it

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -23,15 +23,15 @@ class NaiveStrategy(BaseStrategy):
             volume = unit.calculate_ramp(
                 previous_power, max_power[start], current_power
             )
-            bids.append(
-                {
-                    "start_time": product[0],
-                    "end_time": product[1],
-                    "only_hours": product[2],
-                    "price": marginal_cost,
-                    "volume": volume,
-                }
-            )
+            order: Order = {
+                "start_time": product[0],
+                "end_time": product[1],
+                "only_hours": product[2],
+                "price": marginal_cost,
+                "volume": volume,
+            }
+            order.update({field: None for field in market_config.additional_fields})
+            bids.append(order)
 
             previous_power = volume + current_power
 

--- a/assume/world.py
+++ b/assume/world.py
@@ -121,9 +121,9 @@ class World:
         self,
         start: datetime,
         end: datetime,
-        save_frequency_hours: int,
         simulation_id: str,
         index: pd.Series,
+        save_frequency_hours: int = 24,
         same_process: bool = True,
         bidding_params: dict = {},
         learning_config: dict = {},
@@ -207,6 +207,8 @@ class World:
         id: str or int
 
         """
+        if self.unit_operators.get(id):
+            raise ValueError(f"UnitOperator {id} already exists")
         units_operator = UnitsOperator(available_markets=list(self.markets.values()))
         # creating a new role agent and apply the role of a unitsoperator
         unit_operator_agent = RoleAgent(self.container, suggested_aid=f"{id}")
@@ -221,7 +223,7 @@ class World:
             "output_agent_id": self.output_agent_addr[1],
         }
 
-    async def add_unit(
+    async def async_add_unit(
         self,
         id: str,
         unit_type: str,
@@ -242,7 +244,7 @@ class World:
         """
 
         # check if unit operator exists
-        if unit_operator_id not in self.unit_operators:
+        if unit_operator_id not in self.unit_operators.keys():
             raise ValueError(f"invalid unit operator {unit_operator_id}")
 
         # provided unit type does not exist yet
@@ -272,7 +274,13 @@ class World:
         unit_params["bidding_strategies"] = bidding_strategies
 
         # create unit within the unit operator its associated with
-        unit = unit_class(id=id, index=self.index, forecaster=forecaster, **unit_params)
+        unit = unit_class(
+            id=id,
+            unit_operator=unit_operator_id,
+            index=self.index,
+            forecaster=forecaster,
+            **unit_params,
+        )
         await self.unit_operators[unit_operator_id].add_unit(unit)
 
     def add_market_operator(
@@ -287,6 +295,8 @@ class World:
         id = int
              market operator id is associated with the market its participating
         """
+        if self.market_operators.get(id):
+            raise ValueError(f"MarketOperator {id} already exists")
         market_operator_agent = RoleAgent(
             self.container,
             suggested_aid=id,
@@ -331,7 +341,7 @@ class World:
         market_operator.markets.append(market_config)
         self.markets[f"{market_config.name}"] = market_config
 
-    async def step(self):
+    async def _step(self):
         next_activity = self.clock.get_next_activity()
         if not next_activity:
             self.logger.info("simulation finished - no schedules left")
@@ -340,7 +350,7 @@ class World:
         self.clock.set_time(next_activity)
         return delta
 
-    async def run_async(self, start_ts, end_ts):
+    async def async_run(self, start_ts, end_ts):
         """
         Run the simulation.
         either in learning mode where we run multiple times or in normal mode
@@ -354,7 +364,7 @@ class World:
         self.clock.set_time(start_ts - 1)
         while self.clock.time < end_ts:
             await asyncio.sleep(0)
-            delta = await self.step()
+            delta = await self._step()
             if delta:
                 pbar.update(delta)
                 pbar.set_description(
@@ -371,12 +381,33 @@ class World:
         start_ts = calendar.timegm(self.start.utctimetuple())
         end_ts = calendar.timegm(self.end.utctimetuple())
 
-        return self.loop.run_until_complete(
-            self.run_async(start_ts=start_ts, end_ts=end_ts)
-        )
+        try:
+            return self.loop.run_until_complete(
+                self.async_run(start_ts=start_ts, end_ts=end_ts)
+            )
+        except KeyboardInterrupt:
+            pass
 
     def reset(self):
         self.market_operators = {}
         self.markets = {}
         self.unit_operators = {}
         self.forecast_providers = {}
+
+    def add_unit(
+        self,
+        id: str,
+        unit_type: str,
+        unit_operator_id: str,
+        unit_params: dict,
+        forecaster: Forecaster,
+    ) -> None:
+        return self.loop.run_until_complete(
+            self.async_add_unit(
+                id=id,
+                unit_type=unit_type,
+                unit_operator_id=unit_operator_id,
+                unit_params=unit_params,
+                forecaster=forecaster,
+            )
+        )

--- a/assume/world.py
+++ b/assume/world.py
@@ -149,30 +149,28 @@ class World:
             # if so, we initate the rl learning role with parameters
             from assume.reinforcement_learning.learning_role import Learning
 
-            learning_role = Learning(
+            self.learning_role = Learning(
                 learning_config=self.learning_config,
             )
             self.bidding_params.update(self.learning_config)
 
             same_process = True
             if same_process:
-                self.rl_agent = RoleAgent(
-                    self.container, suggested_aid="learning_agent"
-                )
-                self.rl_agent.add_role(learning_role)
+                rl_agent = RoleAgent(self.container, suggested_aid="learning_agent")
+                rl_agent.add_role(self.learning_role)
             else:
                 # this does not set the clock in output_agent correctly yet
                 # see https://gitlab.com/mango-agents/mango/-/issues/59
                 # but still improves performance
                 def creator(container):
                     agent = RoleAgent(container, suggested_aid="learning_agent")
-                    agent.add_role(learning_role)
+                    agent.add_role(self.learning_role)
 
                 await self.container.as_agent_process(agent_creator=creator)
 
         self.output_agent_addr = (self.addr, "export_agent_1")
         # Add output agent to world
-        output_role = WriteOutput(
+        self.output_role = WriteOutput(
             simulation_id=simulation_id,
             start=start,
             end=end,
@@ -184,14 +182,14 @@ class World:
             output_agent = RoleAgent(
                 self.container, suggested_aid=self.output_agent_addr[1]
             )
-            output_agent.add_role(output_role)
+            output_agent.add_role(self.output_role)
         else:
             # this does not set the clock in output_agent correctly yet
             # see https://gitlab.com/mango-agents/mango/-/issues/59
             # but still improves performance
             def creator(container):
                 agent = RoleAgent(container, suggested_aid=self.output_agent_addr[1])
-                agent.add_role(output_role)
+                agent.add_role(self.output_role)
 
             await self.container.as_agent_process(agent_creator=creator)
 
@@ -259,8 +257,8 @@ class World:
 
             try:
                 if issubclass(self.bidding_types[strategy], LearningStrategy):
-                    self.rl_agent.roles[0].n_rl_units += 1
-                    self.rl_agent.roles[0].rl_units.append(id)
+                    self.learning_role.n_rl_units += 1
+                    self.learning_role.rl_units.append(id)
 
                 bidding_strategies[product_type] = self.bidding_types[strategy](
                     **self.bidding_params

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -49,11 +49,11 @@ if __name__ == "__main__":
     data_format = "timescale"  # "local_db" or "timescale"
 
     if data_format == "local_db":
-        db_url = f"sqlite:///./examples/local_db/assume_db_{example}.db"
+        db_uri = f"sqlite:///./examples/local_db/assume_db_{example}.db"
     elif data_format == "timescale":
-        db_url = "postgresql://assume:assume@localhost:5432/assume"
+        db_uri = "postgresql://assume:assume@localhost:5432/assume"
 
-    world = World(database_uri=db_url, export_csv_path=csv_path)
+    world = World(database_uri=db_uri, export_csv_path=csv_path)
     load_scenario_folder(
         world,
         inputs_path="examples/inputs",

--- a/examples/world_script.py
+++ b/examples/world_script.py
@@ -1,0 +1,84 @@
+import logging
+from datetime import datetime, timedelta
+
+import pandas as pd
+from dateutil import rrule as rr
+
+from assume import World
+from assume.common.forecasts import NaiveForecast
+from assume.common.market_objects import MarketConfig, MarketProduct
+
+log = logging.getLogger(__name__)
+
+db_uri = "postgresql://assume:assume@localhost:5432/assume"
+
+world = World(database_uri=db_uri)
+
+
+async def init():
+    start = datetime(2023, 10, 4)
+    end = datetime(2023, 12, 5)
+    index = pd.date_range(
+        start=start,
+        end=end + timedelta(hours=24),
+        freq="H",
+    )
+    sim_id = "handmade_simulation"
+
+    await world.setup(
+        start=start,
+        end=end,
+        save_frequency_hours=48,
+        simulation_id=sim_id,
+        index=index,
+    )
+
+    marketdesign = [
+        MarketConfig(
+            "EOM",
+            rr.rrule(rr.HOURLY, dtstart=start, until=end),
+            timedelta(hours=1),
+            "pay_as_clear",
+            [MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
+            additional_fields=[],
+        )
+    ]
+
+    mo_id = "market_operator"
+    world.add_market_operator(id=mo_id)
+    for market_config in marketdesign:
+        world.add_market(mo_id, market_config)
+
+    world.add_unit_operator("my_operator")
+    world.add_unit_operator("my_demand")
+    world.add_unit(
+        "demand1",
+        "demand",
+        "my_demand",
+        # the unit_params have no hints
+        {
+            "min_power": 0,
+            "max_power": 1000,
+            "bidding_strategies": {"energy": "naive"},
+            "technology": "demand",
+        },
+        NaiveForecast(index, demand=100),
+    )
+
+    nuclear_forecast = NaiveForecast(index, availability=1, fuel_price=3, co2_price=0.1)
+    world.add_unit(
+        "nuclear1",
+        "power_plant",
+        "my_operator",
+        {
+            "min_power": 200,
+            "max_power": 1000,
+            "bidding_strategies": {"energy": "naive"},
+            "technology": "nuclear",
+        },
+        nuclear_forecast,
+    )
+
+
+world.loop.run_until_complete(init())
+world.run()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,10 +4,12 @@ import pandas as pd
 import pytest
 
 from assume.common.base import SupportsMinMax
+from assume.common.market_objects import MarketConfig
 
 
 class MockMarketConfig:
     product_type = "energy"
+    additional_fields = []
 
 
 class MockMinMaxUnit(SupportsMinMax):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 import pandas as pd
 import pytest
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -50,7 +50,7 @@ def test_reset_function(storage_unit):
     assert storage_unit.current_status == 1
 
     # check if total_power_output is reset
-    assert storage_unit.outputs["power"].equals(
+    assert storage_unit.outputs["energy"].equals(
         pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))
     )
     # the same for pos and neg capacity reserve


### PR DESCRIPTION
I tested creating a scenario without external csv data by using the NaiveForecast and interacting with the World directly.

I found a few issues:
- the naive strategy does now support creating bids for all markets, by adding the additional fields as `None`
- if a value of an order is 0 it was interpreted as a missing value
- if no database is set, writing the final output was failed
- adding units to the world sometimes needed `await` and sometimes it did not, this is fixed by having a wrapper function for `add_units
- the market failed if no until value was set
- adding a market/unit operator twice did overwrite the existing operator (with its configuration)
- the `add_unit` function did not pass the unit_operator_id to the unit_class correctly
- `world._step` is now internal, as one would always use `World.run` instead
- add test script for availability of a powerplant
- fixes to run RL on main branch
- install `toch` and run base scenario in pipeline