### PR TITLE
correctly calculate offset of current timezone

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -416,7 +416,7 @@ def test_broken_timestamps():
 
     unix_epoch_start = datetime.fromtimestamp(0)
     true_unix_epoch_start = unix_start
-    offset = tzlocal().utcoffset(datetime.now())
+    offset = tzlocal().utcoffset(datetime.fromtimestamp(0))
     # this should be 1970-01-01-00-00 but it isn't (when run in CET locale)
     # so we always have this offset
     assert true_unix_epoch_start + offset == unix_epoch_start


### PR DESCRIPTION
We should calculate the offset of our current timezone at unix_epoch=0 to have the correct offset

We calculated the offset of our current time, which might change throughout the year, due to summer time. By taking the offset in January 1970, this matches the date we were comparing

This test did not fail in CI, as the CI always runs in UTC and therefore has an offset of 0