### PR TITLE
Dmas fixes

### DIFF
--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -74,7 +74,7 @@ class MarketMechanism:
 
         # simple check that 1 MW can be bid at least by  powerplants
         def requirement(unit: dict):
-            return unit.get("unit_type") != "power_plant" or abs(unit["max_power"]) > 0
+            return unit.get("unit_type") != "power_plant" or abs(unit["max_power"]) >= 0
 
         return all([requirement(info) for info in content["information"]])
 

--- a/assume/markets/clearing_algorithms/complex_clearing_dmas.py
+++ b/assume/markets/clearing_algorithms/complex_clearing_dmas.py
@@ -110,9 +110,7 @@ class ComplexDmasClearingRole(MarketRole):
             if order_type is not None:
                 tt = (order["start_time"] - start) / duration
                 # block_id, hour, name
-                name = (
-                    f'{order["agent_id"]} {order.get("unit_id", "")}'
-                )
+                name = f'{order["agent_id"]} {order.get("unit_id", "")}'
                 if "exclusive" in order_type:
                     idx = (order["exclusive_id"], tt, name)
                 elif "linked" in order_type:
@@ -270,8 +268,8 @@ class ComplexDmasClearingRole(MarketRole):
                     if orders[type_][block, hour, name][1] > 0
                 )
             else:
-                # TODO actually for linked order in the same hour, 
-                # the maximum price of all its prior required blocks 
+                # TODO actually for linked order in the same hour,
+                # the maximum price of all its prior required blocks
                 # should be used to determine the cost of the additional block
                 return quicksum(
                     orders[type_][block, hour, name][0]

--- a/assume/markets/clearing_algorithms/complex_clearing_dmas.py
+++ b/assume/markets/clearing_algorithms/complex_clearing_dmas.py
@@ -307,7 +307,7 @@ class ComplexDmasClearingRole(MarketRole):
             )
             + (model.source[t] + model.sink[t])
             * self.marketconfig.maximum_bid_price
-            * 1e3
+            * 10
             for t in t_range
         )
         # TODO currently, this does not represent a two-sided clearing, as demand has to be taken

--- a/assume/scenario/oeds/infrastructure.py
+++ b/assume/scenario/oeds/infrastructure.py
@@ -13,8 +13,6 @@ from pvlib.location import Location
 from pvlib.pvsystem import PVSystem
 from sqlalchemy import create_engine
 from tqdm import tqdm
-
-# !pip install git+https://github.com/wind-python/windpowerlib@dev
 from windpowerlib import ModelChain, WindTurbine
 
 from assume.scenario.oeds.static import (
@@ -118,8 +116,8 @@ class InfrastructureInterface:
         new_cchps = []
         # aggregate with generatorID
         for genID in cchps["generatorID"].unique():
+            cchp = cchps[cchps["generatorID"] == genID]
             if genID != 0:
-                cchp = cchps[cchps["generatorID"] == genID]
                 cchp.index = range(len(cchp))
                 cchp.at[0, "maxPower"] = sum(cchp["maxPower"])
                 cchp.at[0, "kwkPowerTherm"] = sum(cchp["kwkPowerTherm"])
@@ -130,7 +128,6 @@ class InfrastructureInterface:
                     cchp.loc[0, cchp.columns]
                 )  # only append the aggregated row!
             else:
-                cchp = cchps[cchps["generatorID"] == 0]
                 cchp.at[0, "turbineTyp"] = "Closed Cycle Heat Power"
                 cchp.at[0, "fuel"] = "gas_combined"
                 for line in range(len(cchp)):
@@ -442,8 +439,8 @@ class InfrastructureInterface:
         # all WEA with nan set hight to mean diameter
         df["diameter"] = df["diameter"].fillna(df["diameter"].mean())
         # all WEA with na are on shore and not allocated to a sea cluster
-        df["nordicSea"] = df["nordicSea"].fillna(0)
-        df["balticSea"] = df["balticSea"].fillna(0)
+        df["nordicSea"] = df["nordicSea"].astype(float).fillna(0)
+        df["balticSea"] = df["balticSea"].astype(float).fillna(0)
         # get name of manufacturer
         df["manufacturer"] = df["manufacturer"].replace(self.windhersteller)
         # try to find the correct type TODO: Check Pattern of new turbines
@@ -790,7 +787,7 @@ def get_wind_series(wind_systems: pd.DataFrame, weather_df: pd.DataFrame):
 
     wt = WindTurbine(82, turbine_type="E-82/2300")
     # todo get wind turbine types from database
