### PR TITLE
Fix double dispatch writing

### DIFF
--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -244,7 +244,12 @@ class WriteOutput(Role):
 
             if self.export_csv_path:
                 data_path = self.export_csv_path / f"{table}.csv"
-                df.to_csv(data_path, mode="a", header=not data_path.exists())
+                df.to_csv(
+                    data_path,
+                    mode="a",
+                    header=not data_path.exists(),
+                    float_format="%.5g",
+                )
 
             if self.db is not None:
                 try:
@@ -506,6 +511,7 @@ class WriteOutput(Role):
                 mode="a",
                 header=not kpi_data_path.exists(),
                 index=None,
+                float_format="%.5g",
             )
 
         if self.db is not None and not df.empty:

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -303,7 +303,7 @@ class UnitsOperator(Role):
         Returns:
             tuple[pd.DataFrame, list[pd.DataFrame]]: market_dispatch and unit_dispatch dataframes
         """
-        now = timestamp2datetime(self.context.current_timestamp)
+        now = timestamp2datetime(self.context.current_timestamp - 1)
         start = timestamp2datetime(last)
 
         market_dispatch = aggregate_step_amount(

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -292,7 +292,7 @@ class UnitsOperator(Role):
         self, product_type: str, last: datetime
     ) -> tuple[pd.DataFrame, list[pd.DataFrame]]:
         """
-        Retrieves the actual dispatch without interfering with other functions.
+        Retrieves the actual dispatch and commits it in the unit.
         We calculate the series of the actual market results dataframe with accepted bids.
         And the unit_dispatch for all units taken care of in the UnitsOperator.
 
@@ -303,8 +303,8 @@ class UnitsOperator(Role):
         Returns:
             tuple[pd.DataFrame, list[pd.DataFrame]]: market_dispatch and unit_dispatch dataframes
         """
-        now = timestamp2datetime(self.context.current_timestamp - 1)
-        start = timestamp2datetime(last)
+        now = timestamp2datetime(self.context.current_timestamp)
+        start = timestamp2datetime(last + 1)
 
         market_dispatch = aggregate_step_amount(
             self.valid_orders[product_type],
@@ -314,7 +314,6 @@ class UnitsOperator(Role):
         )
         unit_dispatch_dfs = []
         for unit_id, unit in self.units.items():
-            # now = now_a - unit.index.freq
             current_dispatch = unit.execute_current_dispatch(start, now)
             end = now
             current_dispatch.name = "power"

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -178,8 +178,9 @@ async def test_write_learning_params(units_operator: UnitsOperator):
     assert len(units_operator.context._scheduler._scheduled_tasks) == open_tasks + 2
 
 
-async def test_multi_products(units_operator: UnitsOperator):
+async def test_get_actual_dispatch(units_operator: UnitsOperator):
     # GIVEN the first hour happened
+    # the UnitOperator does not
     clock = units_operator.context._agent_context._container.clock
 
     last = clock.time
@@ -187,6 +188,18 @@ async def test_multi_products(units_operator: UnitsOperator):
     # WHEN actual_dispatch is called
     market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
     # THEN resulting unit dispatch dataframe contains one row
+    # which is for the current time - as we must know our current dispatch
+    assert unit_dfs[0].index[0].timestamp() == clock.time
+    assert len(unit_dfs[0]) == 1
+    assert len(market_dispatch) == 0
+
+    # WHEN another hour passes
+    clock.set_time(clock.time + 3600)
+    last = clock.time - 3600
+
+    # THEN resulting unit dispatch dataframe contains only one row with current dispatch
+    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    assert unit_dfs[0].index[0].timestamp() == clock.time
     assert len(unit_dfs[0]) == 1
     assert len(market_dispatch) == 0
 
@@ -194,12 +207,6 @@ async def test_multi_products(units_operator: UnitsOperator):
     last = clock.time - 3600
 
     market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
-    assert len(unit_dfs[0]) == 1
-    assert len(market_dispatch) == 0
-
-    clock.set_time(clock.time + 3600)
-    last = clock.time - 3600
-
-    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    assert unit_dfs[0].index[0].timestamp() == clock.time
     assert len(unit_dfs[0]) == 1
     assert len(market_dispatch) == 0

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -176,3 +176,30 @@ async def test_write_learning_params(units_operator: UnitsOperator):
     units_operator.write_learning_params(orderbook, marketconfig)
 
     assert len(units_operator.context._scheduler._scheduled_tasks) == open_tasks + 2
+
+
+async def test_multi_products(units_operator: UnitsOperator):
+    # GIVEN the first hour happened
+    clock = units_operator.context._agent_context._container.clock
+
+    last = clock.time
+    clock.set_time(clock.time + 3600)
+    # WHEN actual_dispatch is called
+    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    # THEN resulting unit dispatch dataframe contains one row
+    assert len(unit_dfs[0]) == 1
+    assert len(market_dispatch) == 0
+
+    clock.set_time(clock.time + 3600)
+    last = clock.time - 3600
+
+    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    assert len(unit_dfs[0]) == 1
+    assert len(market_dispatch) == 0
+
+    clock.set_time(clock.time + 3600)
+    last = clock.time - 3600
+
+    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    assert len(unit_dfs[0]) == 1
+    assert len(market_dispatch) == 0


### PR DESCRIPTION
This fixes the issue that the dispatch is written twice in the units_operator, which @kim-mskw  mentioned in one of the CSVs.

I am not sure, if this fix is correct as we changed the behavior from "write only the dispatch until before now" to "write the dispatch including now" in b1ae73e9ce9d4079df93fa3c901127f7ef59353f
I think this was due to that the current_dispatch should be executed (e.g. confirmed) also for the current hour, and we had a problem if it is not there yet.

Though we might have fixed the need for including the current hour too with 0f43e135f1e08cddabae25cdf2cfdac9a4aff71c in #290  ..?

UPDATE: 
I found that the problem was not writing the current hour twice, but the last one - this is fixed in the last commit.

I wrote a test to make sure that this behavior is confirmed to work, though we probably need more test cases in general.

I am quite sure that this is the fix we need here.