### PR TITLE
Fix datetime warning

### DIFF
--- a/assume/common/mango_serializer.py
+++ b/assume/common/mango_serializer.py
@@ -2,19 +2,20 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import calendar
 import pickle
 from datetime import datetime
 
 from mango.messages.codecs import JSON, GenericProtoMsg
 
+from assume.common.utils import datetime2timestamp, timestamp2datetime
+
 
 def datetime_json_serializer():
     def __tostring__(dt: datetime):
-        return calendar.timegm(dt.utctimetuple())
+        return datetime2timestamp(dt)
 
-    def __fromstring__(dt: datetime):
-        return datetime.utcfromtimestamp(dt)
+    def __fromstring__(ts: float | str):
+        return timestamp2datetime(ts)
 
     return datetime, __tostring__, __fromstring__
 

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -22,7 +22,11 @@ from assume.common.market_objects import (
     Orderbook,
     RegistrationMessage,
 )
-from assume.common.utils import aggregate_step_amount, get_products_index
+from assume.common.utils import (
+    aggregate_step_amount,
+    get_products_index,
+    timestamp2datetime,
+)
 from assume.strategies import BaseStrategy, LearningStrategy
 from assume.units import BaseUnit
 
@@ -298,8 +302,8 @@ class UnitsOperator(Role):
             return
         self.last_sent_dispatch[product_type] = self.context.current_timestamp
 
-        now = datetime.utcfromtimestamp(self.context.current_timestamp)
-        start = datetime.utcfromtimestamp(last)
+        now = timestamp2datetime(self.context.current_timestamp)
+        start = timestamp2datetime(last)
 
         market_dispatch = aggregate_step_amount(
             self.valid_orders[product_type],

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import calendar
 import inspect
 import logging
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from functools import wraps
 from itertools import groupby
 from operator import itemgetter
@@ -427,3 +428,11 @@ def get_products_index(orderbook: Orderbook) -> pd.DatetimeIndex:
     )
 
     return index_products
+
+
+def timestamp2datetime(timestamp: float):
+    return datetime.fromtimestamp(timestamp, tz=UTC).replace(tzinfo=None)
+
+
+def datetime2timestamp(datetime: datetime):
+    return calendar.timegm(datetime.utctimetuple())

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -6,7 +6,7 @@ import calendar
 import inspect
 import logging
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from functools import wraps
 from itertools import groupby
 from operator import itemgetter
@@ -431,7 +431,7 @@ def get_products_index(orderbook: Orderbook) -> pd.DatetimeIndex:
 
 
 def timestamp2datetime(timestamp: float):
-    return datetime.fromtimestamp(timestamp, tz=UTC).replace(tzinfo=None)
+    return datetime.fromtimestamp(timestamp, tz=timezone.utc).replace(tzinfo=None)
 
 
 def datetime2timestamp(datetime: datetime):

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import calendar
 import logging
 import math
 from datetime import datetime
@@ -23,7 +22,12 @@ from assume.common.market_objects import (
     RegistrationMessage,
     RegistrationReplyMessage,
 )
-from assume.common.utils import get_available_products, separate_orders
+from assume.common.utils import (
+    datetime2timestamp,
+    get_available_products,
+    separate_orders,
+    timestamp2datetime,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -258,9 +262,9 @@ class MarketRole(MarketMechanism, Role):
                 self, self.handle_get_unmatched, accept_get_unmatched
             )
 
-        current = datetime.utcfromtimestamp(self.context.current_timestamp)
+        current = timestamp2datetime(self.context.current_timestamp)
         next_opening = self.marketconfig.opening_hours.after(current, inc=True)
-        opening_ts = calendar.timegm(next_opening.utctimetuple())
+        opening_ts = datetime2timestamp(next_opening)
         self.context.schedule_timestamp_task(self.opening(), opening_ts)
 
     async def opening(self):
