### PR TITLE
add reuse lint to CI and pre-commit hook

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -30,6 +30,10 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: '**/pyproject.toml'
+    - name: Check reuse compliance
+      run: |
+        pip install reuse
+        reuse lint
     - name: Install dependencies
       run: |
         sudo apt-get update && sudo apt-get install --no-install-recommends -y coinor-cbc gcc g++ libglpk-dev glpk-utils && sudo rm -rf /var/lib/apt/lists/*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 repos:
+  - repo: https://github.com/fsfe/reuse-tool
+    rev: v2.1.0
+    hooks:
+      - id: reuse
+        args: ["annotate", "--license", "AGPL-3.0-or-later", "--recursive", "--copyright", "ASSUME Developers", "--exclude-year", "--skip-unrecognised", "."]
+
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:

--- a/assume/common/exceptions.py
+++ b/assume/common/exceptions.py
@@ -2,6 +2,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+# Assume Exceptions
+
 
 class AssumeException(Exception):
     pass


### PR DESCRIPTION
This adds linting reuse compliance to the pre-commit hook and the CI.

So that we stay reuse compliant when adding new files