### PR TITLE
update grafana docker version to latest

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -29,7 +29,7 @@ services:
         constraints: [node.role == manager]
 
   grafana:
-    image: grafana/grafana-oss:9.2.15
+    image: grafana/grafana-oss:latest
     container_name: assume_grafana
     user: "104"
     depends_on:


### PR DESCRIPTION
This just updates the grafana version to the latest version, when using grafana with docker from the compose.yml