@@ -269,7 +273,7 @@ class MarketRole(MarketMechanism, Role):
 
         """
         # scheduled to be opened now
-        market_open = datetime.utcfromtimestamp(self.context.current_timestamp)
+        market_open = timestamp2datetime(self.context.current_timestamp)
         market_closing = market_open + self.marketconfig.opening_duration
         products = get_available_products(
             self.marketconfig.market_products, market_open
@@ -303,13 +307,13 @@ class MarketRole(MarketMechanism, Role):
             )
 
         # schedule closing this market
-        closing_ts = calendar.timegm(market_closing.utctimetuple())
+        closing_ts = datetime2timestamp(market_closing)
         self.context.schedule_timestamp_task(self.clear_market(products), closing_ts)
 
         # schedule the next opening too
         next_opening = self.marketconfig.opening_hours.after(market_open)
         if next_opening:
-            next_opening_ts = calendar.timegm(next_opening.utctimetuple())
+            next_opening_ts = datetime2timestamp(next_opening)
             self.context.schedule_timestamp_task(self.opening(), next_opening_ts)
             logger.debug(
                 f"market opening: %s - %s - %s",

--- a/assume/world.py
+++ b/assume/world.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import asyncio
-import calendar
 import logging
 import sys
 import time
@@ -30,6 +29,7 @@ from assume.common import (
     mango_codec_factory,
 )
 from assume.common.base import LearningConfig
+from assume.common.utils import datetime2timestamp, timestamp2datetime
 from assume.markets import MarketRole, clearing_mechanisms
 from assume.strategies import LearningStrategy, bidding_strategies
 from assume.units import BaseUnit, Demand, PowerPlant, Storage
@@ -520,7 +520,7 @@ class World:
             if delta:
                 pbar.update(delta)
                 pbar.set_description(
-                    f"{self.output_role.simulation_id} {datetime.utcfromtimestamp(self.clock.time)}",
+                    f"{self.output_role.simulation_id} {timestamp2datetime(self.clock.time)}",
                     refresh=False,
                 )
             else:
@@ -540,8 +540,8 @@ class World:
         container.
         """
 
