### PR TITLE
glpk can not be installed in readthedocs due to missing libglpk-dev

### DIFF
--- a/environment_docs.yaml
+++ b/environment_docs.yaml
@@ -15,9 +15,10 @@ dependencies:
 - SQLAlchemy
 - pytorch
 - pyomo
+- pypsa
 
 - pip:
-  - .[full]
+  - .[oeds]
   - sphinx<7
   - sphinx-book-theme
   - nbsphinx


### PR DESCRIPTION
I saw that the latest readthedocs build failed due to missing glpk headers.
As glpk is only used for the execution and not for anything in the docs - it is not needed.
https://readthedocs.org/projects/assume/builds/