### PR TITLE
Fix usage of license references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN useradd -m -s /bin/bash admin
 
 RUN mkdir /src
 WORKDIR /src
-COPY README.md LICENSE pyproject.toml .
+COPY README.md pyproject.toml .
 #RUN python -m pip install --upgrade pip
 # thats needed to use create the requirements.txt only
 RUN pip install pip-tools

--- a/README.md
+++ b/README.md
@@ -173,4 +173,4 @@ ASSUME is funded by the Federal Ministry for Economic Affairs and Climate Action
 
 Copyright 2022-2023 [ASSUME developers](https://assume.readthedocs.io/en/latest/developers.html).
 
-ASSUME is licensed under the [GNU Affero General Public License v3.0](./LICENSE). This license is a strong copyleft license that requires that any derivative work be licensed under the same terms as the original work. It is approved by the [Open Source Initiative](https://opensource.org/licenses/AGPL-3.0).
+ASSUME is licensed under the [GNU Affero General Public License v3.0](./LICENSES/AGPL-3.0-or-later.txt). This license is a strong copyleft license that requires that any derivative work be licensed under the same terms as the original work. It is approved by the [Open Source Initiative](https://opensource.org/licenses/AGPL-3.0).

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -189,4 +189,4 @@ Licence
 
 Copyright 2022-2023 :doc:`developers`
 
-ASSUME is licensed under the `GNU Affero General Public License v3.0 <https://github.com/assume-framework/assume/blob/main/LICENSE>`_.
+ASSUME is licensed under the `GNU Affero General Public License v3.0 <https://github.com/assume-framework/assume/blob/main/LICENSES/AGPL-3.0-or-later.txt>`_.


### PR DESCRIPTION
As the docker build is failing, I fixed the references to the license file as this was changed to be reuse compliant.