### PR TITLE
fixes calculation of marginal cost and output_before

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -142,13 +142,6 @@ class BaseUnit:
             else:
                 added_volume = order["accepted_volume"]
             self.outputs[product_type].loc[start:end_excl] += added_volume
-
-            self.outputs[product_type + "_marginal_costs"].loc[start:end_excl] = (
-                self.calculate_marginal_cost(
-                    start, self.outputs[product_type].loc[start]
-                )
-                * self.outputs[product_type].loc[start:end_excl]
-            )
         self.calculate_cashflow(product_type, orderbook)
 
         self.bidding_strategies[product_type].calculate_reward(
@@ -156,6 +149,21 @@ class BaseUnit:
             marketconfig=marketconfig,
             orderbook=orderbook,
         )
+
+    def calculate_generation_cost(
+        self,
+        start: datetime,
+        end: datetime,
+        product_type: str,
+    ):
+        if start not in self.index:
+            return
+        product_type_mc = product_type + "_marginal_costs"
+        for t in self.outputs[product_type_mc][start:end].index:
+            mc = self.calculate_marginal_cost(
+                start, self.outputs[product_type].loc[start]
+            )
+            self.outputs[product_type_mc][t] = mc * self.outputs[product_type][start]
 
     def execute_current_dispatch(
         self,

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -106,6 +106,19 @@ class BaseUnit:
 
         return bids
 
+    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
+        """
+        calculates the marginal cost for the given power
+
+        :param start: the start time of the dispatch
+        :type start: pd.Timestamp
+        :param power: the power output of the unit
+        :type power: float
+        :return: the marginal cost for the given power
+        :rtype: float
+        """
+        return 0
+
     def set_dispatch_plan(
         self,
         marketconfig: MarketConfig,
@@ -125,21 +138,18 @@ class BaseUnit:
             end = order["end_time"]
             end_excl = end - self.index.freq
             if isinstance(order["accepted_volume"], dict):
-                self.outputs[product_type].loc[start:end_excl] += [
-                    order["accepted_volume"][key]
-                    for key in order["accepted_volume"].keys()
-                ]
+                added_volume = list(order["accepted_volume"].values())
             else:
-                self.outputs[product_type].loc[start:end_excl] += order[
-                    "accepted_volume"
-                ]
+                added_volume = order["accepted_volume"]
+            self.outputs[product_type].loc[start:end_excl] += added_volume
 
+            self.outputs[product_type + "_marginal_costs"].loc[start:end_excl] = (
+                self.calculate_marginal_cost(
+                    start, self.outputs[product_type].loc[start]
+                )
+                * self.outputs[product_type].loc[start:end_excl]
+            )
         self.calculate_cashflow(product_type, orderbook)
-
-        self.outputs[product_type + "_marginal_costs"].loc[start:end_excl] += (
-            self.calculate_marginal_cost(start, self.outputs[product_type].loc[start])
-            * self.outputs[product_type].loc[start:end_excl]
-        )
 
         self.bidding_strategies[product_type].calculate_reward(
             unit=self,
@@ -182,7 +192,7 @@ class BaseUnit:
         if dt - self.index.freq < self.index[0]:
             return 0
         else:
-            return self.outputs["energy"].at[dt - self.index.freq]
+            return self.outputs[product_type].at[dt - self.index.freq]
 
     def as_dict(self) -> dict:
         """
@@ -288,19 +298,6 @@ class SupportsMinMax(BaseUnit):
         :type product_type: str
         :return: the min and max power for the given time period
         :rtype: tuple[pd.Series, pd.Series]
-        """
-        pass
-
-    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
-        """
-        Calculates the marginal cost for the given power
-
-        :param start: the start time of the dispatch
-        :type start: pd.Timestamp
-        :param power: the power output of the unit
-        :type power: float
-        :return: the marginal cost for the given power
-        :rtype: float
         """
         pass
 
@@ -532,19 +529,6 @@ class SupportsMinMaxCharge(BaseUnit):
         """
         pass
 
-    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
-        """
-        calculates the marginal cost for the given power
-
-        :param start: the start time of the dispatch
-        :type start: pd.Timestamp
-        :param power: the power output of the unit
-        :type power: float
-        :return: the marginal cost for the given power
-        :rtype: float
-        """
-        pass
-
     def get_soc_before(self, dt: datetime) -> float:
         """
         return SoC before the given datetime.
@@ -720,8 +704,7 @@ class BaseStrategy:
         :param orderbook: The orderbook.
         :type orderbook: Orderbook
         """
-
-    pass
+        pass
 
 
 class LearningStrategy(BaseStrategy):

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -258,15 +258,13 @@ class UnitsOperator(Role):
             end = now
             current_dispatch.name = "power"
             data = pd.DataFrame(current_dispatch)
-            data["soc"] = unit.outputs["soc"][start:end]
+            unit.calculate_generation_cost(start, now, "energy")
+            valid_outputs = ["soc", "cashflow", "marginal_costs", "total_costs"]
 
             for key in unit.outputs.keys():
-                if "cashflow" in key:
-                    data[key] = unit.outputs[key][start:end]
-                if "marginal_costs" in key:
-                    data[key] = unit.outputs[key][start:end]
-                if "total_costs" in key:
-                    data[key] = unit.outputs[key][start:end]
+                for output in valid_outputs:
+                    if output in key:
+                        data[key] = unit.outputs[key][start:end]
 
             data["unit"] = unit_id
             unit_dispatch_dfs.append(data)

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -53,9 +53,9 @@ class MarketMechanism:
         Used to check if a participant is eligible to bid on this market
         """
 
-        # simple check that 1 MW can be bid at least
-        def requirement(unit):
-            return unit["unit_type"] != "power_plant" or abs(unit["max_power"]) >= 1
+        # simple check that 1 MW can be bid at least by  powerplants
+        def requirement(unit: dict):
+            return unit.get("unit_type") != "power_plant" or abs(unit["max_power"]) >= 1
 
         return all([requirement(info) for info in content["information"]])
 

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -52,8 +52,11 @@ class MarketMechanism:
         method to validate a given registration.
         Used to check if a participant is eligible to bid on this market
         """
+
         # simple check that 1 MW can be bid at least
-        requirement = lambda unit: unit["max_power"] >= 1 or unit["min_power"] <= -1
+        def requirement(unit):
+            return unit["unit_type"] != "power_plant" or abs(unit["max_power"]) >= 1
+
         return all([requirement(info) for info in content["information"]])
 
     def validate_orderbook(self, orderbook: Orderbook, agent_tuple: tuple) -> None:

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from datetime import datetime, timedelta
+
+import pandas as pd
+import pytest
+
+from assume.common.base import BaseStrategy, BaseUnit
+from assume.common.forecasts import NaiveForecast
+from assume.common.market_objects import MarketConfig, Orderbook, Product
+
+
+class BasicStrategy(BaseStrategy):
+    def calculate_bids(
+        self,
+        unit: BaseUnit,
+        market_config: MarketConfig,
+        product_tuples: list[Product],
+        **kwargs,
+    ) -> Orderbook:
+        bids = []
+        for product in product_tuples:
+            bids.append(
+                {
+                    "start_time": product[0],
+                    "end_time": product[1],
+                    "only_hours": product[2],
+                    "price": 10,
+                    "volume": 20,
+                }
+            )
+        return bids
+
+
+@pytest.fixture
+def base_unit() -> BaseUnit:
+    # Create a PowerPlant instance with some example parameters
+    index = pd.date_range("2022-01-01", periods=4, freq="H")
+    ff = NaiveForecast(
+        index, availability=1, fuel_price=[10, 11, 12, 13], co2_price=[10, 20, 30, 30]
+    )
+    return BaseUnit(
+        id="test_pp",
+        unit_operator="test_operator",
+        technology="base",
+        bidding_strategies={"energy": BasicStrategy()},
+        index=index,
+    )
+
+
+def test_init_function(base_unit, mock_market_config):
+    assert base_unit.id == "test_pp"
+    assert base_unit.unit_operator == "test_operator"
+    assert base_unit.technology == "base"
+    assert base_unit.as_dict() == {
+        "id": "test_pp",
+        "technology": "base",
+        "unit_operator": "test_operator",
+        "node": "",
+        "unit_type": "base_unit",
+    }
+
+
+def test_output_before(base_unit, mock_market_config):
+    index = base_unit.index
+    assert base_unit.get_output_before(index[0], "energy") == 0
+    assert base_unit.get_output_before(index[0], "fictional_product_type") == 0
+
+    base_unit.outputs["energy"][index[0]] = 100
+    assert base_unit.get_output_before(index[1], "energy") == 100
+    assert base_unit.get_output_before(index[0], "energy") == 0
+
+    base_unit.outputs["fictional_product_type"][index[0]] = 200
+    assert base_unit.get_output_before(index[1], "fictional_product_type") == 200
+    assert base_unit.get_output_before(index[0], "fictional_product_type") == 0
+
+
+def test_calculate_bids(base_unit, mock_market_config):
+    index = base_unit.index
+    start = index[0]
+    end = index[1]
+    product_tuples = [(start, end, None)]
+    bids = base_unit.calculate_bids(mock_market_config, product_tuples)
+    assert bids == [
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": 10,
+            "volume": 20,
+        }
+    ]
+
+    orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": 10,
+            "volume": 10,
+            "accepted_price": 11,
+            "accepted_volume": 10,
+        }
+    ]
+    # mock calculate_marginal_cost
+    base_unit.calculate_marginal_cost = lambda *x: 10
+    base_unit.set_dispatch_plan(mock_market_config, orderbook)
+
+    # we apply the dispatch plan of 10 MW
+    assert base_unit.outputs["energy"][start] == 10
+    assert base_unit.outputs["energy_marginal_costs"][start] == 10 * 10
+    # we received more, as accepted_price is higher
+    assert base_unit.outputs["energy_cashflow"][start] == 10 * 11
+
+    # we somehow sold an additional 10 MW
+    base_unit.set_dispatch_plan(mock_market_config, orderbook)
+
+    # the final output should be 10+10
+    assert base_unit.outputs["energy"][start] == 20
+    # the marginal cost for this volume should be twice as much too
+    assert base_unit.outputs["energy_marginal_costs"][start] == 200
+    assert base_unit.outputs["energy_cashflow"][start] == 20 * 11
+
+
+def test_calculate_multi_bids(base_unit, mock_market_config):
+    index = base_unit.index
+
+    # when we set
+    orderbook = [
+        {
+            "start_time": index[0],
+            "end_time": index[1],
+            "only_hours": None,
+            "price": 10,
+            "volume": 10,
+            "accepted_price": 11,
+            "accepted_volume": 10,
+        },
+        {
+            "start_time": index[1],
+            "end_time": index[2],
+            "only_hours": None,
+            "price": 10,
+            "volume": 10,
+            "accepted_price": 11,
+            "accepted_volume": 10,
+        },
+    ]
+    # mock calculate_marginal_cost
+    base_unit.calculate_marginal_cost = lambda *x: 10
+    base_unit.set_dispatch_plan(mock_market_config, orderbook)
+
+    assert base_unit.outputs["energy"][index[0]] == 10
+    assert base_unit.outputs["energy_marginal_costs"][index[0]] == 100
+    assert base_unit.outputs["energy_cashflow"][index[0]] == 110
+    assert base_unit.outputs["energy"][index[1]] == 10
+    assert base_unit.outputs["energy_marginal_costs"][index[1]] == 100
+    assert base_unit.outputs["energy_cashflow"][index[1]] == 110
+
+    base_unit.set_dispatch_plan(mock_market_config, orderbook)
+
+    # should be correctly applied for the sum, even if different hours are applied
+    assert base_unit.outputs["energy"][index[0]] == 20
+    assert base_unit.outputs["energy_marginal_costs"][index[0]] == 200
+    assert base_unit.outputs["energy_cashflow"][index[0]] == 220
+    assert base_unit.outputs["energy"][index[1]] == 20
+    assert base_unit.outputs["energy_marginal_costs"][index[1]] == 200
+    assert base_unit.outputs["energy_cashflow"][index[1]] == 220
+
+    # in base_unit - this should not do anything but get return the energy dispatch
+    assert (
+        base_unit.execute_current_dispatch(index[0], index[2])
+        == base_unit.outputs["energy"][index[0] : index[2]]
+    ).all()

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -107,6 +107,7 @@ def test_calculate_bids(base_unit, mock_market_config):
     # mock calculate_marginal_cost
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
+    base_unit.calculate_generation_cost(index[0], index[1], "energy")
 
     # we apply the dispatch plan of 10 MW
     assert base_unit.outputs["energy"][start] == 10
@@ -116,6 +117,7 @@ def test_calculate_bids(base_unit, mock_market_config):
 
     # we somehow sold an additional 10 MW
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
+    base_unit.calculate_generation_cost(index[0], index[1], "energy")
 
     # the final output should be 10+10
     assert base_unit.outputs["energy"][start] == 20
@@ -151,6 +153,7 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     # mock calculate_marginal_cost
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
+    base_unit.calculate_generation_cost(index[0], index[1], "energy")
 
     assert base_unit.outputs["energy"][index[0]] == 10
     assert base_unit.outputs["energy_marginal_costs"][index[0]] == 100
@@ -160,6 +163,7 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     assert base_unit.outputs["energy_cashflow"][index[1]] == 110
 
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
+    base_unit.calculate_generation_cost(index[0], index[1], "energy")
 
     # should be correctly applied for the sum, even if different hours are applied
     assert base_unit.outputs["energy"][index[0]] == 20

--- a/tests/test_flexable_storage_strategies.py
+++ b/tests/test_flexable_storage_strategies.py
@@ -17,9 +17,6 @@ from assume.strategies import (
 )
 from assume.units import Storage
 
-start = datetime(2023, 7, 1)
-end = datetime(2023, 7, 2)
-
 
 @pytest.fixture
 def storage() -> Storage:
@@ -50,7 +47,8 @@ def storage() -> Storage:
 
 def test_flexable_eom_storage(mock_market_config, storage):
     index = pd.date_range("2023-07-01", periods=4, freq="H")
-    end = datetime(2023, 7, 1, 1, 0, 0)
+    start = datetime(2023, 7, 1)
+    end = datetime(2023, 7, 1, 1)
     strategy = flexableEOMStorage()
     mc = mock_market_config
     product_tuples = [(start, end, None)]
@@ -129,6 +127,7 @@ def test_flexable_eom_storage(mock_market_config, storage):
 
 def test_flexable_pos_crm_storage(mock_market_config, storage):
     index = pd.date_range("2023-07-01", periods=4, freq="H")
+    start = datetime(2023, 7, 1)
     end = datetime(2023, 7, 1, 4, 0, 0)
     strategy = flexablePosCRMStorage()
     mc = mock_market_config
@@ -169,6 +168,7 @@ def test_flexable_pos_crm_storage(mock_market_config, storage):
 
 def test_flexable_neg_crm_storage(mock_market_config, storage):
     index = pd.date_range("2023-07-01", periods=4, freq="H")
+    start = datetime(2023, 7, 1)
     end = datetime(2023, 7, 1, 4, 0, 0)
     strategy = flexableNegCRMStorage()
     mc = mock_market_config

--- a/tests/test_flexable_strategies.py
+++ b/tests/test_flexable_strategies.py
@@ -38,7 +38,7 @@ def power_plant() -> PowerPlant:
 
 
 def test_flexable_eom(mock_market_config, power_plant):
-    end = datetime(2023, 7, 1, 1, 0, 0)
+    end = datetime(2023, 7, 1, 1)
     strategy = flexableEOM()
     mc = mock_market_config
     product_tuples = [(start, end, None)]


### PR DESCRIPTION
* add tests for base_unit
* remove global start and end in flex storage test

We still had an issue in the marginal_cost calculation which I fixed in a wrong way in #245 
This is now tested and fixed.
While testing, I found that the product_type was not used in the get_output_before function too.