-    wind_power = pd.Series()
+    wind_power = pd.Series(0, weather_df.index)
     std_curve = wt.power_curve
     std_curve["value"] = std_curve["value"] / wt.power_curve["value"].max()
     for line, row in tqdm(wind_systems.iterrows(), total=len(wind_systems)):
@@ -822,8 +819,8 @@ def get_wind_series(wind_systems: pd.DataFrame, weather_df: pd.DataFrame):
 
 def get_solar_series(solar_systems: pd.DataFrame, weather_df: pd.DataFrame):
     systems = []
-    solar_power = pd.Series()
-    battery_power = pd.Series()
+    solar_power = pd.Series(0, weather_df.index)
+    battery_power = pd.Series(0, weather_df.index)
     if solar_systems.empty:
         return solar_power, battery_power
     for info, group in tqdm(solar_systems.groupby(["azimuth", "tilt"])):

--- a/assume/strategies/dmas_powerplant.py
+++ b/assume/strategies/dmas_powerplant.py
@@ -463,6 +463,8 @@ class DmasPowerplantStrategy(BaseStrategy):
             return (p / unit.efficiency) * (f + e * unit.emission_factor)
 
         def get_marginal(p0: float, p1: float, t: int):
+            if p0 == p1:
+                return 1, 0
             marginal = (get_cost(p=p0, t=t) - get_cost(p=p1, t=t)) / (p0 - p1)
             return marginal, p1 - p0
 

--- a/assume/strategies/dmas_powerplant.py
+++ b/assume/strategies/dmas_powerplant.py
@@ -325,10 +325,10 @@ class DmasPowerplantStrategy(BaseStrategy):
             )
             self.model.obj = Objective(expr=quicksum(cashflow), sense=maximize)
             r = self.opt.solve(self.model)
