### PR TITLE
Fixed RL evaluations

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -770,7 +770,8 @@ class LearningConfig(TypedDict):
         noise_sigma (float): The standard deviation of the noise.
         noise_scale (int): Controls the initial strength of the noise.
         noise_dt (int): Determines how quickly the noise weakens over time.
-        trained_policies_path (str): The path to the learned model to load.
+        trained_policies_save_path (str): The path to the learned model to save.
+        trained_policies_load_path (str): The path to the learned model to load.
     """
 
     observation_dimension: int
@@ -790,4 +791,4 @@ class LearningConfig(TypedDict):
     noise_sigma: float
     noise_scale: int
     noise_dt: int
-    trained_policies_path: str
+    trained_policies_save_path: str

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -770,7 +770,7 @@ class LearningConfig(TypedDict):
         noise_sigma (float): The standard deviation of the noise.
         noise_scale (int): Controls the initial strength of the noise.
         noise_dt (int): Determines how quickly the noise weakens over time.
-        trained_actors_path (str): The path to the learned model to load.
+        trained_policies_path (str): The path to the learned model to load.
     """
 
     observation_dimension: int
@@ -790,4 +790,4 @@ class LearningConfig(TypedDict):
     noise_sigma: float
     noise_scale: int
     noise_dt: int
-    trained_actors_path: str
+    trained_policies_path: str

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -439,8 +439,6 @@ class UnitsOperator(Role):
                 if isinstance(order["volume"], dict):
                     if all(volume == 0 for volume in order["volume"].values()):
                         continue
-                elif order["volume"] == 0:
-                    continue
                 order["agent_id"] = (self.context.addr, self.context.aid)
                 if market.volume_tick:
                     order["volume"] = round(order["volume"] / market.volume_tick)

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -185,9 +185,8 @@ class Learning(Role):
 
         self.rl_algorithm.initialize_policy(actors_and_critics)
 
-        if self.continue_learning == True and actors_and_critics == None:
-            load_directory = self.trained_policies_path
-            self.load_policies(load_directory)
+        if self.continue_learning is True and actors_and_critics is None:
+            self.load_policies(self.trained_policies_path)
 
     def load_policies(self, load_directory) -> None:
         """
@@ -222,7 +221,6 @@ class Learning(Role):
         if self.episodes_done > self.episodes_collecting_initial_experience:
             self.rl_algorithm.update_policy()
 
-    # TODO: add evaluation function
     def compare_and_save_policies(self, metrics: dict) -> None:
         """
         Compare evaluation metrics and save policies based on the best achieved performance according to the metrics calculated.

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -221,7 +221,7 @@ class Learning(Role):
         if self.episodes_done > self.episodes_collecting_initial_experience:
             self.rl_algorithm.update_policy()
 
