### PR TITLE
Remove current status

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -35,15 +35,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      # Install the cosign tool except on PR
-      # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v3
-        with:
-          cosign-release: 'v2.1.1'
-
-
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx
         uses: docker/setup-buildx-action@v2
@@ -82,17 +73,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-
-
-      # Sign the resulting Docker image digest except on PRs.
-      # This will only write to the public Rekor transparency log when the Docker
-      # repository is public to avoid leaking data.  If you would like to publish
-      # transparency data even for private images, pass --force to cosign below.
-      # https://github.com/sigstore/cosign
-      - name: Sign the published Docker image
-        if: ${{ github.event_name != 'pull_request' }}
-        env:
-          COSIGN_EXPERIMENTAL: "true"
-        # This step uses the identity token to provision an ephemeral certificate
-        # against the sigstore community Fulcio instance.
-        run: echo "${{ steps.meta.outputs.tags }}" | xargs -I {} cosign sign {}@${{ steps.build-and-push.outputs.digest }}

--- a/.github/workflows/lint-pytest.yml
+++ b/.github/workflows/lint-pytest.yml
@@ -62,4 +62,3 @@ jobs:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:
         flags: pytest
-        fail_ci_if_error: true

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -182,14 +182,21 @@ class SupportsMinMax(BaseUnit):
         return (fuel_cost + emission_cost) / self.efficiency
 
     def get_operation_time(self, start: datetime):
-        """returns the operation time
-        if unit is on since 4 hours, it returns 4
-        if the unit is off since 4 hours, it returns -4
+        """returns the operation time at time start
+        if unit is on the previous 4 hours, it returns 4
+        if the unit was off the previous 4 hours, it returns -4
+
+        The value at start is not considered
         """
+        before = start - self.index.freq
+        # before = start
         max_time = max(self.min_operating_time, self.min_down_time)
-        begin = start - self.index.freq * max_time
-        end = start
+        begin = before - self.index.freq * max_time
+        end = before
         arr = self.outputs["energy"][begin:end][::-1] > 0
+        if len(arr) < 1:
+            # before start of index
+            return max_time
         is_off = not arr[0]
         runn = 0
         for val in arr:
@@ -248,9 +255,11 @@ class SupportsMinMaxCharge(BaseUnit):
 
     def calculate_ramp_discharge(
         self,
+        previous_soc: float,
         previous_power: float,
         power_discharge: float,
         current_power: float = 0,
+        min_power_discharge: float = 0,
     ) -> float:
         if power_discharge == 0:
             return power_discharge
@@ -279,7 +288,11 @@ class SupportsMinMaxCharge(BaseUnit):
         return power_discharge
 
     def calculate_ramp_charge(
-        self, previous_power: float, power_charge: float, current_power: float = 0
+        self,
+        previous_soc: float,
+        previous_power: float,
+        power_charge: float,
+        current_power: float = 0,
     ) -> float:
         if power_charge == 0:
             return power_charge

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -260,9 +260,9 @@ class WriteOutput(Role):
         if self.db is None:
             return
         queries = [
-            f"select market_id as name, avg(price) as avg_price from market_meta where simulation = '{self.simulation_id}' group by market_id",
-            f"select market_id as name, sum(price*demand_volume_energy) as total_cost from market_meta where simulation = '{self.simulation_id}' group by market_id",
-            f"select market_id as name, sum(demand_volume_energy) as total_volume from market_meta where simulation = '{self.simulation_id}' group by market_id",
+            f"select market_id as name, market_id, avg(price) as avg_price from market_meta where simulation = '{self.simulation_id}' group by market_id",
+            f"select market_id as name, market_id, sum(price*demand_volume_energy) as total_cost from market_meta where simulation = '{self.simulation_id}' group by market_id",
+            f"select market_id as name, market_id, sum(demand_volume_energy) as total_volume from market_meta where simulation = '{self.simulation_id}' group by market_id",
             f"select unit_id as name, market_id, avg(power/max_power) as capacity_factor from market_dispatch ud join power_plant_meta um on ud.unit_id = um.\"index\" and ud.simulation=um.simulation where um.simulation = '{self.simulation_id}' group by name, market_id",
         ]
         dfs = []

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -68,7 +68,7 @@ class flexableEOM(BaseStrategy):
                 )
             else:
                 bid_price_inflex = self.calculate_EOM_price_if_off(
-                    unit, marginal_cost_flex, bid_quantity_inflex
+                    unit, marginal_cost_flex, bid_quantity_inflex, start
                 )
 
             if unit.outputs["heat"][start] > 0:
@@ -79,7 +79,7 @@ class flexableEOM(BaseStrategy):
                 power_loss_ratio = 0.0
 
             # Flex-bid price formulation
-            if unit.get_operation_time(start) > unit.min_down_time:
+            if unit.get_operation_time(start) >= unit.min_down_time:
                 bid_quantity_flex = max_power[start] - bid_quantity_inflex
                 bid_price_flex = (1 - power_loss_ratio) * marginal_cost_flex
 
@@ -107,17 +107,21 @@ class flexableEOM(BaseStrategy):
         return bids
 
     def calculate_EOM_price_if_off(
-        self, unit, marginal_cost_inflex, bid_quantity_inflex
+        self,
+        unit: SupportsMinMax,
+        marginal_cost_inflex,
+        bid_quantity_inflex,
+        start: datetime,
     ):
         # The powerplant is currently off and calculates a startup markup as an extra
         # to the marginal cost
         # Calculating the average uninterrupted operating period
-        av_operating_time = max(
-            unit.mean_market_success, unit.min_operating_time, 1
-        )  # 1 prevents division by 0
-
+        av_operating_time = max((unit.outputs[:start] > 0).mean(), 1)
+        # 1 prevents division by 0
         op_time = unit.get_operation_time(start)
         starting_cost = unit.get_starting_costs(op_time)
+        # if we split starting_cost across av_operating_time
+        # we are never adding the other parts of the cost to the following hours
         if bid_quantity_inflex == 0:
             markup = starting_cost / av_operating_time
         else:
@@ -128,7 +132,7 @@ class flexableEOM(BaseStrategy):
         return bid_price_inflex
 
     def calculate_EOM_price_if_on(
-        self, unit, start, marginal_cost_inflex, bid_quantity_inflex
+        self, unit: SupportsMinMax, start, marginal_cost_inflex, bid_quantity_inflex
     ):
         """
         Check the description provided by Thomas in last version, the average downtime is not available
