### PR TITLE
Add ARM docker platform

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -69,9 +69,10 @@ jobs:
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
         id: build-and-push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           context: .
+          platforms: linux/amd64,linux/arm64/v8
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN touch assume/__init__.py
 RUN pip-compile --resolver=backtracking -o requirements.txt ./pyproject.toml
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY README.md pyproject.toml /src
+COPY README.md pyproject.toml cli.py /src
 COPY assume /src/assume
 COPY examples /src/examples
 ENV PATH /home/admin/.local/bin:$PATH


### PR DESCRIPTION
This fixes running the simulation with docker and makes sure, that github also creates an image for ARM architecture (used for example on raspberryPi)