-    def compare_and_save_policies(self, metrics: dict) -> None:
+    def compare_and_save_policies(self, metrics: dict, eval_save_path: str) -> None:
         """
         Compare evaluation metrics and save policies based on the best achieved performance according to the metrics calculated.
 
@@ -251,11 +251,11 @@ class Learning(Role):
                 self.max_eval[metric] = self.rl_eval[metric][-1]
                 if metric == list(metrics.keys())[0]:
                     first_has_new_max = True
-                self.rl_algorithm.save_params(directory=f"{self.trained_policies_path}/{metric}")
+                self.rl_algorithm.save_params(directory=f"{eval_save_path}/{metric}")
 
         # use last metric as default
         if first_has_new_max:
-            self.rl_algorithm.save_params(directory=self.trained_policies_path)
+            self.rl_algorithm.save_params(directory=eval_save_path)
             logger.info(
                 f"Policies saved, episode: {self.eval_episodes_done + 1}, {metric=}, value={value:.2f}"
             )

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
-import os
+from collections import defaultdict
 from datetime import datetime
 
 import torch as th
@@ -94,7 +94,6 @@ class Learning(Role):
         self.create_learning_algorithm(self.rl_algorithm)
 
         # store evaluation values
-        from collections import defaultdict
         self.max_eval = defaultdict(lambda: -1e9)
         self.rl_eval = defaultdict(list)
 

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -737,11 +737,8 @@ def run_learning(
             avg_reward = np.mean(total_rewards)
             # check reward improvement in validation run
             world.learning_config["trained_actors_path"] = old_path
-            if avg_reward > best_reward:
-                # update best reward
-                best_reward = avg_reward
-                world.learning_role.rl_algorithm.save_params(directory=old_path)
 
+            world.learning_role.compare_and_save_policies(avg_reward)
             eval_episode += 1
 
         world.reset()

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -712,9 +712,9 @@ def run_learning(
             and episode > world.learning_role.episodes_collecting_initial_experience
         ):
             old_path = world.learning_config["trained_policies_path"]
-            new_path = f"{old_path}_eval"
+            eval_path = f"{old_path}_eval"
 
-            # save validation params in validation path
+            # save current params in training path
             world.learning_role.rl_algorithm.save_params(directory=old_path)
             world.reset()
 
@@ -727,7 +727,7 @@ def run_learning(
                 perform_learning=False,
                 perform_evaluation=True,
                 eval_episode=eval_episode,
-                trained_policies_path=new_path,
+                trained_policies_path=old_path,
             )
 
             world.run()
@@ -735,9 +735,11 @@ def run_learning(
             total_rewards = world.output_role.get_sum_reward()
             avg_reward = np.mean(total_rewards)
             # check reward improvement in validation run
-            world.learning_config["trained_policies_path"] = old_path
+            # and store best run in eval folder
+            world.learning_role.compare_and_save_policies({"avg_reward": avg_reward}, eval_path)
 
-            world.learning_role.compare_and_save_policies({"avg_reward": avg_reward})
+            # restore previous policy path
+            world.learning_config["trained_policies_path"] = old_path
             eval_episode += 1
 
         world.reset()

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -660,7 +660,6 @@ def run_learning(
     # remove csv path so that nothing is written while learning
     temp_csv_path = world.export_csv_path
     world.export_csv_path = ""
-    best_reward = -1e10
 
     buffer = ReplayBuffer(
         buffer_size=int(world.learning_config.get("replay_buffer_size", 5e5)),
@@ -716,7 +715,7 @@ def run_learning(
             new_path = f"{old_path}_eval"
 
             # save validation params in validation path
-            world.learning_role.rl_algorithm.save_params(directory=new_path)
+            world.learning_role.rl_algorithm.save_params(directory=old_path)
             world.reset()
 
             # load validation run

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -736,7 +736,9 @@ def run_learning(
             avg_reward = np.mean(total_rewards)
             # check reward improvement in validation run
             # and store best run in eval folder
-            world.learning_role.compare_and_save_policies({"avg_reward": avg_reward}, eval_path)
+            world.learning_role.compare_and_save_policies(
+                {"avg_reward": avg_reward}, eval_path
+            )
 
             # restore previous policy path
             world.learning_config["trained_policies_path"] = old_path

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -240,7 +240,7 @@ async def load_scenario_folder_async(
     perform_evaluation: bool = False,
     episode: int = 0,
     eval_episode: int = 0,
-    trained_actors_path: str = "",
+    trained_policies_path: str = "",
 ) -> None:
     """
     Load a scenario from a given path.