@@ -138,9 +142,12 @@ class flexableEOM(BaseStrategy):
 
         t = start
         op_time = unit.get_operation_time(start)
+        # TODO is it correct to bill for cold, hot and warm starts in one start?
         starting_cost = unit.get_starting_costs(op_time)
 
-        price_reduction_restart = starting_cost / min_down_time / bid_quantity_inflex
+        price_reduction_restart = (
+            starting_cost / unit.min_down_time / bid_quantity_inflex
+        )
 
         if unit.outputs["heat"][t] > 0:
             heat_gen_cost = (

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -179,8 +179,8 @@ class flexablePosCRMStorage(BaseStrategy):
                 capacity_price = (
                     abs(specific_revenue) * unit.min_power_discharge / bid_quantity
                 )
-
-            energy_price = capacity_price / (unit.current_SOC * unit.max_volume)
+            soc = unit.get_soc_before(start)
+            energy_price = capacity_price / (soc * unit.max_volume)
 
             if market_config.product_type == "capacity_pos":
                 bids.append(
@@ -297,7 +297,8 @@ def get_specific_revenue(unit, marginal_cost, current_time, foresight, price_for
         )
 
     possible_revenue = 0
-    theoretic_SOC = unit.current_SOC
+    soc = unit.get_soc_before(start)
+    theoretic_SOC = soc
 
     previous_power = unit.get_output_before(t)
     for i, market_price in enumerate(price_forecast):
@@ -309,10 +310,8 @@ def get_specific_revenue(unit, marginal_cost, current_time, foresight, price_for
         theoretic_SOC -= theoretic_power_discharge / unit.max_volume
         previous_power = theoretic_power_discharge
 
-    if unit.current_SOC - theoretic_SOC != 0:
-        possible_revenue = (
-            possible_revenue / (unit.current_SOC - theoretic_SOC) / unit.max_volume
-        )
+    if soc != theoretic_SOC:
+        possible_revenue = possible_revenue / (soc - theoretic_SOC) / unit.max_volume
     else:
         possible_revenue = possible_revenue / unit.max_volume
 

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -40,7 +40,8 @@ class flexableEOMStorage(BaseStrategy):
             (unit.outputs["energy"] / unit.efficiency_discharge),
             (unit.outputs["energy"] * unit.efficiency_charge),
         )
-        theoretic_SOC = unit.initial_soc - ((dispatch / unit.max_volume)).sum()
+        soc = unit.get_soc_before(start)
+        theoretic_SOC = soc - ((dispatch / unit.max_volume)).sum()
 
         min_power_charge, max_power_charge = unit.calculate_min_max_charge(
             start, end_all
@@ -60,32 +61,32 @@ class flexableEOMStorage(BaseStrategy):
             current_power_charge = min(current_power, 0)
 
             max_power_discharge[start] = unit.calculate_ramp_discharge(
+                theoretic_SOC,
                 previous_power,
                 max_power_discharge[start],
                 current_power_discharge,
                 min_power_discharge[0],
-                theoretic_SOC,
             )
             min_power_discharge[start] = unit.calculate_ramp_discharge(
+                theoretic_SOC,
                 previous_power,
                 min_power_discharge[start],
                 current_power_discharge,
                 min_power_discharge[start],
-                theoretic_SOC,
             )
             max_power_charge[start] = unit.calculate_ramp_charge(
+                theoretic_SOC,
                 previous_power,
                 max_power_charge[start],
                 current_power_charge,
                 min_power_charge[start],
-                theoretic_SOC,
             )
             min_power_charge[start] = unit.calculate_ramp_charge(
+                theoretic_SOC,
                 previous_power,
                 min_power_charge[start],
                 current_power_charge,
                 min_power_charge[start],
-                theoretic_SOC,
             )
 
             price_forecast = unit.forecaster["price_forecast"]
@@ -151,8 +152,10 @@ class flexablePosCRMStorage(BaseStrategy):
         for product in product_tuples:
             start = product[0]
             current_power = unit.outputs["energy"].at[start]
+            soc = unit.get_soc_before(start)
 
             bid_quantity = unit.calculate_ramp_discharge(
+                soc,
                 previous_power,
                 max_power_discharge[start],
                 current_power,
@@ -228,6 +231,7 @@ class flexableNegCRMStorage(BaseStrategy):
         end = product_tuples[-1][1]
 
         previous_power = unit.get_output_before(start)
+        soc = unit.get_soc_before(start)
 
         min_power_charge, max_power_charge = unit.calculate_min_max_charge(start, end)
 
@@ -236,6 +240,7 @@ class flexableNegCRMStorage(BaseStrategy):
             start = product[0]
             current_power = unit.outputs["energy"].at[start]
             bid_quantity = unit.calculate_ramp_charge(
+                soc,
                 previous_power,
                 max_power_charge[start],
                 current_power,
@@ -297,12 +302,13 @@ def get_specific_revenue(unit, marginal_cost, current_time, foresight, price_for
         )
 
     possible_revenue = 0
-    soc = unit.get_soc_before(start)
+    soc = unit.get_soc_before(current_time)
     theoretic_SOC = soc
 
     previous_power = unit.get_output_before(t)
     for i, market_price in enumerate(price_forecast):
         theoretic_power_discharge = unit.calculate_ramp_discharge(
+            soc,
             previous_power=previous_power,
             power_discharge=max_power_discharge[i],
         )

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -105,9 +105,8 @@ class RLStrategy(LearningStrategy):
         bid_price_inflex = min(bid_prices)
 
         # Flex-bid price formulation
-        if unit.current_status:
-            bid_quantity_flex = max_power - bid_quantity_inflex
-            bid_price_flex = max(bid_prices)
+        bid_quantity_flex = max_power - bid_quantity_inflex
+        bid_price_flex = max(bid_prices)
 
         bids = [
             {

--- a/assume/strategies/storage_strategies.py
+++ b/assume/strategies/storage_strategies.py
@@ -150,7 +150,8 @@ class complexEOMStorage(BaseStrategy):
             unit.mean_market_success, unit.min_operating_time, 1
         )  # 1 prevents division by 0
 
-        starting_cost = self.get_starting_costs(time=unit.current_down_time, unit=unit)
+        op_time = unit.get_operation_time(start)
+        starting_cost = unit.get_starting_costs(op_time)
         markup = starting_cost / av_operating_time / bid_quantity_mr
 
         bid_price_mr = min(marginal_cost_mr + markup, 3000.0)
@@ -164,9 +165,8 @@ class complexEOMStorage(BaseStrategy):
             return 0
 
         t = start
-        min_down_time = max(unit.min_down_time, 1)
-
-        starting_cost = self.get_starting_costs(time=min_down_time, unit=unit)
+        op_time = unit.get_operation_time(start)
+        starting_cost = unit.get_starting_costs(op_time)
 
         price_reduction_restart = starting_cost / min_down_time / bid_quantity_mr
 

--- a/assume/strategies/storage_strategies.py
+++ b/assume/strategies/storage_strategies.py
@@ -146,9 +146,8 @@ class complexEOMStorage(BaseStrategy):
         return average_price
 
     def calculate_EOM_price_if_off(self, unit, marginal_cost_mr, bid_quantity_mr):
-        av_operating_time = max(
-            unit.mean_market_success, unit.min_operating_time, 1
-        )  # 1 prevents division by 0
+        av_operating_time = max((unit.outputs[:start] > 0).mean(), 1)
+        # 1 prevents division by 0
 
         op_time = unit.get_operation_time(start)
         starting_cost = unit.get_starting_costs(op_time)
@@ -168,7 +167,7 @@ class complexEOMStorage(BaseStrategy):
         op_time = unit.get_operation_time(start)
         starting_cost = unit.get_starting_costs(op_time)
 
-        price_reduction_restart = starting_cost / min_down_time / bid_quantity_mr
+        price_reduction_restart = starting_cost / unit.min_down_time / bid_quantity_mr
 
         possible_revenue = self.get_possible_revenues(
             marginal_cost=marginal_cost_flex,

--- a/assume/units/electrolyser.py
+++ b/assume/units/electrolyser.py
@@ -50,8 +50,7 @@ class Electrolyser(BaseUnit):
 
     def reset(self):
         """Reset the unit to its initial state."""
-        self.current_status = 1
-        self.current_down_time = self.min_down_time
+        pass
 
     def calculate_min_max_power(
         self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
@@ -63,9 +62,6 @@ class Electrolyser(BaseUnit):
         operational_window : dict
             Dictionary containing the operational window for the next time step.
         """
-        if self.current_status == 0 and self.current_down_time < self.min_down_time:
-            return None
-
         max_power = self.max_hydrogen_output.at[start]
         min_power = self.min_hydrogen_output.at[start]
 
@@ -104,11 +100,7 @@ class Electrolyser(BaseUnit):
         if self.outputs["energy"][start:end_excl].min() < self.min_power:
             self.outputs["energy"].loc[start:end_excl] = 0
             self.outputs["hydrogen"].loc[start:end_excl] = 0
-            self.current_status = 0
-            self.current_down_time += 1
         else:
-            self.current_status = 1
-            self.current_down_time = 0
             self.outputs["hydrogen"].loc[start:end_excl] = self.outputs["energy"][
                 start:end_excl
             ]

--- a/assume/units/heatpump.py
+++ b/assume/units/heatpump.py
@@ -60,9 +60,6 @@ class HeatPump(SupportsMinMax):
     def reset(self):
         """Reset the unit to its initial state."""
 
-        self.current_status = 1
-        self.current_down_time = self.min_down_time
-
         self.outputs["heat"] = pd.Series(0.0, index=self.index)
         min_thermal_output = self.outputs["heat"].loc[
             self.index[0] : self.index[0] + pd.Timedelta("24h")
@@ -108,9 +105,6 @@ class HeatPump(SupportsMinMax):
         assert heat_demand.min() >= 0
 
         cop = self.calculate_cop()
-
-        if self.current_status == 0 and self.current_down_time < self.min_down_time:
-            return None
 
         # check if min_power is a series or a float
         min_power = (
@@ -162,11 +156,7 @@ class HeatPump(SupportsMinMax):
         if self.outputs["energy"][start:end_excl].min() < self.min_power:
             self.outputs["energy"].loc[start:end_excl] = 0
             self.outputs["heat"].loc[start:end_excl] = 0
-            self.current_status = 0
-            self.current_down_time += 1
         else:
-            self.current_status = 1
-            self.current_down_time = 0
             self.outputs["heat"].loc[start:end_excl] = self.outputs["energy"][
                 start:end_excl
             ]

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -103,8 +103,6 @@ class PowerPlant(SupportsMinMax):
         self.outputs["rewards"] = pd.Series(0.0, index=self.index)
         self.outputs["regrets"] = pd.Series(0.0, index=self.index)
 
-        self.mean_market_success = 0
-
     def execute_current_dispatch(
         self,
         start: pd.Timestamp,

--- a/tests/test_flexable_strategies.py
+++ b/tests/test_flexable_strategies.py
@@ -47,7 +47,6 @@ def test_flexable_eom(mock_market_config, power_plant):
     assert bids[1]["volume"] == 800
 
     # start-up situation with ramping restriction
-    power_plant.current_status = 0
     power_plant.ramp_up = 400
     bids = strategy.calculate_bids(power_plant, mc, product_tuples=product_tuples)
     assert len(bids) == 2

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -1,6 +1,9 @@
+import pytest
+
 from assume.cli import cli
 
 
+@pytest.mark.slow
 def test_cli():
     args = "-s example_01a -c base -db sqlite:///./examples/local_db/test_mini.db"
     cli(args.split(" "))

--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -100,12 +100,7 @@ def test_init_function(power_plant_1, power_plant_2, power_plant_3):
 
 
 def test_reset_function(power_plant_1):
-    power_plant_1.current_status = 0
-    assert power_plant_1.current_status == 0
-
     power_plant_1.reset()
-    assert power_plant_1.current_status == 1
-
     # check if total_power_output is reset
     assert power_plant_1.outputs["energy"].equals(
         pd.Series(0.0, index=pd.date_range("2022-01-01", periods=4, freq="H"))

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,4 +1,5 @@
 import math
+from datetime import timedelta
 
 import pandas as pd
 import pytest
@@ -107,6 +108,23 @@ def test_calculate_operational_window(storage_unit):
     assert min_power_discharge[0] == 40
     assert max_power_discharge[0] == 60
 
+    start = start + timedelta(hours=1)
+
+
+def test_soc_constraint(storage_unit):
+    # start should not be the first hour of index to manipulate soc
+    product_tuple = (
+        pd.Timestamp("2022-01-01 01:00:00"),
+        pd.Timestamp("2022-01-01 02:00:00"),
+        None,
+    )
+    start = product_tuple[0]
+    end = product_tuple[1]
+
+    storage_unit.outputs["energy"][start] = 10
+    storage_unit.outputs["capacity_neg"][start] = -50
+    storage_unit.outputs["capacity_pos"][start] = 30
+
     storage_unit.outputs["soc"][start - storage_unit.index.freq] = 0.05
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
         start, end
@@ -121,9 +139,8 @@ def test_calculate_operational_window(storage_unit):
         start, end
     )
     assert min_power_charge[0] == -40
-    # TODO: remove rounding?
     assert math.isclose(
-        max_power_charge[0], round(-50 / storage_unit.efficiency_charge, 1)
+        max_power_charge[0], -50 / storage_unit.efficiency_charge, abs_tol=0.1
     )
 
 
@@ -181,6 +198,7 @@ def test_storage_feedback(storage_unit, mock_market_config):
     # we can not bid the maximum anymore, because we already provide energy on the other market
     assert max_power_discharge[start] == 50
 
+    storage_unit.execute_current_dispatch(start, end)
     # second market request for next interval
     start = pd.Timestamp("2022-01-01 01:00:00")
     end = pd.Timestamp("2022-01-01 02:00:00")
@@ -224,9 +242,11 @@ def test_storage_ramping(storage_unit):
     assert max_power_discharge[start] == 100
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        0, max_power_discharge[start]
+        0.5, 0, max_power_discharge[start]
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(0, max_power_charge[start])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(
+        0.5, 0, max_power_charge[start]
+    )
 
     assert max_ramp_discharge == 60
     assert max_ramp_charge == -60
@@ -245,9 +265,11 @@ def test_storage_ramping(storage_unit):
     end = product_tuple[1]
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        60, max_power_discharge[start]
+        0.5, 60, max_power_discharge[start]
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(60, max_power_charge[start])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(
+        0.5, 60, max_power_charge[start]
+    )
 
     assert max_ramp_discharge == 100
     assert max_ramp_charge == 0
@@ -258,7 +280,7 @@ def test_storage_ramping(storage_unit):
     # next hour
     product_tuple = (
         pd.Timestamp("2022-01-01 02:00:00"),
-        pd.Timestamp("2022-01-01 01:00:00"),
+        pd.Timestamp("2022-01-01 03:00:00"),
         None,
     )
 
@@ -266,9 +288,11 @@ def test_storage_ramping(storage_unit):
     end = product_tuple[1]
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        -60, max_power_discharge[start]
+        0.5, -60, max_power_discharge[start]
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(-60, max_power_charge[start])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(
+        0.5, -60, max_power_charge[start]
+    )
 
     assert max_ramp_discharge == 0
     assert max_ramp_charge == -100
@@ -278,8 +302,8 @@ def test_execute_dispatch(storage_unit):
     storage_unit.reset()
 
     product_tuple = (
-        pd.Timestamp("2022-01-01 00:00:00"),
         pd.Timestamp("2022-01-01 01:00:00"),
+        pd.Timestamp("2022-01-01 02:00:00"),
         None,
     )
     start = product_tuple[0]
@@ -287,32 +311,40 @@ def test_execute_dispatch(storage_unit):
 
     storage_unit.outputs["energy"][start] = 100
     storage_unit.outputs["soc"][start - storage_unit.index.freq] = 0.5
+
+    # dispatch full discharge
     dispatched_energy = storage_unit.execute_current_dispatch(start, end)
     assert dispatched_energy[0] == 100
     assert math.isclose(
         storage_unit.outputs["soc"][start],
-        round(
-            0.5 - 100 / storage_unit.efficiency_discharge / storage_unit.max_volume, 2
-        ),
+        0.5 - 100 / storage_unit.efficiency_discharge / storage_unit.max_volume,
     )
+
+    # dispatch full charging
     storage_unit.outputs["energy"][start] = -100
     storage_unit.outputs["soc"][start - storage_unit.index.freq] = 0.5
     dispatched_energy = storage_unit.execute_current_dispatch(start, end)
     assert dispatched_energy[0] == -100
     assert math.isclose(
         storage_unit.outputs["soc"][start],
-        round(0.5 + 100 * storage_unit.efficiency_charge / storage_unit.max_volume, 2),
+        0.5 + 100 * storage_unit.efficiency_charge / storage_unit.max_volume,
     )
     storage_unit.outputs["energy"][start] = 100
     storage_unit.outputs["soc"][start - storage_unit.index.freq] = 0.05
     dispatched_energy = storage_unit.execute_current_dispatch(start, end)
-    assert dispatched_energy[0] == round(50 * storage_unit.efficiency_discharge, 1)
+    assert math.isclose(
+        dispatched_energy[0], 50 * storage_unit.efficiency_discharge, abs_tol=0.1
+    )
     storage_unit.outputs["energy"][start] = -100
     storage_unit.outputs["soc"][start - storage_unit.index.freq] = 0.95
     dispatched_energy = storage_unit.execute_current_dispatch(start, end)
-    assert dispatched_energy[0] == round(-50 / storage_unit.efficiency_charge, 1)
+    assert math.isclose(
+        dispatched_energy[0], -50 / storage_unit.efficiency_charge, abs_tol=0.1
+    )
     storage_unit.outputs["soc"][start] = 1
 
+    start = start + storage_unit.index.freq
+    end = end + storage_unit.index.freq
     storage_unit.outputs["energy"][start] = -100
     dispatched_energy = storage_unit.execute_current_dispatch(start, end)
     assert dispatched_energy[0] == 0

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -56,14 +56,16 @@ def test_minmaxcharge():
 
     # stay turned off
     assert (
-        mmc.calculate_ramp_charge(previous_power=0, power_charge=0, current_power=0)
+        mmc.calculate_ramp_charge(
+            0.5, previous_power=0, power_charge=0, current_power=0
+        )
         == 0
     )
 
     # stay turned off
     assert (
         mmc.calculate_ramp_discharge(
-            previous_power=0, power_discharge=0, current_power=0
+            0.5, previous_power=0, power_discharge=0, current_power=0
         )
         == 0
     )
@@ -84,8 +86,13 @@ def test_minmax_operationtime():
 
     mm.outputs["energy"][-4:] = 0
     runtime = mm.get_operation_time(datetime(2023, 7, 2))
-    assert runtime < 0
+    assert runtime == -3
 
-    mm.outputs["energy"][-1:] = 1000
+    mm.outputs["energy"][-2:] = 1000
     runtime = mm.get_operation_time(datetime(2023, 7, 2))
     assert runtime == 1
+
+    mm.outputs["energy"][:] = 400
+    mm.outputs["energy"][-1:] = 0
+    runtime = mm.get_operation_time(datetime(2023, 7, 2))
+    assert runtime == 5


### PR DESCRIPTION
This removes occurances of `current_status`, `current_down_time`, `current_SOC` and uses the `unit.outputs` instead