### PR TITLE
improve error handling if database is not reachable

### DIFF
--- a/assume/cli.py
+++ b/assume/cli.py
@@ -64,18 +64,21 @@ def cli(args=None):
     else:
         db_uri = f"sqlite:///./examples/local_db/{name}.db"
 
-    world = World(
-        database_uri=db_uri,
-        export_csv_path=args.csv_export_path,
-        log_level=args.loglevel,
-    )
-    load_scenario_folder(
-        world,
-        inputs_path=args.input_path,
-        scenario=args.scenario,
-        study_case=args.case_study,
-    )
-    world.run()
+    try:
+        world = World(
+            database_uri=db_uri,
+            export_csv_path=args.csv_export_path,
+            log_level=args.loglevel,
+        )
+        load_scenario_folder(
+            world,
+            inputs_path=args.input_path,
+            scenario=args.scenario,
+            study_case=args.case_study,
+        )
+        world.run()
+    except KeyboardInterrupt:
+        pass
 
 
 if __name__ == "__main__":

--- a/assume/world.py
+++ b/assume/world.py
@@ -74,10 +74,11 @@ class World:
                     self.db.connection()
                     connected = True
                     self.logger.info("connected to db")
-                except OperationalError:
+                except OperationalError as e:
                     self.logger.error(
                         f"could not connect to {database_uri}, trying again"
                     )
+                    self.logger.error(f"{e}")
                     time.sleep(2)
         else:
             self.db = None


### PR DESCRIPTION
Ensures error reporting for easier debugging of unreachable databases

#### wrong port
assume -s example_01a -db "postgresql://assume:assume@localhost:6432/assume"
> ERROR:assume.world:(psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL: connection to server at "localhost" (::1), port 6432 failed: Connection refused

#### wrong credentials
assume -s example_01a -db "postgresql://assume:ass3ume@localhost:5432/assume"
> ERROR:assume.world:(psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  password authentication failed for user "assume"

#### wrong database
assume -s example_01a -db "postgresql://assume:assume@localhost:5432/assume2"
> ERROR:assume.world:(psycopg2.OperationalError) connection to server at "localhost" (::1), port 5432 failed: FATAL:  database "assume2" does not exist