@@ -256,7 +256,7 @@ async def load_scenario_folder_async(
     perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
     episode (int, optional): The episode number for learning. Defaults to 0.
     eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
-    trained_actors_path (str, optional): The path to the trained actors. Defaults to an empty string.
+    trained_policies_path (str, optional): The path to the trained actors. Defaults to an empty string.
 
     Raises:
     ValueError: If the specified scenario or study case is not found in the provided inputs.
@@ -321,12 +321,12 @@ async def load_scenario_folder_async(
     )
     learning_config["evaluation_mode"] = perform_evaluation
 
-    if not learning_config.get("trained_actors_path"):
-        if trained_actors_path:
-            learning_config["trained_actors_path"] = trained_actors_path
+    if not learning_config.get("trained_policies_path"):
+        if trained_policies_path:
+            learning_config["trained_policies_path"] = trained_policies_path
         else:
             learning_config[
-                "trained_actors_path"
+                "trained_policies_path"
             ] = f"{inputs_path}/learned_strategies/{sim_id}"
 
     if learning_config.get("learning_mode", False):
@@ -489,7 +489,7 @@ def load_scenario_folder(
     perform_evaluation: bool = False,
     episode: int = 1,
     eval_episode: int = 1,
-    trained_actors_path="",
+    trained_policies_path="",
 ):
     """
     Load a scenario from a given path.
@@ -505,7 +505,7 @@ def load_scenario_folder(
     perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
     episode (int, optional): The episode number for learning. Defaults to 0.
     eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
-    trained_actors_path (str, optional): The path to the trained actors. Defaults to an empty string.
+    trained_policies_path (str, optional): The path to the trained actors. Defaults to an empty string.
 
     Raises:
     ValueError: If the specified scenario or study case is not found in the provided inputs.
@@ -520,7 +520,7 @@ def load_scenario_folder(
             perform_evaluation=False,
             episode=1,
             eval_episode=1,
-            trained_actors_path="",
+            trained_policies_path="",
         )
 
     Notes:
@@ -541,7 +541,7 @@ def load_scenario_folder(
             perform_evaluation=perform_evaluation,
             episode=episode,
             eval_episode=eval_episode,
-            trained_actors_path=trained_actors_path,
+            trained_policies_path=trained_policies_path,
         )
     )
 
@@ -712,7 +712,7 @@ def run_learning(
             episode % validation_interval == 0
             and episode > world.learning_role.episodes_collecting_initial_experience
         ):
-            old_path = world.learning_config["trained_actors_path"]
+            old_path = world.learning_config["trained_policies_path"]
             new_path = f"{old_path}_eval"
 
             # save validation params in validation path
@@ -728,7 +728,7 @@ def run_learning(
                 perform_learning=False,
                 perform_evaluation=True,
                 eval_episode=eval_episode,
-                trained_actors_path=new_path,
+                trained_policies_path=new_path,
             )
 
             world.run()
@@ -736,9 +736,9 @@ def run_learning(
             total_rewards = world.output_role.get_sum_reward()
             avg_reward = np.mean(total_rewards)
             # check reward improvement in validation run
-            world.learning_config["trained_actors_path"] = old_path
+            world.learning_config["trained_policies_path"] = old_path
 
-            world.learning_role.compare_and_save_policies(avg_reward)
+            world.learning_role.compare_and_save_policies({"avg_reward": avg_reward})
             eval_episode += 1
 
         world.reset()

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -4,6 +4,7 @@
 
 import logging
 from datetime import datetime, timedelta
+from pathlib import Path
 from typing import Optional, Tuple
 
 import dateutil.rrule as rr
@@ -13,6 +14,7 @@ import yaml
 from tqdm import tqdm
 
 from assume.common.base import LearningConfig
+from assume.common.exceptions import AssumeException
 from assume.common.forecasts import CsvForecaster, Forecaster
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.world import World
@@ -42,16 +44,16 @@ def load_file(
     If the index is specified, the dataframe is resampled to the index, if possible. If not, None is returned.
 
     Args:
-    path (str): The path to the csv file.
-    config (dict): The config file containing file mappings.
-    file_name (str): The name of the csv file.
-    index (pd.DatetimeIndex, optional): The index of the dataframe. Defaults to None.
+        path (str): The path to the csv file.
+        config (dict): The config file containing file mappings.
+        file_name (str): The name of the csv file.
+        index (pd.DatetimeIndex, optional): The index of the dataframe. Defaults to None.
 
     Returns:
-    pd.DataFrame: The dataframe containing the loaded data.
+        pd.DataFrame: The dataframe containing the loaded data.
 
     Raises:
-    FileNotFoundError: If the specified file is not found, returns None.
+        FileNotFoundError: If the specified file is not found, returns None.
     """
     df = None
 
@@ -117,10 +119,10 @@ def convert_to_rrule_freq(string: str) -> Tuple[int, int]:
     Convert a string to a rrule frequency and interval.
 
     Args:
-    string (str): The string to be converted. Should be in the format of "1h" or "1d" or "1w".
+        string (str): The string to be converted. Should be in the format of "1h" or "1d" or "1w".
 
     Returns:
-    Tuple[int, int]: The rrule frequency and interval.
+        Tuple[int, int]: The rrule frequency and interval.
     """
     freq = freq_map[string[-1]]
     interval = int(string[:-1])
@@ -240,7 +242,6 @@ async def load_scenario_folder_async(
     perform_evaluation: bool = False,
     episode: int = 0,
     eval_episode: int = 0,
-    trained_policies_path: str = "",
 ) -> None:
     """
     Load a scenario from a given path.
@@ -248,18 +249,17 @@ async def load_scenario_folder_async(
     This function loads a scenario within a specified study case from a given path, setting up the world environment for simulation and learning.
 
     Args:
-    world (World): An instance of the World class representing the simulation environment.
-    inputs_path (str): The path to the folder containing input files necessary for the scenario.
-    scenario (str): The name of the scenario to be loaded.
-    study_case (str): The specific study case within the scenario to be loaded.
-    perform_learning (bool, optional): A flag indicating whether learning should be performed. Defaults to True.
-    perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
-    episode (int, optional): The episode number for learning. Defaults to 0.
-    eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
-    trained_policies_path (str, optional): The path to the trained actors. Defaults to an empty string.
+        world (World): An instance of the World class representing the simulation environment.
+        inputs_path (str): The path to the folder containing input files necessary for the scenario.
+        scenario (str): The name of the scenario to be loaded.
+        study_case (str): The specific study case within the scenario to be loaded.
+        perform_learning (bool, optional): A flag indicating whether learning should be performed. Defaults to True.
+        perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
+        episode (int, optional): The episode number for learning. Defaults to 0.
+        eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
 
     Raises:
-    ValueError: If the specified scenario or study case is not found in the provided inputs.
+        ValueError: If the specified scenario or study case is not found in the provided inputs.
 
     """
 
@@ -321,13 +321,19 @@ async def load_scenario_folder_async(
     )
     learning_config["evaluation_mode"] = perform_evaluation
 
-    if not learning_config.get("trained_policies_path"):
-        if trained_policies_path:
-            learning_config["trained_policies_path"] = trained_policies_path
-        else:
-            learning_config[
-                "trained_policies_path"
-            ] = f"{inputs_path}/learned_strategies/{sim_id}"
+    if learning_config.get("trained_policies_save_path"):
+        learning_config[
+            "trained_policies_save_path"
+        ] = f"{inputs_path}/{learning_config['trained_policies_save_path']}"
+    else:
+        learning_config[
+            "trained_policies_save_path"
+        ] = f"{inputs_path}/learned_strategies/{sim_id}"
+
+    if learning_config.get("trained_policies_load_path"):
+        learning_config[
+            "trained_policies_load_path"
+        ] = f"{inputs_path}/{learning_config['trained_policies_load_path']}"
 
     if learning_config.get("learning_mode", False):
         sim_id = f"{sim_id}_{episode}"
@@ -489,7 +495,6 @@ def load_scenario_folder(
     perform_evaluation: bool = False,
     episode: int = 1,
     eval_episode: int = 1,
-    trained_policies_path="",
 ):
     """
     Load a scenario from a given path.
@@ -497,18 +502,17 @@ def load_scenario_folder(
     This function loads a scenario within a specified study case from a given path, setting up the world environment for simulation and learning.
 
     Args:
-    world (World): An instance of the World class representing the simulation environment.
-    inputs_path (str): The path to the folder containing input files necessary for the scenario.
-    scenario (str): The name of the scenario to be loaded.
-    study_case (str): The specific study case within the scenario to be loaded.
-    perform_learning (bool, optional): A flag indicating whether learning should be performed. Defaults to True.
-    perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
-    episode (int, optional): The episode number for learning. Defaults to 0.
-    eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
-    trained_policies_path (str, optional): The path to the trained actors. Defaults to an empty string.
+        world (World): An instance of the World class representing the simulation environment.
+        inputs_path (str): The path to the folder containing input files necessary for the scenario.
+        scenario (str): The name of the scenario to be loaded.
+        study_case (str): The specific study case within the scenario to be loaded.
+        perform_learning (bool, optional): A flag indicating whether learning should be performed. Defaults to True.
+        perform_evaluation (bool, optional): A flag indicating whether evaluation should be performed. Defaults to False.
+        episode (int, optional): The episode number for learning. Defaults to 0.
+        eval_episode (int, optional): The episode number for evaluation. Defaults to 0.
 
     Raises:
-    ValueError: If the specified scenario or study case is not found in the provided inputs.
+        ValueError: If the specified scenario or study case is not found in the provided inputs.
 
     Example:
         >>> load_scenario_folder(
@@ -520,15 +524,15 @@ def load_scenario_folder(
             perform_evaluation=False,
             episode=1,
             eval_episode=1,
-            trained_policies_path="",
+            trained_policies_save_path="",
         )
 
     Notes:
-    - The function sets up the world environment based on the provided inputs and configuration files.
-    - If `perform_learning` is set to True, the function initializes the learning mode with the specified episode number.
-    - If `perform_evaluation` is set to True, the function performs evaluation using the specified evaluation episode number.
-    - The function utilizes the specified inputs to configure the simulation environment, including market parameters, unit operators, and forecasting data.
-    - After calling this function, the world environment is prepared for further simulation and analysis.
+        - The function sets up the world environment based on the provided inputs and configuration files.
+        - If `perform_learning` is set to True and learning_mode is set, the function initializes the learning mode with the specified episode number.
+        - If `perform_evaluation` is set to True, the function performs evaluation using the specified evaluation episode number.
+        - The function utilizes the specified inputs to configure the simulation environment, including market parameters, unit operators, and forecasting data.
+        - After calling this function, the world environment is prepared for further simulation and analysis.
 
     """
     world.loop.run_until_complete(
@@ -541,7 +545,6 @@ def load_scenario_folder(
             perform_evaluation=perform_evaluation,
             episode=episode,
             eval_episode=eval_episode,
-            trained_policies_path=trained_policies_path,
         )
     )
 
@@ -559,11 +562,11 @@ async def async_load_custom_units(
     This function loads custom units of a specified type from a given path within a scenario, adding them to the world environment for simulation.
 
     Args:
-    world (World): An instance of the World class representing the simulation environment.
-    inputs_path (str): The path to the folder containing input files necessary for the custom units.
-    scenario (str): The name of the scenario from which the custom units are to be loaded.
-    file_name (str): The name of the file containing the custom units.
-    unit_type (str): The type of the custom units to be loaded.
+        world (World): An instance of the World class representing the simulation environment.
+        inputs_path (str): The path to the folder containing input files necessary for the custom units.
+        scenario (str): The name of the scenario from which the custom units are to be loaded.
+        file_name (str): The name of the file containing the custom units.
+        unit_type (str): The type of the custom units to be loaded.
     """
     path = f"{inputs_path}/{scenario}"
 
@@ -602,11 +605,11 @@ def load_custom_units(
     This function loads custom units of a specified type from a given path within a scenario, adding them to the world environment for simulation.
 
     Args:
-    world (World): An instance of the World class representing the simulation environment.
-    inputs_path (str): The path to the folder containing input files necessary for the custom units.
-    scenario (str): The name of the scenario from which the custom units are to be loaded.
-    file_name (str): The name of the file containing the custom units.
-    unit_type (str): The type of the custom units to be loaded.
+        world (World): An instance of the World class representing the simulation environment.
+        inputs_path (str): The path to the folder containing input files necessary for the custom units.
+        scenario (str): The name of the scenario from which the custom units are to be loaded.
+        file_name (str): The name of the file containing the custom units.
+        unit_type (str): The type of the custom units to be loaded.
 
     Example:
         >>> load_custom_units(
@@ -618,10 +621,10 @@ def load_custom_units(
         )
 
     Notes:
-    - The function loads custom units from the specified file within the given scenario and adds them to the world environment for simulation.
-    - If the specified custom units file is not found, a warning is logged.
-    - Each unique unit operator in the custom units is added to the world's unit operators.
-    - The custom units are added to the world environment based on their type for use in simulations.
+        - The function loads custom units from the specified file within the given scenario and adds them to the world environment for simulation.
+        - If the specified custom units file is not found, a warning is logged.
+        - Each unique unit operator in the custom units is added to the world's unit operators.
+        - The custom units are added to the world environment based on their type for use in simulations.
     """
     world.loop.run_until_complete(
         async_load_custom_units(
@@ -678,6 +681,16 @@ def run_learning(
     )
 
     eval_episode = 1
+    save_path = world.learning_config["trained_policies_save_path"]
+
+    if Path(save_path).is_dir():
+        # we are in learning mode and about to train new policies, which might overwrite existing ones
+        accept = input(
+            f"{save_path=} exists - should we overwrite current learnings? (y/N)"
+        )
+        if not accept.lower().startswith("y"):
+            # stop here - do not start learning or save anything
+            raise AssumeException("don't overwrite existing strategies")
 
     for episode in tqdm(
         range(1, world.learning_role.training_episodes + 1),
@@ -711,11 +724,8 @@ def run_learning(
             episode % validation_interval == 0
             and episode > world.learning_role.episodes_collecting_initial_experience
         ):
-            old_path = world.learning_config["trained_policies_path"]
-            eval_path = f"{old_path}_eval"
-
             # save current params in training path
-            world.learning_role.rl_algorithm.save_params(directory=old_path)
+            world.learning_role.rl_algorithm.save_params(directory=save_path)
             world.reset()
 
             # load validation run
@@ -727,7 +737,6 @@ def run_learning(
                 perform_learning=False,
                 perform_evaluation=True,
                 eval_episode=eval_episode,
-                trained_policies_path=old_path,
             )
 
             world.run()
@@ -736,14 +745,9 @@ def run_learning(
             avg_reward = np.mean(total_rewards)
             # check reward improvement in validation run
             # and store best run in eval folder
-            world.learning_role.compare_and_save_policies(
-                {"avg_reward": avg_reward}, eval_path
-            )
+            world.learning_role.compare_and_save_policies({"avg_reward": avg_reward})
 
-            # restore previous policy path
-            world.learning_config["trained_policies_path"] = old_path
             eval_episode += 1
-
         world.reset()
 
         # in load_scenario_folder_async, we initiate new container and kill old if present

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -84,8 +84,8 @@ class RLAdvancedOrderStrategy(LearningStrategy):
                 dt=kwargs.get("noise_dt", 1.0),
             )
 
-        elif Path(load_path=kwargs["trained_actors_path"]).is_dir():
-            self.load_actor_params(load_path=kwargs["trained_actors_path"])
+        elif Path(load_path=kwargs["trained_policies_path"]).is_dir():
+            self.load_actor_params(load_path=kwargs["trained_policies_path"])
 
     def calculate_bids(
         self,

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -84,8 +84,8 @@ class RLAdvancedOrderStrategy(LearningStrategy):
                 dt=kwargs.get("noise_dt", 1.0),
             )
 
-        elif Path(kwargs["trained_policies_path"]).is_dir():
-            self.load_actor_params(load_path=kwargs["trained_policies_path"])
+        elif Path(kwargs["trained_policies_save_path"]).is_dir():
+            self.load_actor_params(load_path=kwargs["trained_policies_save_path"])
 
     def calculate_bids(
         self,

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -84,7 +84,7 @@ class RLAdvancedOrderStrategy(LearningStrategy):
                 dt=kwargs.get("noise_dt", 1.0),
             )
 
-        elif Path(load_path=kwargs["trained_policies_path"]).is_dir():
+        elif Path(kwargs["trained_policies_path"]).is_dir():
             self.load_actor_params(load_path=kwargs["trained_policies_path"])
 
     def calculate_bids(

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -12,6 +12,9 @@ import torch as th
 from assume.common.base import LearningStrategy, SupportsMinMax
 from assume.common.market_objects import MarketConfig, Orderbook, Product
 from assume.reinforcement_learning.learning_utils import Actor, NormalActionNoise
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class RLStrategy(LearningStrategy):
@@ -77,8 +80,10 @@ class RLStrategy(LearningStrategy):
                 dt=kwargs.get("noise_dt", 1.0),
             )
 
-        elif Path(kwargs["trained_actors_path"]).is_dir():
-            self.load_actor_params(load_path=kwargs["trained_actors_path"])
+        elif Path(kwargs["trained_policies_path"]).is_dir():
+            self.load_actor_params(load_path=kwargs["trained_policies_path"])
+        else:
+            logger.error("did not have learning mode and folder did not exist")
 
     def calculate_bids(
         self,

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 
@@ -12,7 +13,6 @@ import torch as th
 from assume.common.base import LearningStrategy, SupportsMinMax
 from assume.common.market_objects import MarketConfig, Orderbook, Product
 from assume.reinforcement_learning.learning_utils import Actor, NormalActionNoise
-import logging
 
 logger = logging.getLogger(__name__)
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -80,8 +80,8 @@ class RLStrategy(LearningStrategy):
                 dt=kwargs.get("noise_dt", 1.0),
             )
 
-        elif Path(kwargs["trained_policies_path"]).is_dir():
-            self.load_actor_params(load_path=kwargs["trained_policies_path"])
+        elif Path(kwargs["trained_policies_save_path"]).is_dir():
+            self.load_actor_params(load_path=kwargs["trained_policies_save_path"])
         else:
             logger.error("did not have learning mode and folder did not exist")
 

--- a/assume/world.py
+++ b/assume/world.py
@@ -242,7 +242,9 @@ class World:
             # separate process does not support buffer and learning
             self.learning_agent_addr = (self.addr, "learning_agent")
             rl_agent = RoleAgent(
-                self.container, suggested_aid=self.learning_agent_addr[1]
+                self.container,
+                suggested_aid=self.learning_agent_addr[1],
+                suspendable_tasks=False,
             )
             rl_agent.add_role(self.learning_role)
 
@@ -281,14 +283,20 @@ class World:
             self.addresses.append(self.addr)
 
             def creator(container):
-                agent = RoleAgent(container, suggested_aid=self.output_agent_addr[1])
+                agent = RoleAgent(
+                    container,
+                    suggested_aid=self.output_agent_addr[1],
+                    suspendable_tasks=False,
+                )
                 agent.add_role(self.output_role)
                 clock_agent = DistributedClockAgent(container)
 
             await self.container.as_agent_process(agent_creator=creator)
         else:
             output_agent = RoleAgent(
-                self.container, suggested_aid=self.output_agent_addr[1]
+                self.container,
+                suggested_aid=self.output_agent_addr[1],
+                suspendable_tasks=False,
             )
             output_agent.add_role(self.output_role)
 
@@ -311,7 +319,9 @@ class World:
 
         units_operator = UnitsOperator(available_markets=list(self.markets.values()))
         # creating a new role agent and apply the role of a unitsoperator
-        unit_operator_agent = RoleAgent(self.container, suggested_aid=f"{id}")
+        unit_operator_agent = RoleAgent(
+            self.container, suggested_aid=f"{id}", suspendable_tasks=False
+        )
         unit_operator_agent.add_role(units_operator)
 
         # add the current unitsoperator to the list of operators currently existing
@@ -433,8 +443,7 @@ class World:
         if self.market_operators.get(id):
             raise ValueError(f"MarketOperator {id} already exists")
         market_operator_agent = RoleAgent(
-            self.container,
-            suggested_aid=id,
+            self.container, suggested_aid=id, suspendable_tasks=False
         )
         market_operator_agent.markets = []
 

--- a/cli.py
+++ b/cli.py
@@ -14,6 +14,8 @@ from pathlib import Path
 import argcomplete
 import yaml
 from sqlalchemy import make_url
+import warnings
+from assume.common.exceptions import AssumeException
 
 os.makedirs("./examples/outputs", exist_ok=True)
 os.makedirs("./examples/local_db", exist_ok=True)
@@ -114,6 +116,10 @@ def cli(args=None):
     else:
         db_uri = f"sqlite:///./examples/local_db/{name}.db"
 
+    # add these two weird hacks for now
+    warnings.filterwarnings("ignore", "coroutine.*?was never awaited.*")
+    logging.getLogger("asyncio").setLevel("FATAL")
+
     try:
         # import package after argcomplete.autocomplete
         # to improve autocompletion speed
@@ -144,6 +150,8 @@ def cli(args=None):
 
     except KeyboardInterrupt:
         pass
+    except Exception as e:
+        print(f"Simulation aborted: {e}")
 
 
 if __name__ == "__main__":

--- a/docs/source/learning_algorithm.rst
+++ b/docs/source/learning_algorithm.rst
@@ -31,7 +31,8 @@ The following table shows the options that can be adjusted and gives a short exp
   observation_dimension                   The dimension of the observations given to the actor in the bidding strategy.
   action_dimension                        The dimension of the actors made by the actor, which equals the output neurons of the actor neural net.
   continue_learning                       Whether to use pre-learned strategies and then continue learning.
-  trained_policies_path                   If pre-learned strategies should be used, where are they stored?
+  trained_policies_save_path              Where to store the newly trained rl strategies - only needed when 
+  trained_policies_load_path              If pre-learned strategies should be used, where are they stored? - only needed when continue_learning
   max_bid_price                           The maximum bid price which limits the action of the actor to this price.
   learning_mode                           Should we use learning mode at all? If not, the learning bidding strategy is overwritten with a default strategy.
   algorithm                               Specifies which algorithm to use. Currently, only MATD3 is implemented.

--- a/docs/source/learning_algorithm.rst
+++ b/docs/source/learning_algorithm.rst
@@ -31,7 +31,7 @@ The following table shows the options that can be adjusted and gives a short exp
   observation_dimension                   The dimension of the observations given to the actor in the bidding strategy.
   action_dimension                        The dimension of the actors made by the actor, which equals the output neurons of the actor neural net.
   continue_learning                       Whether to use pre-learned strategies and then continue learning.
-  trained_actors_path                         If pre-learned strategies should be used, where are they stored?
+  trained_policies_path                   If pre-learned strategies should be used, where are they stored?
   max_bid_price                           The maximum bid price which limits the action of the actor to this price.
   learning_mode                           Should we use learning mode at all? If not, the learning bidding strategy is overwritten with a default strategy.
   algorithm                               Specifies which algorithm to use. Currently, only MATD3 is implemented.

--- a/examples/inputs/example_02a/config.yaml
+++ b/examples/inputs/example_02a/config.yaml
@@ -13,7 +13,7 @@ base:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    trained_actors_path: null
+    trained_policies_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001
@@ -57,7 +57,7 @@ tiny:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    load_model_path: None
+    trained_policies_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/inputs/example_02a/config.yaml
+++ b/examples/inputs/example_02a/config.yaml
@@ -13,7 +13,7 @@ base:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    trained_policies_path: null
+    trained_policies_save_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001
@@ -57,7 +57,8 @@ tiny:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    trained_policies_path: null
+    trained_policies_save_path: null
+    trained_policies_load_path: "./learned_strategies/example_02a_tiny/avg_reward"
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/inputs/example_02b/config.yaml
+++ b/examples/inputs/example_02b/config.yaml
@@ -13,7 +13,7 @@ base:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    trained_actors_path: null
+    trained_policies_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/inputs/example_02b/config.yaml
+++ b/examples/inputs/example_02b/config.yaml
@@ -13,7 +13,7 @@ base:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: False
-    trained_policies_path: null
+    trained_policies_save_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/inputs/example_02c/config.yaml
+++ b/examples/inputs/example_02c/config.yaml
@@ -13,7 +13,7 @@ dam:
     observation_dimension: 97
     action_dimension: 2
     continue_learning: False
-    trained_policies_path: null
+    trained_policies_save_path: null
     max_bid_price: 200
     algorithm: matd3
     learning_rate: 0.0001
@@ -63,7 +63,7 @@ tiny:
     observation_dimension: 50
     action_dimension: 2
     continue_learning: True
-    trained_policies_path: null
+    trained_policies_save_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/inputs/example_02c/config.yaml
+++ b/examples/inputs/example_02c/config.yaml
@@ -13,7 +13,7 @@ dam:
     observation_dimension: 97
     action_dimension: 2
     continue_learning: False
-    load_model_path: None
+    trained_policies_path: null
     max_bid_price: 200
     algorithm: matd3
     learning_rate: 0.0001
@@ -62,8 +62,8 @@ tiny:
   learning_config:
     observation_dimension: 50
     action_dimension: 2
-    continue_learning: False
-    load_model_path: None
+    continue_learning: True
+    trained_policies_path: null
     max_bid_price: 100
     algorithm: matd3
     learning_rate: 0.001

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -329,8 +329,8 @@
     "                dt=kwargs.get(\"noise_dt\", 1.0),\n",
     "            )\n",
     "\n",
-    "        elif Path(load_path=kwargs[\"trained_policies_path\"]).is_dir():\n",
-    "            self.load_actor_params(load_path=kwargs[\"trained_policies_path\"])"
+    "        elif Path(load_path=kwargs[\"trained_policies_save_path\"]).is_dir():\n",
+    "            self.load_actor_params(load_path=kwargs[\"trained_policies_save_path\"])"
    ]
   },
   {
@@ -1215,7 +1215,7 @@
     "    \"observation_dimension\": 50,\n",
     "    \"action_dimension\": 2,\n",
     "    \"continue_learning\": False,\n",
-    "    \"trained_policies_path\": \"None\",\n",
+    "    \"trained_policies_save_path\": \"None\",\n",
     "    \"max_bid_price\": 100,\n",
     "    \"algorithm\": \"matd3\",\n",
     "    \"learning_rate\": 0.001,\n",

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -329,8 +329,8 @@
     "                dt=kwargs.get(\"noise_dt\", 1.0),\n",
     "            )\n",
     "\n",
-    "        elif Path(load_path=kwargs[\"trained_actors_path\"]).is_dir():\n",
-    "            self.load_actor_params(load_path=kwargs[\"trained_actors_path\"])"
+    "        elif Path(load_path=kwargs[\"trained_policies_path\"]).is_dir():\n",
+    "            self.load_actor_params(load_path=kwargs[\"trained_policies_path\"])"
    ]
   },
   {
@@ -1215,7 +1215,7 @@
     "    \"observation_dimension\": 50,\n",
     "    \"action_dimension\": 2,\n",
     "    \"continue_learning\": False,\n",
-    "    \"trained_actors_path\": \"None\",\n",
+    "    \"trained_policies_path\": \"None\",\n",
     "    \"max_bid_price\": 100,\n",
     "    \"algorithm\": \"matd3\",\n",
     "    \"learning_rate\": 0.001,\n",

--- a/tests/test_learning_role.py
+++ b/tests/test_learning_role.py
@@ -30,7 +30,7 @@ def test_learning_init():
         "learning_mode": False,
         "training_episodes": 3,
         "continue_learning": False,
-        "trained_policies_path": None,
+        "trained_policies_save_path": None,
     }
     # test init
     l = Learning(learning_config, start, end)

--- a/tests/test_learning_role.py
+++ b/tests/test_learning_role.py
@@ -30,7 +30,7 @@ def test_learning_init():
         "learning_mode": False,
         "training_episodes": 3,
         "continue_learning": False,
-        "trained_actors_path": None,
+        "trained_policies_path": None,
     }
     # test init
     l = Learning(learning_config, start, end)


### PR DESCRIPTION
Fixed RL evaluations to use compare_and_save_policies function instead of comparing in 

- enabled the origignal function compare_and_save_policies()
- was basically redundant in code
- also changed the collect initial experience to be overwritten to 1 when it is 0 because otherwise the buffer gives an error, because it has no entries to sample from