### PR TITLE
use latest github actions versions for codecov too

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -66,7 +66,7 @@ jobs:
           result.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:


### PR DESCRIPTION
this was missing in the last PR, as it gave another warning