### PR TITLE
various fixes and unit cashflow

### DIFF
--- a/assume/common/forecasts.py
+++ b/assume/common/forecasts.py
@@ -111,10 +111,15 @@ class CsvForecaster(Forecaster):
         """
         Calculates the forecasts if they are not already calculated.
         """
+        cols = []
         for pp in self.powerplants.index:
             col = f"availability_{pp}"
             if col not in self.forecasts.columns:
-                self.forecasts[col] = 1
+                s = pd.Series(1, index=self.forecasts.index)
+                s.name = col
+                cols.append(s)
+        cols.append(self.forecasts)
+        self.forecasts = pd.concat(cols, axis=1).copy()
         if "price_EOM" not in self.forecasts.columns:
             self.forecasts["price_EOM"] = self.calculate_EOM_price_forecast()
         if "residual_load_EOM" not in self.forecasts.columns:

--- a/assume/common/scenario_loader.py
+++ b/assume/common/scenario_loader.py
@@ -298,7 +298,7 @@ async def load_scenario_folder_async(
 
     # Initialize world
 
-    save_frequency_hours = config.get("save_frequency_hours", None)
+    save_frequency_hours = config.get("save_frequency_hours", 48)
     sim_id = f"{scenario}_{study_case}"
 
     learning_config = config.get("learning_config", {})

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -217,8 +217,13 @@ class UnitsOperator(Role):
         unit_dispatch_dfs = []
         for unit_id, unit in self.units.items():
             current_dispatch = unit.execute_current_dispatch(start, now)
+            end = now - unit.index.freq
             current_dispatch.name = "power"
             data = pd.DataFrame(current_dispatch)
+            data["soc"] = unit.outputs["soc"][start:end]
+            for key in unit.outputs.keys():
+                if "cashflow" in key:
+                    data[key] = unit.outputs[key][start:end]
             data["unit"] = unit_id
             unit_dispatch_dfs.append(data)
 

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -376,17 +376,19 @@ class UnitsOperator(Role):
         :param marketconfig: the market configuration
         :type marketconfig: MarketConfig
         """
-        learning_unit_count = 0
+        learning_strategies = []
         action_dimension = 0
         for unit in self.units.values():
             bidding_strategy = unit.bidding_strategies.get(marketconfig.product_type)
             if isinstance(bidding_strategy, LearningStrategy):
-                learning_unit_count += 1
+                learning_strategies.append(bidding_strategy)
                 # should be the same across all strategies
                 action_dimension = bidding_strategy.act_dim
-        if learning_unit_count > 0:
+        if len(learning_strategies) > 0:
             start = orderbook[0]["start_time"]
             unit_rl_strategy_dfs = []
+            learning_unit_count = len(learning_strategies)
+            learning_mode = learning_strategies[0].learning_mode
 
             all_observations = []
             all_rewards = []
@@ -434,7 +436,6 @@ class UnitsOperator(Role):
 
             data = (all_observations, all_actions, all_rewards)
             learning_data = pd.concat(unit_rl_strategy_dfs)
-            # TODO send observation and action also to output agent if neede din visualisation of grafana
 
             db_aid = self.context.data_dict.get("output_agent_id")
             db_addr = self.context.data_dict.get("output_agent_addr")
@@ -452,7 +453,7 @@ class UnitsOperator(Role):
             learning_role_id = "learning_agent"
             learning_role_addr = self.context.addr
 
-            if learning_role_id and learning_role_addr:
+            if learning_mode:
                 self.context.schedule_instant_acl_message(
                     receiver_id=learning_role_id,
                     receiver_addr=learning_role_addr,

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -147,7 +147,7 @@ class flexableEOM(BaseStrategy):
         :return: The bid price of the unit
         :rtype: float
         """
-        av_operating_time = max((unit.outputs[:start] > 0).mean(), 1)
+        av_operating_time = max((unit.outputs["energy"][:start] > 0).mean(), 1)
         # 1 prevents division by 0
         op_time = unit.get_operation_time(start)
         starting_cost = unit.get_starting_costs(op_time)

--- a/assume/strategies/storage_strategies.py
+++ b/assume/strategies/storage_strategies.py
@@ -186,7 +186,7 @@ class complexEOMStorage(BaseStrategy):
         :return: the bid price
         :rtype: float
         """
-        av_operating_time = max((unit.outputs[:start] > 0).mean(), 1)
+        av_operating_time = max((unit.outputs["energy"][:start] > 0).mean(), 1)
         # 1 prevents division by 0
 
         op_time = unit.get_operation_time(start)

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -299,7 +299,7 @@ class PowerPlant(SupportsMinMax):
         # needed minimum + capacity_neg - what is already sold is actual minimum
         min_power = self.min_power + capacity_neg - base_load
         # min_power should be at least the heat demand at that time
-        min_power = min_power.where(min_power >= heat_demand, heat_demand)
+        min_power = min_power.clip(lower=heat_demand)
 
         max_power = (
             self.forecaster.get_availability(self.id)[start:end_excl] * self.max_power
@@ -309,7 +309,7 @@ class PowerPlant(SupportsMinMax):
         # remove what has already been bid
         max_power = max_power - base_load
         # make sure that max_power is > 0 for all timesteps
-        max_power = max_power.where(max_power >= 0, 0)
+        max_power = max_power.clip(lower=0)
 
         return min_power, max_power
 

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -190,36 +190,6 @@ class PowerPlant(SupportsMinMax):
         #     logger.error(f"{max_pow} greater than {self.max_power} - bidding twice?")
         return self.outputs["energy"].loc[start:end_excl]
 
-    def calculate_cashflow(self, product_type: str, orderbook: Orderbook):
-        """
-        Calculates the cashflow of the unit based on the provided product type and orderbook.
-        Returns the cashflow of the unit.
-
-        :param product_type: the product type of the unit
-        :type product_type: str
-        :param orderbook: the orderbook of the unit
-        :type orderbook: Orderbook
-        :return: the cashflow of the unit
-        :rtype: float
-        """
-        for order in orderbook:
-            start = order["start_time"]
-            end = order["end_time"]
-            end_excl = end - self.index.freq
-
-            if isinstance(order["accepted_volume"], dict):
-                cashflow = float(
-                    order["accepted_price"][i] * order["accepted_volume"][i]
-                    for i in order["accepted_volume"].keys()
-                )
-            else:
-                cashflow = float(order["accepted_price"] * order["accepted_volume"])
-
-            hours = (end - start) / timedelta(hours=1)
-            self.outputs[f"{product_type}_cashflow"].loc[start:end_excl] += (
-                cashflow * hours
-            )
-
     def calc_simple_marginal_cost(
         self,
     ):

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -379,7 +379,7 @@ class Storage(SupportsMinMaxCharge):
             else self.min_power_charge
         )
         min_power_charge -= base_load + capacity_pos
-        min_power_charge = (min_power_charge).where(min_power_charge <= 0, 0)
+        min_power_charge = min_power_charge.clip(upper=0)
 
         max_power_charge = (
             self.max_power_charge[start:end_excl]
@@ -397,9 +397,7 @@ class Storage(SupportsMinMaxCharge):
 
         # restrict charging according to max_volume
         max_soc_charge = self.calculate_soc_max_charge(self.get_soc_before(start))
-        max_power_charge = max_power_charge.where(
-            max_power_charge > max_soc_charge, max_soc_charge
-        )
+        max_power_charge = max_power_charge.clip(lower=max_soc_charge)
 
         return min_power_charge, max_power_charge
 
@@ -428,7 +426,7 @@ class Storage(SupportsMinMaxCharge):
             else self.min_power_discharge
         )
         min_power_discharge -= base_load + capacity_neg
-        min_power_discharge = (min_power_discharge).where(min_power_discharge >= 0, 0)
+        min_power_discharge = min_power_discharge.clip(lower=0)
 
         max_power_discharge = (
             self.max_power_discharge[start:end_excl]
@@ -446,9 +444,7 @@ class Storage(SupportsMinMaxCharge):
 
         # restrict according to min_volume
         max_soc_discharge = self.calculate_soc_max_discharge(self.get_soc_before(start))
-        max_power_discharge = max_power_discharge.where(
-            max_power_discharge < max_soc_discharge, max_soc_discharge
-        )
+        max_power_discharge = max_power_discharge.clip(upper=max_soc_discharge)
 
         return min_power_discharge, max_power_discharge
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -181,6 +181,7 @@ def test_storage_feedback(storage_unit, mock_market_config):
             "end_time": end,
             "only_hours": None,
             "price": cost_discharge,
+            "accepted_price": cost_discharge,
             "accepted_volume": max_power_discharge[start] / 2,
         }
     ]

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -66,6 +66,7 @@ async def test_set_unit_dispatch(units_operator: UnitsOperator):
             "volume": 500,
             "accepted_volume": 500,
             "price": 1000,
+            "accepted_price": 1000,
             "agent_id": "gen1",
             "unit_id": "testdemand",
             "only_hours": None,


### PR DESCRIPTION
This PR adds the SoC and Cashflow calculation to the output.
* It also fixes a bug in flexable and storage strategies.
* Moves from `.where` to `.clip` in appropriate places
* fixes default value for `save_frequency_hours`
* fixes defragmented forecast dataframe
* fixes sending message to learning mode #163 
