### PR TITLE
fix bugs in tutorial 6

### DIFF
--- a/examples/notebooks/06_advanced_orders_example.ipynb
+++ b/examples/notebooks/06_advanced_orders_example.ipynb
@@ -136,7 +136,19 @@
    },
    "outputs": [],
    "source": [
-    "!pip install assume-framework\n",
+    "!pip install assume-framework"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "vscode": {
+     "languageId": "shellscript"
+    }
+   },
+   "outputs": [],
+   "source": [
     "!pip install pyomo\n",
     "!apt-get install -y -qq glpk-utils"
    ]
@@ -1269,7 +1281,6 @@
     "import pandas as pd\n",
     "from functools import partial\n",
     "\n",
-    "DB_URI = \"postgresql://assume:assume@localhost:5432/assume\"\n",
     "engine = create_engine(DB_URI)"
    ]
   },
@@ -1393,8 +1404,10 @@
     "#plot the sum of accepted volume for each simulation over time\n",
     "for i, sim in enumerate(df.simulation.unique()):\n",
     "    data=df[df.simulation == sim].sort_index()\n",
+    "    #set index to datetime\n",
+    "    data.index = pd.to_datetime(data.index)\n",
     "    #sum over bid_types\n",
-    "    data=data.groupby([data.index]).sum()\n",
+    "    data=data[\"accepted_volume\"].groupby([data.index]).sum()\n",
     "    #reset index and fill empty data points with zero\n",
     "    time_index = pd.date_range(start=min(df.index), end=max(df.index), freq='1h')\n",
     "    data=data.reindex(time_index, fill_value=0.0)\n",
@@ -1409,7 +1422,7 @@
     "    # add horizontal corridor for min and max power\n",
     "    ax[i].fill_between(data.index, 385.5, 950, color='lightgreen', alpha=0.5)\n",
     "    ax[i].fill_between(data.index, 0, 385.5,\n",
-    "                       where=(data['accepted_volume'] > 0) & (data['accepted_volume'] < 385.5),\n",
+    "                       where=(data > 0) & (data < 385.5),\n",
     "                      color='lightcoral', alpha=0.5\n",
     "                      )\n",
     "\n",


### PR DESCRIPTION
When running in Colab, the Tutorial 6 returns Warnings when running the simulation with flexableEOM strategy:
"WARNING:pyomo.repn.plugins.lp_writer:EXPORT Suffix 'dual' found on 1 block:    dual LP writer cannot export suffixes to LP files.  Skipping."

This is not fixed yet! Does anyone know how to fix this? I run pip install pyomo in the beginning of the notebook. It does not help to install it again...

Also the visualization did not return the wanted output. This is fixed by this PR.