### PR TITLE
Remove empty bid as method of bidding strategy

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -708,6 +708,30 @@ class BaseStrategy:
         """
         pass
 
+    def remove_empty_bids(self, bids: list) -> list:
+        """
+        Removes empty bids from the orderbook. Use this method to clean the bids before submitting
+        them to the market to speed up the market clearing process, and if zero volume bids are not
+        required for the specific market.
+
+        Args:
+            bids (list): The bids.
+
+        Returns:
+            list: The cleaned bids.
+        """
+
+        cleaned_bids = []
+        for bid in bids:
+            if isinstance(bid["volume"], dict):
+                if all(volume == 0 for volume in bid["volume"].values()):
+                    continue
+            elif bid["volume"] == 0:
+                continue
+            cleaned_bids.append(bid)
+
+        return cleaned_bids
+
 
 class LearningStrategy(BaseStrategy):
     """

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -451,11 +451,6 @@ class UnitsOperator(Role):
                 product_tuples=products,
             )
             for i, order in enumerate(product_bids):
-                if isinstance(order["volume"], dict):
-                    if all(volume == 0 for volume in order["volume"].values()):
-                        continue
-                elif order["volume"] == 0:
-                    continue
                 order["agent_id"] = (self.context.addr, self.context.aid)
                 if market.volume_tick:
                     order["volume"] = round(order["volume"] / market.volume_tick)

--- a/assume/strategies/advanced_orders.py
+++ b/assume/strategies/advanced_orders.py
@@ -180,6 +180,8 @@ class flexableEOMBlock(BaseStrategy):
             }
         )
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
     def calculate_reward(
@@ -369,6 +371,8 @@ class flexableEOMLinked(BaseStrategy):
                 "bid_id": block_id,
             }
         )
+
+        bids = self.remove_empty_bids(bids)
 
         return bids
 

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -61,6 +61,9 @@ class OTCStrategy(BaseStrategy):
                     "volume": volume,
                 }
             )
+
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -119,4 +122,7 @@ class MarkupStrategy(BaseStrategy):
                     "volume": volume,
                 }
             )
+
+        bids = self.remove_empty_bids(bids)
+
         return bids

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -153,6 +153,8 @@ class flexableEOM(BaseStrategy):
             previous_power = bid_quantity_inflex + bid_quantity_flex + current_power
             op_time = max(op_time, 0) + 1 if previous_power > 0 else min(op_time, 0) - 1
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
     def calculate_reward(
@@ -280,6 +282,8 @@ class flexablePosCRM(BaseStrategy):
             )
             previous_power = bid_quantity + current_power
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -386,6 +390,8 @@ class flexableNegCRM(BaseStrategy):
                 }
             )
             previous_power = current_power + bid_quantity
+
+        bids = self.remove_empty_bids(bids)
 
         return bids
 

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -169,6 +169,8 @@ class flexableEOMStorage(BaseStrategy):
             theoretic_SOC += delta_soc
             previous_power = bid_quantity + current_power
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
     def calculate_reward(
@@ -348,6 +350,8 @@ class flexablePosCRMStorage(BaseStrategy):
                     f"Product {market_config.product_type} is not supported by this strategy."
                 )
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -462,6 +466,8 @@ class flexableNegCRMStorage(BaseStrategy):
                 raise ValueError(
                     f"Product {market_config.product_type} is not supported by this strategy."
                 )
+
+        bids = self.remove_empty_bids(bids)
 
         return bids
 

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -254,6 +254,8 @@ class RLAdvancedOrderStrategy(LearningStrategy):
                 }
             )
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
     def get_actions(self, next_observation):

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -173,6 +173,8 @@ class RLStrategy(LearningStrategy):
         unit.outputs["rl_actions"][start] = actions
         unit.outputs["rl_exploration_noise"][start] = noise
 
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
     def get_actions(self, next_observation):

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -73,6 +73,10 @@ class NaiveSingleBidStrategy(BaseStrategy):
             else:
                 op_time = min(op_time, 0) - 1
 
