### PR TITLE
Add a way to ask a MarketRole for its required_fields

### DIFF
--- a/assume/markets/clearing_algorithms/complex_clearing.py
+++ b/assume/markets/clearing_algorithms/complex_clearing.py
@@ -137,9 +137,10 @@ def market_clearing_opt(orders, market_products, mode):
 
 
 class ComplexClearingRole(MarketRole):
+    required_fields = ["bid_type"]
+
     def __init__(self, marketconfig: MarketConfig):
         super().__init__(marketconfig)
-        assert "bid_type" in self.marketconfig.additional_fields
 
     def validate_orderbook(self, orderbook: Orderbook, agent_tuple) -> None:
         super().validate_orderbook(orderbook, agent_tuple)

--- a/assume/markets/clearing_algorithms/complex_clearing_dmas.py
+++ b/assume/markets/clearing_algorithms/complex_clearing_dmas.py
@@ -31,11 +31,10 @@ order_types = ["single_ask", "single_bid", "linked_ask", "exclusive_ask"]
 
 
 class ComplexDmasClearingRole(MarketRole):
+    required_fields = ["link", "block_id", "exclusive_id"]
+
     def __init__(self, marketconfig: MarketConfig):
         super().__init__(marketconfig)
-        assert "link" in self.marketconfig.additional_fields
-        assert "block_id" in self.marketconfig.additional_fields
-        assert "exclusive_id" in self.marketconfig.additional_fields
 
     def clear(
         self, orderbook: Orderbook, market_products: list[MarketProduct]

--- a/assume/markets/clearing_algorithms/nodal_pricing.py
+++ b/assume/markets/clearing_algorithms/nodal_pricing.py
@@ -3,22 +3,18 @@ from itertools import groupby
 from operator import itemgetter
 
 import pandas as pd
-
-try:
-    from pyomo.environ import (
-        ConcreteModel,
-        ConstraintList,
-        NonNegativeReals,
-        Objective,
-        Reals,
-        Set,
-        Suffix,
-        Var,
-        maximize,
-    )
-    from pyomo.opt import SolverFactory, check_available_solvers
-except ImportError:
-    pass
+from pyomo.environ import (
+    ConcreteModel,
+    ConstraintList,
+    NonNegativeReals,
+    Objective,
+    Reals,
+    Set,
+    Suffix,
+    Var,
+    maximize,
+)
+from pyomo.opt import SolverFactory, check_available_solvers
 
 from assume.common.market_objects import MarketConfig, MarketProduct, Orderbook
 from assume.markets.base_market import MarketRole
@@ -29,6 +25,8 @@ SOLVERS = ["glpk", "cbc", "gurobi", "cplex"]
 
 
 class NodalPyomoMarketRole(MarketRole):
+    required_fields = ["node_id"]
+
     def __init__(
         self,
         marketconfig: MarketConfig,
@@ -45,7 +43,6 @@ class NodalPyomoMarketRole(MarketRole):
         network = {"Line_0": (0, 1, 100), "Line_1": (1, 2, 100), "Line_2": (2, 0, 100)}
         """
         super().__init__(marketconfig)
-        assert "node_id" in self.marketconfig.additional_fields
         self.nodes = nodes
         self.network = network
 


### PR DESCRIPTION
This makes it possible to check compatibility between a MarketRole and a MarketMechanism in an easy way

As required_fields is a class variable, it is set without instatiation of ClearingRole Object