### PR TITLE
add assume_cli as a package using assume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,9 @@ RUN touch assume/__init__.py
 RUN pip-compile --resolver=backtracking -o requirements.txt ./pyproject.toml
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY README.md pyproject.toml cli.py /src
+COPY README.md pyproject.toml /src
 COPY assume /src/assume
+COPY assume_cli /src/assume_cli
 COPY examples /src/examples
 ENV PATH /home/admin/.local/bin:$PATH
 RUN chown -R admin /src /home/admin

--- a/assume/world.py
+++ b/assume/world.py
@@ -89,7 +89,7 @@ class World:
         addr: Union[tuple[str, int], str] = "world",
         database_uri: str = "",
         export_csv_path: str = "",
-        log_level: str = "WARNING",
+        log_level: str = "INFO",
         distributed_role: Optional[bool] = None,
     ) -> None:
         logging.getLogger("assume").setLevel(log_level)

--- a/assume/world.py
+++ b/assume/world.py
@@ -37,7 +37,6 @@ from assume.units import BaseUnit, Demand, PowerPlant, Storage
 
 file_handler = logging.FileHandler(filename="assume.log", mode="w+")
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
-stdout_handler.setLevel(logging.WARNING)
 handlers = [file_handler, stdout_handler]
 logging.basicConfig(level=logging.INFO, handlers=handlers)
 logging.getLogger("mango").setLevel(logging.WARNING)
@@ -90,7 +89,7 @@ class World:
         addr: Union[tuple[str, int], str] = "world",
         database_uri: str = "",
         export_csv_path: str = "",
-        log_level: str = "INFO",
+        log_level: str = "WARNING",
         distributed_role: Optional[bool] = None,
     ) -> None:
         logging.getLogger("assume").setLevel(log_level)

--- a/assume/world.py
+++ b/assume/world.py
@@ -7,6 +7,7 @@ import logging
 import sys
 import time
 from datetime import datetime
+from pathlib import Path
 from sys import platform
 from typing import Optional, Union
 
@@ -101,6 +102,9 @@ class World:
         self.export_csv_path = export_csv_path
         # intialize db connection at beginning of simulation
         if database_uri:
+            if str(database_uri).startswith("sqlite:///"):
+                db_path = Path(str(database_uri).replace("sqlite:///", ""))
+                db_path.parent.mkdir(exist_ok=True)
             self.db = create_engine(make_url(database_uri))
             connected = False
             while not connected:

--- a/assume_cli/__init__.py
+++ b/assume_cli/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later

--- a/assume_cli/cli.py
+++ b/assume_cli/cli.py
@@ -16,15 +16,12 @@ import argcomplete
 import yaml
 from sqlalchemy import make_url
 
-os.makedirs("./examples/outputs", exist_ok=True)
-os.makedirs("./examples/local_db", exist_ok=True)
-
 
 def db_uri_completer(prefix, parsed_args, **kwargs):
     return {
-        "sqlite://example.db": "example",
-        f"sqlite://examples/local_db/{parsed_args.scenario}.db": "current scenario",
-        "sqlite:///": "in-memory",
+        "sqlite:///example.db": "example",
+        f"sqlite:///examples/local_db/{parsed_args.scenario}.db": "current scenario",
+        "sqlite://": "in-memory",
         "postgresql://assume:assume@localhost:5432/assume": "localhost",
         "postgresql://assume:assume@assume_db:5432/assume": "docker",
         "mysql://username:password@localhost:3306/database": "mysql",
@@ -124,6 +121,8 @@ def cli(args=None):
         # to improve autocompletion speed
         from assume import World
         from assume.scenario.loader_csv import load_scenario_folder, run_learning
+
+        os.makedirs("./examples/local_db", exist_ok=True)
 
         world = World(
             database_uri=db_uri,

--- a/assume_cli/cli.py
+++ b/assume_cli/cli.py
@@ -98,7 +98,7 @@ def cli(args=None):
         "-l",
         "--loglevel",
         help="logging level used for file log",
-        default="INFO",
+        default="WARNING",
         type=str,
         metavar="LOGLEVEL",
         choices=set(logging._nameToLevel.keys()),

--- a/assume_cli/cli.py
+++ b/assume_cli/cli.py
@@ -98,7 +98,7 @@ def cli(args=None):
         "-l",
         "--loglevel",
         help="logging level used for file log",
-        default="WARNING",
+        default="INFO",
         type=str,
         metavar="LOGLEVEL",
         choices=set(logging._nameToLevel.keys()),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers=[
 
 packages = [
     { include="assume", from="." },
+    { include="assume_cli", from="." },
 ]
 
 [tool.poetry.dependencies]
@@ -73,7 +74,7 @@ full = ["torch", "glpk","pyomo", "pypsa", "windpowerlib", "pvlib", "demandlib", 
 test = ["black", "isort", "matplotlib", "pytest", "pytest-cov", "pytest-asyncio", "glpk", "mypy"]
 
 [tool.poetry.scripts]
-assume = "cli:cli"
+assume = "assume_cli.cli:cli"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -3,8 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import pytest
-
-from cli import cli
+from assume_cli.cli import cli
 
 
 @pytest.mark.slow

--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import pytest
+
 from assume_cli.cli import cli
 
 


### PR DESCRIPTION
It is needed to be an extra package so that the completion is fast when using `assume -h` for example.

Without this, it tries to do `from cli import cli`, while cli is not an installed package, just a script lying around. 
This makes it possible to run scenarios in other folders than the cloned one too.

For examples using `assume -i . -s my_example -c tiny` works, if I created one myself.

This also correctly sets the -l LOGLEVEL switch to set the same level output on the stdout output as in the log_file