-            if (r.solver.status == SolverStatus.ok) & (
+            if (r.solver.status == SolverStatus.ok) and (
                 r.solver.termination_condition == TerminationCondition.optimal
             ):
-                log.info(f"find optimal solution in step: {step}")
+                log.debug("find optimal solution in step: %s", step)
 
                 self._set_results(
                     unit,
@@ -466,27 +466,34 @@ class DmasPowerplantStrategy(BaseStrategy):
             marginal = (get_cost(p=p0, t=t) - get_cost(p=p1, t=t)) / (p0 - p1)
             return marginal, p1 - p0
 
-        def get_maximal_profit_hours(base_price):
+        def get_maximal_profit_hours(base_price, start=0):
+            """
+            decides when to turn the powerplant on if it is currently off
+
+            we calculate the sliding window and see when the most profitable time is to turn on.
+            This does search the most profitable hours, even if the first hour might be sufficient to match our marginal costs
+            """
             max_profit, start_hour = 0, 0
             run_time = unit.min_operating_time
-            for t in range(hour_count - run_time):
+            for t in range(start, hour_count - run_time):
                 p = np.sum(unit.min_power * base_price[t : t + run_time])
+
                 if p > max_profit:
                     max_profit = p
                     start_hour = t
-            return [
-                *range(
+            return list(
+                range(
                     start_hour,
-                    min(start_hour + unit.min_operating_time, hour_count),
+                    min(start_hour + run_time, hour_count),
                 )
-            ]
+            )
 
         order_book, last_power, block_number = {}, np.zeros(hour_count), 0
         tr = np.arange(hour_count)
         links = {i: None for i in tr}
 
         max_hours = get_maximal_profit_hours(base_price)
-        start_cost = unit.cold_start_cost / unit.min_power**2
+        start_cost = unit.cold_start_cost / max(unit.min_power, 10) ** 2
 
         yesterday = start.date() - timedelta(days=1)
 
@@ -505,7 +512,7 @@ class DmasPowerplantStrategy(BaseStrategy):
                     reduction = 0
                     hours_needed_to_run = unit.min_operating_time - runtime
                     hours = (
-                        [*range(hours_needed_to_run)]
+                        list(range(hours_needed_to_run))
                         if hours_needed_to_run > 0
                         else [0]
                     )
@@ -641,6 +648,9 @@ class DmasPowerplantStrategy(BaseStrategy):
             for hour in last_on_hours:
                 if links[hour - 1] is None:
                     # we need to start mid day
+                    # first update the next efficient start
+                    max_hours = get_maximal_profit_hours(base_price, hour)
+
                     if all(result["power"][max_hours] > 0):
                         # pwp is on and must runtime is not reached or it is turned off and started later
                         for t in max_hours:
@@ -759,4 +769,5 @@ class DmasPowerplantStrategy(BaseStrategy):
             )
             del df["hour"]
             df["exclusive_id"] = None
+        df["unit_id"] = unit.id
         return df.to_dict("records")

--- a/tests/test_dmas_market.py
+++ b/tests/test_dmas_market.py
@@ -13,8 +13,8 @@ from assume.markets.clearing_algorithms.complex_clearing_dmas import (
     ComplexDmasClearingRole,
 )
 
-start = datetime(2020, 1, 1)
-end = datetime(2020, 12, 2)
+start = datetime(2018, 1, 1)
+end = datetime(2018, 1, 2)
 
 simple_dayahead_auction_config = MarketConfig(
     market_id="simple_dayahead_auction",
@@ -338,6 +338,114 @@ def test_use_link_order():
     assert meta[1]["demand_volume"] == 100
 
 
+def test_use_link_order2():
+    # test taking a linked order - use more expensive hour 0 to have cheaper overall dispatch.
+    next_opening = simple_dayahead_auction_config.opening_hours.after(datetime.now())
+    products = get_available_products(
+        simple_dayahead_auction_config.market_products, next_opening
+    )
+
+    start1 = products[0][0]
+    end1 = products[0][1]
+    start2 = products[1][0]
+    end2 = products[1][1]
+
+    orderbook: Orderbook = [
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": 100,
+            "price": 40,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": 50,
+            "price": 80,
+            "agent_id": "gen1",
+            "bid_id": "bid2",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": 100,
+            "price": 80,
+            "agent_id": "gen2",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": 100,
+            "price": 50,
+            "agent_id": "gen2",
+            "bid_id": "bid2",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": 10,
+            "price": 60,
+            "agent_id": "gen3",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": -100,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": -100,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+    ]
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[1]["price"] == 50
+    assert meta[0]["price"] == 40
+    assert meta[0]["supply_volume"] == 100
+    assert meta[0]["demand_volume"] == 100
+    assert meta[1]["supply_volume"] == 100
+    assert meta[1]["demand_volume"] == 100
+
+
 def test_market():
     """
     For debugging, the following might help:
@@ -424,4 +532,63 @@ def test_market():
     assert meta[0]["demand_volume"] == 500
 
 
-# [{'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 34.63333333333333, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 7'), 'bid_id': 'Unit 7_1', 'unit_id': 'Unit 7'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 25.65, 'volume': 500.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 2'), 'bid_id': 'Unit 2_1', 'unit_id': 'Unit 2'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 53.50000000000001, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 4'), 'bid_id': 'Unit 4_1', 'unit_id': 'Unit 4'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 3000.0, 'volume': -2082.7, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'eom_de'), 'bid_id': 'demand_EOM_1', 'unit_id': 'demand_EOM'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 45.05, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 3'), 'bid_id': 'Unit 3_1', 'unit_id': 'Unit 3'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 13.633333333333335, 'volume': 500.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 1'), 'bid_id': 'Unit 1_1', 'unit_id': 'Unit 1'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 43.63333333333334, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 1'), 'bid_id': 'Unit 5_1', 'unit_id': 'Unit 5'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 33.63333333333333, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 6'), 'bid_id': 'Unit 6_1', 'unit_id': 'Unit 6'}]
+def test_clearing():
+    start = datetime(2018, 1, 1, 1)
+    end = datetime(2018, 1, 2, 1)
+    products = [(start, end, None)]
+    orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": 0.2,
+            "volume": 4900,
+            "node": "DE1",
+            "block_id": None,
+            "link": None,
+            "exclusive_id": None,
+            "agent_id": ("world", "renewablesDE1"),
+            "bid_id": "renewablesDE1_wind_1",
+            "unit_id": "renewablesDE1_wind",
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": 65,  # .000505,
+            "volume": 81.0,
+            "node": "DE1",
+            "block_id": None,
+            "link": None,
+            "exclusive_id": None,
+            "agent_id": ("world", "conventionalDE1"),
+            "bid_id": "conventionalDE1_gas_34_1",
+            "unit_id": "conventionalDE1_gas_34",
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "only_hours": None,
+            "price": 1000.0,
+            "volume": -4832,
+            "node": "DE1",
+            "block_id": None,
+            "link": None,
+            "exclusive_id": None,
+            "agent_id": ("world", "demandDE1"),
+            "bid_id": "demandDE11_1",
+            "unit_id": "demandDE11",
+        },
+    ]
+
+    simple_dayahead_auction_config.maximum_bid_price = 1e9
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[0]["price"] == 0.2
+
+    # maximum_bid_price should not be too high.. Some floating point issue in pyomo..?
+    # I don't konw why this happens
+    simple_dayahead_auction_config.maximum_bid_price = 1e12
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[0]["price"] == 65

--- a/tests/test_dmas_market.py
+++ b/tests/test_dmas_market.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 from dateutil import rrule as rr
 from dateutil.relativedelta import relativedelta as rd
 
-from assume.common.market_objects import MarketConfig, MarketProduct
+from assume.common.market_objects import MarketConfig, MarketProduct, Orderbook
 from assume.common.utils import get_available_products
 from assume.markets.clearing_algorithms.complex_clearing_dmas import (
     ComplexDmasClearingRole,
@@ -18,7 +18,7 @@ end = datetime(2020, 12, 2)
 
 simple_dayahead_auction_config = MarketConfig(
     market_id="simple_dayahead_auction",
-    market_products=[MarketProduct(rd(hours=+1), 24, rd(hours=1))],
+    market_products=[MarketProduct(rd(hours=+1), 2, rd(hours=1))],
     additional_fields=["exclusive_id", "link", "block_id"],
     opening_hours=rr.rrule(
         rr.HOURLY,
@@ -38,7 +38,304 @@ def test_dmas_market_init():
     products = get_available_products(
         simple_dayahead_auction_config.market_products, next_opening
     )
-    assert len(products) == 24
+    assert len(products) == 2
+
+
+def test_insufficient_generation():
+    next_opening = simple_dayahead_auction_config.opening_hours.after(datetime.now())
+    products = get_available_products(
+        simple_dayahead_auction_config.market_products, next_opening
+    )
+
+    start = products[0][0]
+    end = products[-1][1]
+
+    orderbook: Orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 30,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 60,
+            "agent_id": "gen1",
+            "bid_id": "bid2",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": -201,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+    ]
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[0]["price"] == 60
+    assert meta[0]["supply_volume"] == 200
+    assert meta[0]["demand_volume"] == 201
+
+
+def test_remaining_generation():
+    next_opening = simple_dayahead_auction_config.opening_hours.after(datetime.now())
+    products = get_available_products(
+        simple_dayahead_auction_config.market_products, next_opening
+    )
+
+    start = products[0][0]
+    end = products[-1][1]
+
+    orderbook: Orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 30,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 60,
+            "agent_id": "gen1",
+            "bid_id": "bid2",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 50,
+            "price": 40,
+            "agent_id": "gen1",
+            "bid_id": "bid3",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 50,
+            "price": 45,
+            "agent_id": "gen1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": -200,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+    ]
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[0]["price"] == 45
+    assert meta[0]["supply_volume"] == 200
+    assert meta[0]["demand_volume"] == 200
+
+
+def test_link_order():
+    # test not taking a linked order.
+    next_opening = simple_dayahead_auction_config.opening_hours.after(datetime.now())
+    products = get_available_products(
+        simple_dayahead_auction_config.market_products, next_opening
+    )
+
+    start = products[0][0]
+    end = products[-1][1]
+
+    # cheap bid2 can not be taken, as it would require taking expensive bid1 - which would raise the price to 60 instead of 40
+    orderbook: Orderbook = [
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 60,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": 0,
+            "link": -1,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 100,
+            "price": 0,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": 1,
+            "link": 0,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 200,
+            "price": 40,
+            "agent_id": "gen1",
+            "bid_id": "bid3",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": -200,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+    ]
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    # should actually clear to 40, link orders are limited for same hour
+    assert meta[0]["price"] == 60
+    assert meta[0]["supply_volume"] == 200
+    assert meta[0]["demand_volume"] == 200
+
+
+def test_use_link_order():
+    # test taking a linked order - use more expensive hour 0 to have cheaper overall dispatch.
+    next_opening = simple_dayahead_auction_config.opening_hours.after(datetime.now())
+    products = get_available_products(
+        simple_dayahead_auction_config.market_products, next_opening
+    )
+
+    start1 = products[0][0]
+    end1 = products[0][1]
+    start2 = products[1][0]
+    end2 = products[1][1]
+
+    orderbook: Orderbook = [
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": 100,
+            "price": 60,
+            "agent_id": "gen1",
+            "bid_id": "bid1",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": 0,
+            "link": -1,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": 100,
+            "price": 0,
+            "agent_id": "gen1",
+            "bid_id": "bid2",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": 1,
+            "link": 0,
+        },
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": 100,
+            "price": 40,
+            "agent_id": "gen1",
+            "bid_id": "bid3",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": 100,
+            "price": 100,
+            "agent_id": "gen1",
+            "bid_id": "bid3",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start1,
+            "end_time": end1,
+            "volume": -100,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start2,
+            "end_time": end2,
+            "volume": -100,
+            "price": 700,
+            "agent_id": "dem1",
+            "bid_id": "bid4",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+    ]
+    mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
+    accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
+    assert meta[1]["price"] == 0
+    assert meta[0]["price"] == 60
+    assert meta[0]["supply_volume"] == 100
+    assert meta[0]["demand_volume"] == 100
+    assert meta[1]["supply_volume"] == 100
+    assert meta[1]["demand_volume"] == 100
 
 
 def test_market():
@@ -53,19 +350,17 @@ def test_market():
     products = get_available_products(
         simple_dayahead_auction_config.market_products, next_opening
     )
-    assert len(products) == 24
 
     print(products)
     start = products[0][0]
     end = products[-1][1]
-    only_hours = products[0][2]
 
     orderbook: Orderbook = [
         {
             "start_time": start,
             "end_time": end,
-            "volume": 120,
-            "price": 120,
+            "volume": 180.0,
+            "price": 58,
             "agent_id": "gen1",
             "bid_id": "bid1",
             "only_hours": None,
@@ -76,8 +371,8 @@ def test_market():
         {
             "start_time": start,
             "end_time": end,
-            "volume": 80,
-            "price": 58,
+            "volume": 10,
+            "price": 90,
             "agent_id": "gen1",
             "bid_id": "bid2",
             "only_hours": None,
@@ -88,7 +383,19 @@ def test_market():
         {
             "start_time": start,
             "end_time": end,
-            "volume": 100,
+            "volume": 10,
+            "price": 19,
+            "agent_id": "gen1",
+            "bid_id": "bid5",
+            "only_hours": None,
+            "exclusive_id": None,
+            "block_id": None,
+            "link": None,
+        },
+        {
+            "start_time": start,
+            "end_time": end,
+            "volume": 10,
             "price": 53,
             "agent_id": "gen1",
             "bid_id": "bid3",
@@ -100,8 +407,8 @@ def test_market():
         {
             "start_time": start,
             "end_time": end,
-            "volume": -180,
-            "price": 70,
+            "volume": -500,
+            "price": 700,
             "agent_id": "dem1",
             "bid_id": "bid4",
             "only_hours": None,
@@ -112,10 +419,9 @@ def test_market():
     ]
     mr = ComplexDmasClearingRole(simple_dayahead_auction_config)
     accepted_orders, rejected_orders, meta = mr.clear(orderbook, products)
-    assert meta[0]["demand_volume"] > 0
-    assert meta[0]["price"] > 0
-    import pandas as pd
+    assert meta[0]["price"] == 90
+    assert meta[0]["supply_volume"] == 210
+    assert meta[0]["demand_volume"] == 500
 
-    print(pd.DataFrame(accepted_orders))
-    print(pd.DataFrame(rejected_orders))
-    print(meta)
+
+# [{'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 34.63333333333333, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 7'), 'bid_id': 'Unit 7_1', 'unit_id': 'Unit 7'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 25.65, 'volume': 500.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 2'), 'bid_id': 'Unit 2_1', 'unit_id': 'Unit 2'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 53.50000000000001, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 4'), 'bid_id': 'Unit 4_1', 'unit_id': 'Unit 4'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 3000.0, 'volume': -2082.7, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'eom_de'), 'bid_id': 'demand_EOM_1', 'unit_id': 'demand_EOM'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 45.05, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 3'), 'bid_id': 'Unit 3_1', 'unit_id': 'Unit 3'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 13.633333333333335, 'volume': 500.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 1'), 'bid_id': 'Unit 1_1', 'unit_id': 'Unit 1'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 43.63333333333334, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 1'), 'bid_id': 'Unit 5_1', 'unit_id': 'Unit 5'}, {'start_time': datetime.datetime(2019, 1, 1, 1, 0), 'end_time': datetime.datetime(2019, 1, 1, 2, 0), 'only_hours': None, 'price': 33.63333333333333, 'volume': 1000.0, 'link': None, 'block_id': None, 'exclusive_id': None, 'agent_id': ('world', 'Operator 6'), 'bid_id': 'Unit 6_1', 'unit_id': 'Unit 6'}]


### PR DESCRIPTION
This includes various fixes to the dMAS strategies

* use durations from market_products
* use constraints from config
* set accepted volume/price correctly
* set bid identifiers and meta correctly
* fix left out start calculation for powerplant in get_maximal_profit_hours
* use logging instead of print
* add tests to ensure correct clearing behavior

The strategies can be used in combination with the naive strategies as well as the normal pay_as_clear and pay_as_bid as well.