-        start_ts = calendar.timegm(self.start.utctimetuple())
-        end_ts = calendar.timegm(self.end.utctimetuple())
+        start_ts = datetime2timestamp(self.start)
+        end_ts = datetime2timestamp(self.end)
 
         try:
             return self.loop.run_until_complete(

--- a/examples/distributed_simulation/config.py
+++ b/examples/distributed_simulation/config.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import asyncio
-import calendar
 import logging
 import os
 from datetime import datetime, timedelta
@@ -13,6 +12,7 @@ from dateutil import rrule as rr
 
 from assume import World
 from assume.common.market_objects import MarketConfig, MarketProduct
+from assume.common.utils import datetime2timestamp
 
 log = logging.getLogger(__name__)
 
@@ -80,8 +80,8 @@ async def worker(world: World, marketdesign: list[MarketConfig], create_worker):
         await asyncio.sleep(2)
         world.logger.info("starting simulation")
         await world.async_run(
-            start_ts=calendar.timegm(world.start.utctimetuple()),
-            end_ts=calendar.timegm(world.end.utctimetuple()),
+            start_ts=datetime2timestamp(world.start),
+            end_ts=datetime2timestamp(world.end),
         )
     elif world.distributed_role is False:
         await world.clock_agent.stopped

--- a/tests/test_market.py
+++ b/tests/test_market.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import calendar
 from datetime import datetime
 
 import pandas as pd
@@ -14,6 +13,7 @@ from mango.util.clock import ExternalClock
 from mango.util.termination_detection import tasks_complete_or_sleeping
 
 from assume.common.market_objects import MarketConfig
+from assume.common.utils import datetime2timestamp
 from assume.markets.base_market import MarketProduct, MarketRole
 
 start = datetime(2020, 1, 1)
@@ -38,7 +38,7 @@ async def market_role() -> MarketRole:
 
     yield market_role
 
-    end_ts = calendar.timegm(end.utctimetuple())
+    end_ts = datetime2timestamp(end)
     clock.set_time(end_ts)
     await tasks_complete_or_sleeping(container)
     await container.shutdown()

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import calendar
 from datetime import datetime
 
 import pandas as pd
@@ -16,6 +15,7 @@ from mango.util.termination_detection import tasks_complete_or_sleeping
 from assume.common.forecasts import NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.units_operator import UnitsOperator
+from assume.common.utils import datetime2timestamp
 from assume.strategies.naive_strategies import NaiveSingleBidStrategy
 from assume.units.demand import Demand
 from assume.units.powerplant import PowerPlant
@@ -53,12 +53,12 @@ async def units_operator() -> UnitsOperator:
     unit = Demand("testdemand", index=index, **params_dict)
     await units_role.add_unit(unit)
 
-    start_ts = calendar.timegm(start.utctimetuple())
+    start_ts = datetime2timestamp(start)
     clock.set_time(start_ts)
 
     yield units_role
 
-    end_ts = calendar.timegm(end.utctimetuple())
+    end_ts = datetime2timestamp(end)
     clock.set_time(end_ts)
     await tasks_complete_or_sleeping(container)
     await container.shutdown()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -426,6 +426,15 @@ def test_broken_timestamps():
     # and for the utc timestamp
     assert 0 == calendar.timegm(unix_start.utctimetuple())
 
+    # pandas fromtimestamp has this problem too:
+    assert offset + unix_start == pd.Timestamp.fromtimestamp(0)
+
+    # though this can work
+    assert unix_start == pd.Timestamp(0)
+
+    # the other way works with pandas
+    assert pd.Timestamp(unix_start).timestamp() == 0
+
 
 def test_timestamp2datetime():
     unix_start = datetime(1970, 1, 1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import calendar
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 import pandas as pd
@@ -422,7 +422,7 @@ def test_broken_timestamps():
     assert true_unix_epoch_start + offset == unix_epoch_start
     # however, we want to have everything in UTC
     # so we need this approach to get a datetime
-    assert unix_start == datetime.fromtimestamp(0, tz=UTC).replace(tzinfo=None)
+    assert unix_start == datetime.fromtimestamp(0, tz=timezone.utc).replace(tzinfo=None)
     # and for the utc timestamp
     assert 0 == calendar.timegm(unix_start.utctimetuple())
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,21 +2,25 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from datetime import datetime, timedelta
+import calendar
+from datetime import UTC, datetime, timedelta
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
 from dateutil import rrule as rr
+from dateutil.tz import tzlocal
 
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.utils import (
     aggregate_step_amount,
+    datetime2timestamp,
     get_available_products,
     get_products_index,
     initializer,
     plot_orderbook,
     separate_orders,
+    timestamp2datetime,
     visualize_orderbook,
 )
 from assume.scenario.loader_csv import convert_to_rrule_freq, make_market_config
@@ -403,6 +407,34 @@ def test_plot_function(mock_pyplot):
         o["block_id"] = i + 1
         i += 1
     visualize_orderbook(orderbook)
+
+
+def test_broken_timestamps():
+    # timestamp is not in UTC, but is timezone-independent
+    # in general, we expect timestamps to be unix-epoch timestamps
+    unix_start = datetime(1970, 1, 1)
+
+    unix_epoch_start = datetime.fromtimestamp(0)
+    true_unix_epoch_start = unix_start
+    offset = tzlocal().utcoffset(datetime.now())
+    # this should be 1970-01-01-00-00 but it isn't (when run in CET locale)
+    # so we always have this offset
+    assert true_unix_epoch_start + offset == unix_epoch_start
+    # however, we want to have everything in UTC
+    # so we need this approach to get a datetime
+    assert unix_start == datetime.fromtimestamp(0, tz=UTC).replace(tzinfo=None)
+    # and for the utc timestamp
+    assert 0 == calendar.timegm(unix_start.utctimetuple())
+
+
+def test_timestamp2datetime():
+    unix_start = datetime(1970, 1, 1)
+    assert unix_start == timestamp2datetime(0)
+
+
+def test_datetime2timestamp():
+    unix_start = datetime(1970, 1, 1)
+    assert 0 == datetime2timestamp(unix_start)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This drops the timezone information after conversion and therefore stays compliant with the current behavior.
This is a follow-up to #285

It also includes tests for the helper functions, to make sure that they adhere to the offset correctly.
Running the tests in CI might not be always helpful, as they probably run in UTC and therefore do not have weird issues.

The existing and current behavior is to always convert datetimes into UTC and never store the Timezone with them.