### PR TITLE
152 define bid type to 'SB' if not set

### DIFF
--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -175,6 +175,9 @@ class MarketRole(Role):
                 ), f"minimum_bid_price {order['price']}"
 
                 if "bid_type" in order.keys():
+                    order["bid_type"] = (
+                        "SB" if order["bid_type"] == None else order["bid_type"]
+                    )
                     assert order["bid_type"] in [
                         "SB",
                         "BB",
@@ -245,6 +248,11 @@ class MarketRole(Role):
         )
 
     async def clear_market(self, market_products: list[MarketProduct]):
+        # Check if order is in time slots for current opening
+        # for order in self.all_orders:
+        #     assert (
+        #         order["start_time"] in index
+        #     ), f"order start time not in {self.marketconfig.market_products}"
         (
             accepted_orderbook,
             rejected_orderbook,

--- a/assume/markets/clearing_algorithms/complex_clearing.py
+++ b/assume/markets/clearing_algorithms/complex_clearing.py
@@ -13,7 +13,6 @@ log = logging.getLogger(__name__)
 SOLVERS = ["glpk", "cbc", "gurobi", "cplex"]
 
 
-# TODO: remove paradoxically accepted orders from solution
 def pay_as_clear_opt(
     market_agent: MarketRole,
     market_products: list[MarketProduct],
@@ -103,6 +102,7 @@ def pay_as_clear_opt(
         orders=orders,
         market_products=market_products,
         market_clearing_prices=market_clearing_prices,
+        market_agent=market_agent,
     )
 
 
@@ -237,6 +237,7 @@ def pay_as_clear_complex_opt(
         orders=orders,
         market_products=market_products,
         market_clearing_prices=market_clearing_prices,
+        market_agent=market_agent,
     )
 
 
@@ -246,6 +247,7 @@ def extract_results(
     orders,
     market_products,
     market_clearing_prices,
+    market_agent,
 ):
     accepted_orders: Orderbook = []
     rejected_orders: Orderbook = []
@@ -312,5 +314,7 @@ def extract_results(
                 "only_hours": product[2],
             }
         )
+
+    market_agent.all_orders = []
 
     return accepted_orders, rejected_orders, meta

--- a/assume/markets/clearing_algorithms/complex_clearing.py
+++ b/assume/markets/clearing_algorithms/complex_clearing.py
@@ -316,4 +316,6 @@ def extract_results(
             }
         )
 
+    model.clear()
+
     return accepted_orders, rejected_orders, meta

--- a/assume/markets/clearing_algorithms/complex_clearing.py
+++ b/assume/markets/clearing_algorithms/complex_clearing.py
@@ -96,13 +96,14 @@ def pay_as_clear_opt(
     # Find the dual variable for the balance constraint
     market_clearing_prices = {t: model.dual[model.energy_balance[t]] for t in model.T}
 
+    market_agent.all_orders = []
+
     return extract_results(
         model=model,
         eps=eps,
         orders=orders,
         market_products=market_products,
         market_clearing_prices=market_clearing_prices,
-        market_agent=market_agent,
     )
 
 
@@ -231,13 +232,14 @@ def pay_as_clear_complex_opt(
     # Find the dual variable for the balance constraint
     market_clearing_prices = {t: model.prices[t].value for t in model.T}
 
+    market_agent.all_orders = []
+
     return extract_results(
         model=model,
         eps=eps,
         orders=orders,
         market_products=market_products,
         market_clearing_prices=market_clearing_prices,
-        market_agent=market_agent,
     )
 
 
@@ -247,7 +249,6 @@ def extract_results(
     orders,
     market_products,
     market_clearing_prices,
-    market_agent,
 ):
     accepted_orders: Orderbook = []
     rejected_orders: Orderbook = []
@@ -314,7 +315,5 @@ def extract_results(
                 "only_hours": product[2],
             }
         )
-
-    market_agent.all_orders = []
 
     return accepted_orders, rejected_orders, meta


### PR DESCRIPTION
The bid type is now defined as 'SB' in base_market in case it is not defined but requested.
Also the orders in marketconfig.all_orders and the model are deleted after each calculation. If not, the bid_ids are not unique and the model creates some errors.