+        bids = self.remove_empty_bids(bids)
+
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -125,6 +129,9 @@ class NaiveProfileStrategy(BaseStrategy):
         }
 
         bids = [order]
+
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -185,6 +192,9 @@ class NaivePosReserveStrategy(BaseStrategy):
                 }
             )
             previous_power = volume + current_power
+
+        bids = self.remove_empty_bids(bids)
+
         return bids
 
 
@@ -246,4 +256,7 @@ class NaiveNegReserveStrategy(BaseStrategy):
                 }
             )
             previous_power = volume + current_power
+
+        bids = self.remove_empty_bids(bids)
+
         return bids

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -75,8 +75,6 @@ class NaiveSingleBidStrategy(BaseStrategy):
 
         bids = self.remove_empty_bids(bids)
 
-        bids = self.remove_empty_bids(bids)
-
         return bids
 
 

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -20,7 +20,7 @@ class Storage(SupportsMinMaxCharge):
     """
     A class for a storage unit.
 
-    Attributes:
+    Args:
         id (str): The ID of the storage unit.
         technology (str): The technology of the storage unit.
         node (str): The node of the storage unit.

--- a/examples/notebooks/03_custom_unit_example.ipynb
+++ b/examples/notebooks/03_custom_unit_example.ipynb
@@ -481,6 +481,8 @@
     "\n",
     "            # append the order to the list of bids\n",
     "            bids.append(order)\n",
+    "        \n",
+    "        bids = self.remove_empty_bids(bids)\n",
     "\n",
     "        return bids"
    ]

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -394,6 +394,8 @@
     "    actions, noise = self.get_actions(next_observation)\n",
     "\n",
     "    bids = actions\n",
+    "    \n",
+    "    bids = self.remove_empty_bids(bids)\n",
     "\n",
     "    return bids"
    ]
@@ -840,6 +842,8 @@
     "    unit.outputs[\"rl_observations\"][start] = next_observation\n",
     "    unit.outputs[\"rl_actions\"][start] = actions\n",
     "    unit.outputs[\"rl_exploration_noise\"][start] = noise\n",
+    "    \n",
+    "    bids = self.remove_empty_bids(bids)\n",
     "\n",
     "    return bids"
    ]

--- a/tests/test_advanced_order_strategy.py
+++ b/tests/test_advanced_order_strategy.py
@@ -81,13 +81,13 @@ def test_eom_with_blocks(mock_market_config, power_plant):
     assert power_plant.get_operation_time(product_index[0]) == -1
 
     bids = strategy.calculate_bids(power_plant, mc, product_tuples=product_tuples)
-    assert len(bids) == 25
-    assert bids[0]["price"] == 0
-    assert bids[0]["volume"] == 0
+    assert len(bids) == 24
+    assert bids[0]["price"] == 30
+    assert bids[0]["volume"] == 200
     assert bids[1]["price"] == 30
-    assert bids[1]["volume"] == 200
+    assert bids[1]["volume"] == 600
     assert bids[2]["price"] == 30
-    assert bids[2]["volume"] == 600
+    assert bids[2]["volume"] == 800
     assert bids[-1]["price"] == 30
     assert bids[-1]["volume"] == {
         product_index[i]: 0 if i == 0 else 200 for i in range(len(product_index))
@@ -136,16 +136,13 @@ def test_eom_with_links(mock_market_config, power_plant):
     assert power_plant.get_operation_time(product_index[0]) == -1
 
     bids = strategy.calculate_bids(power_plant, mc, product_tuples=product_tuples)
-    assert len(bids) == 25
-    assert bids[0]["price"] == 0
-    assert bids[0]["volume"] == {product_index[0]: 0}
-    assert bids[0]["parent_bid_id"] == None
+    assert len(bids) == 24
+    assert bids[0]["price"] == 30
+    assert bids[0]["volume"] == {product_index[1]: 200}
+    assert bids[0]["parent_bid_id"] == power_plant.id + "_block"
     assert bids[1]["price"] == 30
-    assert bids[1]["volume"] == {product_index[1]: 200}
+    assert bids[1]["volume"] == {product_index[2]: 600}
     assert bids[1]["parent_bid_id"] == power_plant.id + "_block"
-    assert bids[2]["price"] == 30
-    assert bids[2]["volume"] == {product_index[2]: 600}
-    assert bids[2]["parent_bid_id"] == power_plant.id + "_block"
     assert bids[-1]["price"] == 30
     assert bids[-1]["volume"] == {
         product_index[i]: 0 if i == 0 else 200 for i in range(len(product_index))

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -178,3 +178,57 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
         base_unit.execute_current_dispatch(index[0], index[2])
         == base_unit.outputs["energy"][index[0] : index[2]]
     ).all()
+
+
+def test_clear_empty_bids(base_unit, mock_market_config):
+    # Test empty bids
+    bids = []
+    index = base_unit.index
+    for start in index:
+        bids.append(
+            {
+                "start_time": start,
+                "end_time": start + timedelta(hours=1),
+                "only_hours": None,
+                "price": 10,
+                "volume": 0,
+            }
+        )
+    assert (
+        base_unit.bidding_strategies[mock_market_config.name].remove_empty_bids(bids)
+        == []
+    )
+
+    # Test non-empty bids
+    non_empty_bids = []
+    for start in index:
+        non_empty_bids.append(
+            {
+                "start_time": start,
+                "end_time": start + timedelta(hours=1),
+                "only_hours": None,
+                "price": 10,
+                "volume": 10,
+            }
+        )
+    non_empty_bids_result = base_unit.bidding_strategies[
+        mock_market_config.name
+    ].remove_empty_bids(non_empty_bids)
+    assert non_empty_bids_result == non_empty_bids
+
+    # Test mixed empty and non-empty bids
+    mixed_bids = []
+    for start in index:
+        mixed_bids.append(
+            {
+                "start_time": start,
+                "end_time": start + timedelta(hours=1),
+                "only_hours": None,
+                "price": 10,
+                "volume": 0 if start.hour % 2 == 0 else 10,
+            }
+        )
+    mixed_bids_result = base_unit.bidding_strategies[
+        mock_market_config.name
+    ].remove_empty_bids(mixed_bids)
+    assert mixed_bids_result == [bid for bid in mixed_bids if bid["volume"] > 0]

--- a/tests/test_extended.py
+++ b/tests/test_extended.py
@@ -61,8 +61,11 @@ def test_otc_strategy_scaled(scale, mock_supports_minmax):
 
     power = 400 * scale
 
-    assert bids[0]["price"] == 3
-    assert bids[0]["volume"] == power
+    if power != 0:
+        assert bids[0]["price"] == 3
+        assert bids[0]["volume"] == power
+    else:
+        assert len(bids) == 0
 
 
 if __name__ == "__main__":

--- a/tests/test_flexable_storage_strategies.py
+++ b/tests/test_flexable_storage_strategies.py
@@ -112,7 +112,7 @@ def test_flexable_eom_storage(mock_market_config, storage):
     ]
     storage.forecaster = NaiveForecast(index, availability=1, price_forecast=forecast)
     bids = strategy.calculate_bids(storage, mc, product_tuples=product_tuples)
-    assert len(bids) == 24
+    assert len(bids) == 20
     assert math.isclose(
         bids[0]["price"],
         np.mean(forecast[0:13]) * storage.efficiency_charge,
@@ -138,35 +138,23 @@ def test_flexable_eom_storage(mock_market_config, storage):
     )
     assert bids[3]["volume"] == -100
     assert math.isclose(
-        bids[4]["price"],
-        np.mean(forecast[0:17]) / storage.efficiency_discharge,
-        abs_tol=0.01,
-    )
-    assert bids[4]["volume"] == 0
-    assert math.isclose(
-        bids[8]["price"],
+        bids[7]["price"],
         np.mean(forecast[0:21]) / storage.efficiency_discharge,
         abs_tol=0.01,
     )
-    assert math.isclose(bids[8]["volume"], 14.444, abs_tol=0.01)
+    assert math.isclose(bids[7]["volume"], 14.444, abs_tol=0.01)
     assert math.isclose(
-        bids[12]["price"],
+        bids[11]["price"],
         np.mean(forecast[0:25]) / storage.efficiency_discharge,
         abs_tol=0.01,
     )
-    assert bids[12]["volume"] == 100
+    assert bids[11]["volume"] == 100
     assert math.isclose(
-        bids[16]["price"],
+        bids[14]["price"],
         np.mean(forecast[4:]) * storage.efficiency_charge,
         abs_tol=0.01,
     )
-    assert bids[16]["volume"] == -100
-    assert math.isclose(
-        bids[20]["price"],
-        np.mean(forecast[8:]) * storage.efficiency_charge,
-        abs_tol=0.01,
-    )
-    assert bids[20]["volume"] == 0
+    assert bids[14]["volume"] == -100
 
 
 def test_flexable_pos_crm_storage(mock_market_config, storage):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -374,7 +374,7 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     storage_unit.outputs["soc"][start] = 0.5
 
     bids = strategy.calculate_bids(storage_unit, mc, product_tuples=product_tuples)
-    bids[0]["accepted_volume"] = bids[0]["volume"]
+    assert len(bids) == 0
 
     # dispatch full discharge
     storage_unit.set_dispatch_plan(mc, bids)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -378,6 +378,7 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
 
     # dispatch full discharge
     storage_unit.set_dispatch_plan(mc, bids)
+    storage_unit.execute_current_dispatch(start, end)
 
     assert storage_unit.outputs["energy"][start] == 100
     assert math.isclose(
@@ -389,6 +390,8 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     storage_unit.outputs["soc"][start] = 0.5
 
     storage_unit.set_dispatch_plan(mc, bids)
+    storage_unit.execute_current_dispatch(start, end)
+
     assert storage_unit.outputs["energy"][start] == -100
     assert math.isclose(
         storage_unit.outputs["soc"][end],
@@ -399,6 +402,8 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     storage_unit.outputs["soc"][start] = 0.05
 
     storage_unit.set_dispatch_plan(mc, bids)
+    storage_unit.execute_current_dispatch(start, end)
+
     assert math.isclose(
         storage_unit.outputs["energy"][start],
         50 * storage_unit.efficiency_discharge,
@@ -409,6 +414,8 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     storage_unit.outputs["soc"][start] = 0.95
 
     storage_unit.set_dispatch_plan(mc, bids)
+    storage_unit.execute_current_dispatch(start, end)
+
     assert math.isclose(
         storage_unit.outputs["energy"][start],
         -50 / storage_unit.efficiency_charge,
@@ -422,10 +429,13 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     product_tuples = [(start, end, None)]
 
     bids = strategy.calculate_bids(storage_unit, mc, product_tuples=product_tuples)
-    bids[0]["accepted_volume"] = bids[0]["volume"]
+    assert len(bids) == 0
 
     storage_unit.outputs["energy"][start] = -100
+
     storage_unit.set_dispatch_plan(mc, bids)
+    storage_unit.execute_current_dispatch(start, end)
+
     assert storage_unit.outputs["energy"][start] == 0
     assert math.isclose(storage_unit.outputs["soc"][end], 1, abs_tol=0.001)
 


### PR DESCRIPTION
Removes the clearing of empty bids from unit operator into the bidding strategies themselves. This allows for the user to control this behavior and keep bids with volume of 0 if needed (such as for redispatch market)