### PR TITLE
Maintanence to comply with future Warnings

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/assume/common/mango_serializer.py
+++ b/assume/common/mango_serializer.py
@@ -4,7 +4,7 @@
 
 import calendar
 import pickle
-from datetime import datetime
+from datetime import UTC, datetime
 
 from mango.messages.codecs import JSON, GenericProtoMsg
 
@@ -14,7 +14,7 @@ def datetime_json_serializer():
         return calendar.timegm(dt.utctimetuple())
 
     def __fromstring__(dt: datetime):
-        return datetime.utcfromtimestamp(dt)
+        return datetime.fromtimestamp(dt, tz=UTC)
 
     return datetime, __tostring__, __fromstring__
 

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -4,7 +4,7 @@
 
 import logging
 from collections import defaultdict
-from datetime import datetime
+from datetime import UTC, datetime
 from itertools import groupby
 from operator import itemgetter
 
@@ -298,8 +298,8 @@ class UnitsOperator(Role):
             return
         self.last_sent_dispatch = self.context.current_timestamp
 
-        now = datetime.utcfromtimestamp(self.context.current_timestamp)
-        start = datetime.utcfromtimestamp(last)
+        now = datetime.fromtimestamp(self.context.current_timestamp, tz=UTC)
+        start = datetime.fromtimestamp(last, tz=UTC)
 
         market_dispatch = aggregate_step_amount(
             self.valid_orders[product_type],

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -5,7 +5,7 @@
 import calendar
 import logging
 import math
-from datetime import datetime
+from datetime import UTC, datetime
 from itertools import groupby
 from operator import itemgetter
 
@@ -270,7 +270,7 @@ class MarketRole(MarketMechanism, Role):
                 self, self.handle_get_unmatched, accept_get_unmatched
             )
 
-        current = datetime.utcfromtimestamp(self.context.current_timestamp)
+        current = datetime.fromtimestamp(self.context.current_timestamp)
         next_opening = self.marketconfig.opening_hours.after(current, inc=True)
         opening_ts = calendar.timegm(next_opening.utctimetuple())
         self.context.schedule_timestamp_task(self.opening(), opening_ts)
@@ -281,7 +281,7 @@ class MarketRole(MarketMechanism, Role):
 
         """
         # scheduled to be opened now
-        market_open = datetime.utcfromtimestamp(self.context.current_timestamp)
+        market_open = datetime.fromtimestamp(self.context.current_timestamp, tz=UTC)
         market_closing = market_open + self.marketconfig.opening_duration
         products = get_available_products(
             self.marketconfig.market_products, market_open

--- a/assume/world.py
+++ b/assume/world.py
@@ -7,7 +7,7 @@ import calendar
 import logging
 import sys
 import time
-from datetime import datetime
+from datetime import UTC, datetime
 from sys import platform
 from typing import Any, Optional, Tuple, Union
 
@@ -541,7 +541,7 @@ class World:
             if delta:
                 pbar.update(delta)
                 pbar.set_description(
-                    f"{self.output_role.simulation_id} {datetime.utcfromtimestamp(self.clock.time)}",
+                    f"{self.output_role.simulation_id} {datetime.fromtimestamp(self.clock.time, tz=UTC)}",
                     refresh=False,
                 )
             else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.11"
 argcomplete = "^3.1.4"
 nest-asyncio = "^1.5.6"
 mango-agents-assume = "^1.1.1-8"

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -181,7 +181,7 @@ async def test_market_for_BB(market_role: MarketRole):
     market_role.marketconfig.maximum_bid_volume = 9090
 
     end = start + rd(hours=24)
-    time_range = pd.date_range(start, end - pd.Timedelta("1H"), freq="1H")
+    time_range = pd.date_range(start, end - pd.Timedelta("1h"), freq="1h")
     market_role.open_auctions |= {
         (time, time + rd(hours=1), None) for time in time_range
     }

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -163,7 +163,7 @@ def test_initializer():
 def test_sep_block_orders():
     start = datetime(2020, 1, 1)
     end = datetime(2020, 1, 2)
-    index = pd.date_range(start, end - pd.Timedelta("1H"), freq="1H")
+    index = pd.date_range(start, end - pd.Timedelta("1h"), freq="1h")
     orderbook = [
         {
             "start_time": start,
@@ -201,7 +201,7 @@ def test_sep_block_orders():
             "bid_id": "gen1_1",
         },
     ]
-    index = pd.date_range(start, end - pd.Timedelta("1H"), freq="4H")
+    index = pd.date_range(start, end - pd.Timedelta("1h"), freq="4h")
     orderbook.append(
         {
             "start_time": start,
@@ -225,10 +225,10 @@ def test_sep_block_orders():
 
 def test_get_products_index():
     index_1 = pd.date_range(
-        start=datetime(2020, 1, 1, 0), end=datetime(2020, 1, 1, 5), freq="1H"
+        start=datetime(2020, 1, 1, 0), end=datetime(2020, 1, 1, 5), freq="1h"
     )
     index_2 = pd.date_range(
-        start=datetime(2020, 1, 1, 0), end=datetime(2020, 1, 1, 7), freq="1H"
+        start=datetime(2020, 1, 1, 0), end=datetime(2020, 1, 1, 7), freq="1h"
     )
     orderbook = [
         {


### PR DESCRIPTION
- drop python 3.10 and use python 3.11 and 3.12 instead
- update use of datetime to fit future depreciation of utcfromtimestamp()
- update "H" to "h" to comply with pandas