### PR TITLE
Fixes for AMIRIS Scenario loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,7 @@ examples/outputs
 
 examples/notebooks/inputs
 examples/notebooks/outputs
+**/scenario/*.csv
+*.pb
+*.jar
+fameSetup.yaml

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -99,15 +99,18 @@ class WriteOutput(Role):
         table_names = inspect(self.db).get_table_names()
         # Iterate through each table
         for table_name in table_names:
-            with self.db.begin() as db:
-                # Read table into Pandas DataFrame
-                query = text(
-                    f"delete from {table_name} where simulation = '{simulation_id}'"
-                )
-                rowcount = db.execute(query).rowcount
-                # has to be done manually with raw queries
-                db.commit()
-                logger.debug("deleted %s rows from %s", rowcount, table_name)
+            try:
+                with self.db.begin() as db:
+                    # Read table into Pandas DataFrame
+                    query = text(
+                        f"delete from \"{table_name}\" where simulation = '{simulation_id}'"
+                    )
+                    rowcount = db.execute(query).rowcount
+                    # has to be done manually with raw queries
+                    db.commit()
+                    logger.debug("deleted %s rows from %s", rowcount, table_name)
+            except Exception as e:
+                logger.error(f"could not clear old scenarios from table {table_name}")
 
     def del_similar_runs(self):
         """

--- a/assume/scenario/loader_amiris.py
+++ b/assume/scenario/loader_amiris.py
@@ -16,6 +16,8 @@ from assume.common.base import LearningConfig
 from assume.common.forecasts import CsvForecaster, Forecaster, NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.world import World
+import yaml
+from yamlinclude import YamlIncludeConstructor
 
 logger = logging.getLogger(__name__)
 
@@ -82,11 +84,48 @@ def get_matching_send_one_or_multi(agent_id: int, contract: dict):
     return contract["ReceiverId"][idx]
 
 
+def interpolate_blocksizes(
+    installed_power: float,
+    block_size_in_mw: float,
+    min_eff: float,
+    max_eff: float,
+    min_markup: float,
+    max_markup: float,
+):
+    """
+    This method interpolates efficiencies and markups for a given powerplant
+    The fist powerplant receives the highest markup and lowest efficiency.
+    The last one has lowest markup and highest efficiency.
+    """
+    full_blocks = int(installed_power // block_size_in_mw)
+    block_sizes = [block_size_in_mw for i in range(full_blocks)]
+    last_block = installed_power % block_size_in_mw
+    if last_block > 0:
+        block_sizes.append(last_block)
+
+    # interpolate
+    gradient_markup = (max_markup - min_markup) / (len(block_sizes) - 1)
+    gradient_eff = (max_eff - min_eff) / (len(block_sizes) - 1)
+    markups = []
+    efficiencies = []
+    for i, power in enumerate(block_sizes):
+        # markup is high to low
+        # efficiency is low to high
+        markups.append(max_markup - i * gradient_markup)
+        efficiencies.append(min_eff + i * gradient_eff)
+    return list(zip(block_sizes, markups, efficiencies))
+
+
 def add_agent_to_world(
-    agent: dict, world: World, prices: dict, contracts: list, base_path: str
+    agent: dict,
+    world: World,
+    prices: dict,
+    contracts: list,
+    base_path: str,
+    markups: dict = {},
 ):
     match agent["Type"]:
-        case "EnergyExchange":
+        case "EnergyExchange" | "DayAheadMarketSingleZone":
             market_config = MarketConfig(
                 name=f"Market_{agent['Id']}",
                 opening_hours=rr.rrule(
@@ -141,7 +180,44 @@ def add_agent_to_world(
                 )
 
         case "StorageTrader":
-            world.add_unit_operator(f"Operator_{agent['Id']}")
+            operator_id = f"Operator_{agent['Id']}"
+            world.add_unit_operator(operator_id)
+            device = agent["Attributes"]["Device"]
+            strategy = agent["Attributes"]["Strategy"]
+            if strategy["StrategistType"] != "SINGLE_AGENT_MIN_SYSTEM_COST":
+                logger.warning(f"unknown strategy for storage trader: {strategy}")
+
+            forecast_price = prices.get("co2", 20)
+            # TODO forecast should be calculated using calculate_EOM_price_forecast
+            forecast = NaiveForecast(
+                world.index,
+                availability=1,
+                co2_price=prices.get("co2", 2),
+                # price_forecast is used for price_EOM
+                price_forecast=forecast_price,
+            )
+
+            max_volume = device["EnergyToPowerRatio"] * device["InstalledPowerInMW"]
+            initial_soc = 100 * device["InitialEnergyLevelInMWH"] / max_volume
+            # TODO device["SelfDischargeRatePerHour"]
+            world.add_unit(
+                f"StorageTrader_{agent['Id']}",
+                "storage",
+                operator_id,
+                {
+                    "max_power_charge": device["InstalledPowerInMW"],
+                    "max_power_discharge": device["InstalledPowerInMW"],
+                    "efficiency_charge": device["ChargingEfficiency"],
+                    "efficiency_discharge": device["DischargingEfficiency"],
+                    "initial_soc": initial_soc,
+                    "max_volume": max_volume,
+                    "bidding_strategies": {"energy": "flexable_eom_storage"},
+                    "technology": "hydro",  # PSPP? Pump-Storage Power Plant
+                    "emission_factor": 0,
+                },
+                forecast,
+            )
+
         case "RenewableTrader":
             world.add_unit_operator(f"Operator_{agent['Id']}")
             # send, receive = get_send_receive_msgs_per_id(agent["Id"], contracts)
@@ -152,21 +228,26 @@ def add_agent_to_world(
         case "SystemOperatorTrader":
             world.add_unit_operator(f"Operator_{agent['Id']}")
 
-        case "ConventionalPlantOperator" | "ConventionalTrader":
-            # this can be left out for now - we only use the actual plant
-            # TODO the conventional Trader sets markup for the according plantbuilder - we should respect that too
+        case "ConventionalPlantOperator":
             world.add_unit_operator(f"Operator_{agent['Id']}")
-            pass
+        case "ConventionalTrader":
+            world.add_unit_operator(f"Operator_{agent['Id']}")
+            min_markup = agent["Attributes"]["minMarkup"]
+            max_markup = agent["Attributes"]["minMarkup"]
+            markups[agent["Id"]] = (min_markup, max_markup)
         case "PredefinedPlantBuilder":
             # this is the actual powerplant
             prototype = agent["Attributes"]["Prototype"]
             attr = agent["Attributes"]
             send, receive = get_send_receive_msgs_per_id(agent["Id"], contracts)
-            operator_id = get_matching_send_one_or_multi(agent["Id"], send[0])
-            operator_id = f"Operator_{operator_id}"
+            raw_operator_id = get_matching_send_one_or_multi(agent["Id"], send[0])
+            send_t, receive_t = get_send_receive_msgs_per_id(raw_operator_id, contracts)
+            raw_trader_id = get_matching_send_one_or_multi(raw_operator_id, send_t[2])
+            operator_id = f"Operator_{raw_operator_id}"
             fuel_price = prices.get(translate_fuel_type[prototype["FuelType"]], 0)
             fuel_price += prototype.get("OpexVarInEURperMWH", 0)
             # TODO CyclingCostInEURperMW
+            # costs due to plant start up
             forecast = NaiveForecast(
                 world.index,
                 availability=prototype["PlannedAvailability"],
@@ -174,22 +255,36 @@ def add_agent_to_world(
                 co2_price=prices.get("co2", 2),
             )
             # TODO UnplannedAvailabilityFactor is not respected
-            world.add_unit(
-                f"PredefinedPlantBuilder_{agent['Id']}",
-                "power_plant",
-                operator_id,
-                {
-                    # I think AMIRIS plans per block - so minimum is 1 block
-                    "min_power": attr["BlockSizeInMW"],
-                    "max_power": attr["InstalledPowerInMW"],
-                    "bidding_strategies": {"energy": "naive"},
-                    "technology": translate_fuel_type[prototype["FuelType"]],
-                    "fuel_type": translate_fuel_type[prototype["FuelType"]],
-                    "emission_factor": prototype["SpecificCo2EmissionsInTperMWH"],
-                    "efficiency": sum(attr["Efficiency"].values()) / 2,
-                },
-                forecast,
+
+            min_markup, max_markup = markups.get(raw_trader_id, (0,0))
+            # Amiris interpolates blocks linearly
+            interpolated_values = interpolate_blocksizes(
+                attr["InstalledPowerInMW"],
+                attr["BlockSizeInMW"],
+                attr["Efficiency"]["Minimal"],
+                attr["Efficiency"]["Maximal"],
+                min_markup,
+                max_markup,
             )
+            # add a unit for each block
+            for i, values in enumerate(interpolated_values):
+                power, markup, efficiency = values
+                world.add_unit(
+                    f"PredefinedPlantBuilder_{agent['Id']}_{i}",
+                    "power_plant",
+                    operator_id,
+                    {
+                        # AMIRIS does not have min_power
+                        "min_power": 0,
+                        "max_power": power,
+                        "bidding_strategies": {"energy": "naive"},
+                        "technology": translate_fuel_type[prototype["FuelType"]],
+                        "fuel_type": translate_fuel_type[prototype["FuelType"]],
+                        "emission_factor": prototype["SpecificCo2EmissionsInTperMWH"],
+                        "efficiency": efficiency,
+                    },
+                    forecast,
+                )
         case "VariableRenewableOperator" | "Biogas":
             send, receive = get_send_receive_msgs_per_id(agent["Id"], contracts)
             operator_id = get_matching_send_one_or_multi(agent["Id"], send[0])
@@ -241,10 +336,9 @@ async def load_amiris_async(
     study_case: str,
     base_path: str,
 ):
-    # In practice - this seems fixed in AMIRIS
-    DeliveryIntervalInSteps = 3600
-
     amiris_scenario = read_amiris_yaml(base_path)
+    # DeliveryIntervalInSteps = 3600
+    # In practice - this seems to be a fixed number in AMIRIS
 
     start = amiris_scenario["GeneralProperties"]["Simulation"]["StartTime"]
     start = pd.to_datetime(start, format="%Y-%m-%d_%H:%M:%S")
@@ -253,7 +347,7 @@ async def load_amiris_async(
     # AMIRIS caveat: start and end is always two minutes before actual start
     start += timedelta(minutes=2)
     sim_id = f"{scenario}_{study_case}"
-    save_interval = amiris_scenario["GeneralProperties"]["Output"]["Interval"]
+    save_interval = amiris_scenario["GeneralProperties"]["Output"]["Interval"]//2
     prices = {}
     index = pd.date_range(start=start, end=end, freq="1h", inclusive="left")
     await world.setup(
@@ -263,10 +357,38 @@ async def load_amiris_async(
         simulation_id=sim_id,
         index=index,
     )
-    for agent in amiris_scenario["Agents"]:
+    # helper dict to map trader markups/markdowns to powerplants
+    markups = {}
+    keyorder = [
+        "EnergyExchange",
+        "DayAheadMarketSingleZone",
+        "CarbonMarket",
+        "FuelsMarket",
+        "DemandTrader",
+        "StorageTrader",
+        "RenewableTrader",
+        "NoSupportTrader",
+        "ConventionalTrader",
+        "SystemOperatorTrader",
+        "ConventionalPlantOperator",
+        "PredefinedPlantBuilder",
+        "VariableRenewableOperator",
+        "Biogas",
+        "MeritOrderForecaster",
+        "SupportPolicy",
+    ]
+    agents_sorted = sorted(amiris_scenario["Agents"], key= lambda agent: keyorder.index((agent["Type"])))
+    for agent in agents_sorted:
         add_agent_to_world(
-            agent, world, prices, amiris_scenario["Contracts"], base_path
+            agent,
+            world,
+            prices,
+            amiris_scenario["Contracts"],
+            base_path,
+            markups,
         )
+    # calculate market price before simulation
+    world
 
 
 if __name__ == "__main__":
@@ -276,7 +398,11 @@ if __name__ == "__main__":
     scenario = "Germany2019"  # Germany2019 or Austria2019 or Simple
     base_path = f"../amiris-examples/{scenario}/"
     amiris_scenario = read_amiris_yaml(base_path)
-    sends, receives = get_send_receive_msgs_per_id(1000, amiris_scenario["Contracts"])
+    amiris_scenario["markups"] = {}
+    sends, receives = get_send_receive_msgs_per_id(
+        1000,
+        amiris_scenario["Contracts"],
+    )
 
     demand_agent = amiris_scenario["Agents"][3]
     demand_series = read_csv(
@@ -293,4 +419,5 @@ if __name__ == "__main__":
             base_path,
         )
     )
+    print(f"did load {scenario} - now simulating")
     world.run()

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -118,7 +118,7 @@ class MarkupStrategy(BaseStrategy):
                     "start_time": start,
                     "end_time": end,
                     "only_hours": product[2],
-                    "price": price*self.rel_markup+self.abs_markup,
+                    "price": price * self.rel_markup + self.abs_markup,
                     "volume": volume,
                 }
             )

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -64,3 +64,62 @@ class OTCStrategy(BaseStrategy):
                 }
             )
         return bids
+
+
+class MarkupStrategy(BaseStrategy):
+    """
+    Strategy for Markup (over the counter trading) markets
+    """
+
+    def __init__(self, *args, abs_markup=0, rel_markup=0, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.abs_markup = abs_markup
+        self.rel_markup = rel_markup
+
+    def calculate_bids(
+        self,
+        unit: SupportsMinMax,
+        market_config: MarketConfig,
+        product_tuples: list[Product],
+        **kwargs,
+    ) -> Orderbook:
+        """
+        Takes information from a unit that the unit operator manages and
+        defines how it is dispatched to the market
+
+        Returns a list of bids that the unit operator will submit to the market
+        :param unit: unit to dispatch
+        :type unit: SupportsMinMax
+        :param market_config: market configuration
+        :type market_config: MarketConfig
+        :param product_tuples: list of products to dispatch
+        :type product_tuples: list[Product]
+        :param kwargs: additional arguments
+        :type kwargs: dict
+        :return: orderbook
+        :rtype: Orderbook
+        """
+        bids = []
+        for product in product_tuples:
+            start = product[0]
+            end = product[1]
+
+            min_power, max_power = unit.calculate_min_max_power(
+                start, end
+            )  # max_power describes the maximum power output of the unit
+            current_power = unit.outputs["energy"].at[
+                start
+            ]  # current power output describes the power output at the start of the product
+            volume = max_power[start]
+            price = unit.calculate_marginal_cost(start, current_power + volume)
+
+            bids.append(
+                {
+                    "start_time": start,
+                    "end_time": end,
+                    "only_hours": product[2],
+                    "price": price*self.rel_markup+self.abs_markup,
+                    "volume": volume,
+                }
+            )
+        return bids


### PR DESCRIPTION
* add calculation of interpolated efficiencies and markups for powerplants - this gives much more realistic results, due to a smooth price curve of the powerplants
* connect trader with plant operator ids correctly
* pick up the markup correctly and use it  as `fixed_cost` in the powerplant
* fix availability values above 1
* load amiris scenario in correct agent order