### PR TITLE
update github actions

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Workaround: https://github.com/docker/build-push-action/issues/461
       - name: Setup Docker buildx

--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -23,9 +23,9 @@ jobs:
         python-version: ["3.10", "3.11"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -57,10 +57,10 @@ jobs:
         pytest --cov --cov-report=xml --junitxml="result.xml"
 
     - name: Upload tests results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always()
       with:
-        name: test-results
+        name: test-results-${{ matrix.python-version }}
         path: |
           coverage.xml
           result.xml


### PR DESCRIPTION
This fixes the following warning on our runs:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, actions/upload-artifact@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
