### PR TITLE
create docs as pdf using lualatex

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -26,6 +26,7 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.imgconverter",
     "sphinxcontrib.mermaid",
     "sphinx.ext.todo",
     "sphinx.ext.mathjax",
@@ -93,3 +94,24 @@ nbsphinx_prolog = """
 """
 
 nbsphinx_allow_errors = True
+
+# --- Latex configuration ---
+
+latex_engine = "lualatex"
+latex_elements = {
+    "fontpkg": r"""
+\setmainfont{DejaVu Serif}
+\setsansfont{DejaVu Sans}
+\setmonofont{DejaVu Sans Mono}
+""",
+    "preamble": r"""
+\usepackage[titles]{tocloft}
+\usepackage{commonunicode}
+\cftsetpnumwidth {1.25cm}\cftsetrmarg{1.5cm}
+\setlength{\cftchapnumwidth}{0.75cm}
+\setlength{\cftsecindent}{\cftchapnumwidth}
+\setlength{\cftsecnumwidth}{1.25cm}
+""",
+    "fncychap": r"\usepackage[Bjornstrup]{fncychap}",
+    "printindex": r"\footnotesize\raggedright\printindex",
+}

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -79,8 +79,8 @@ Documentation
 * :doc:`learning`
 * :doc:`learning_algorithm`
 * :doc:`buffers`
-* :doc:`assume`
 * :doc:`support_policies`
+* :doc:`assume`
 
 .. toctree::
    :hidden:
@@ -94,8 +94,8 @@ Documentation
    learning
    learning_algorithm
    buffers
-   assume
    support_policies
+   assume
 
 
 Indices and tables

--- a/docs/source/learning_algorithm.rst
+++ b/docs/source/learning_algorithm.rst
@@ -85,9 +85,9 @@ TD3 is summarized in the following picture from the others of the original paper
 
 
 The steps in the algorithm are translated to implementations in ASSUME in the following way.
-The initialization of the actors and critics is done by the :func:`assume.reinforcement_learning.MATD3.initialize_policy` function, which is called
+The initialization of the actors and critics is done by the :func:`assume.reinforcement_learning.algorithms.matd3.TD3.initialize_policy` function, which is called
 in the learning role. The replay buffer needs to be stable across different episodes, which corresponds to runs of the entire simulation, hence it needs to be detached from the
 entities of the simualtion that are killed after each episode, like the elarning role. Therefore, it is initialized independently and given to the learning role
 at the beginning of each episode. For more information regarding the buffer see :doc:`buffers`.
 
-The core of the algorithm is embodied by the :func:`assume.reinforcement_learning.MATD3.update_policy` in the learning algorithms. Here the critic and the actor are updated according to the algorithm.
+The core of the algorithm is embodied by the :func:`assume.reinforcement_learning.algorithms.matd3.TD3.update_policy` in the learning algorithms. Here the critic and the actor are updated according to the algorithm.

--- a/docs/source/market_config.rst
+++ b/docs/source/market_config.rst
@@ -6,7 +6,7 @@ Market Configurations
 =====================
 
 The market configuration allows an extensive configuration of multiple bidding options.
-A full list of configurations and explanation is given here.
+A full list of configurations and explanation of the :meth:`assume.common.market_objects.MarketConfig` is given here.
 
 
  ============================= =====================================================
@@ -51,7 +51,7 @@ Most important, the `market_products` are a list of MarketProduct objects.
 MarketProduct
 -------------
 
-Each MarketProduct contains the three informations:
+Each :meth:`assume.common.market_objects.MarketProduct` contains the three informations:
 
 - duration (a relative timedelta or recurrency rule)
 - count (how many consecutive products are available for trading)

--- a/docs/source/market_mechanism.rst
+++ b/docs/source/market_mechanism.rst
@@ -29,11 +29,15 @@ In the future, the MarketMechanism will be a class which contains the additional
 
 The available market mechanisms are the following:
 
-1. PayAsClearRole in [simple](http://localhost:8000/assume.markets.clearing_algorithms.html#module-assume.markets.clearing_algorithms.simple)
-2. PayAsBidRole in [simple](http://localhost:8000/assume.markets.clearing_algorithms.html#module-assume.markets.clearing_algorithms.simple)
-3. PayAsClearAonRole in [all_or_nothing](http://localhost:8000/assume.markets.clearing_algorithms.html#module-assume.markets.clearing_algorithms.all_or_nothing)
-4. PayAsBidAonRole in [all_or_nothing](http://localhost:8000/assume.markets.clearing_algorithms.html#module-assume.markets.clearing_algorithms.all_or_nothing)
-5. ComplexClearingRole in [complex_clearing](http://localhost:8000/assume.markets.clearing_algorithms.html#module-assume.markets.clearing_algorithms.complex_clearing)
+1. :py:meth:`assume.markets.clearing_algorithms.simple.PayAsClearRole`
+2. :py:meth:`assume.markets.clearing_algorithms.simple.PayAsBidRole`
+3. :py:meth:`assume.markets.clearing_algorithms.all_or_nothing.PayAsClearAonRole`
+4. :py:meth:`assume.markets.clearing_algorithms.all_or_nothing.PayAsBidAonRole`
+5. :py:meth:`assume.markets.clearing_algorithms.complex_clearing.ComplexClearingRole`
+6. :py:meth:`assume.markets.clearing_algorithms.complex_clearing_dmas.ComplexDmasClearingRole`
+7. :py:meth:`assume.markets.clearing_algorithms.redispatch.RedispatchMarketRole`
+8. :py:meth:`assume.markets.clearing_algorithms.nodal_pricing.NodalMarketRole`
+9. :py:meth:`assume.markets.clearing_algorithms.contracts.PayAsBidContractRole`
 
 The :code:`PayAsClearRole` performs an electricity market clearing using a pay-as-clear mechanism.
 This means that the clearing price is the highest price that is still accepted.

--- a/docs/source/scenario_loader.rst
+++ b/docs/source/scenario_loader.rst
@@ -149,7 +149,7 @@ An example configuration of how this can be used is shown here:
     world.run()
 
 This creates operators each per NUTS areas and creates a single EOM market, just as the `DMAS simulation <https://github.com/NOWUM/dmas/>`_ from FH Aachen.
-For more information consult the methods documentation :py:meth:`assume.scenario.loader_oeds.load_oeds`.
+For more information consult the methods documentation :py:meth:`assume.scenario.loader_oeds.load_oeds_async`.
 
 .. _pypsa_loader_doc:
 
@@ -167,7 +167,7 @@ An example can be seen from the pypsa scigrid case:
 
 .. code-block:: python
 
-    from assume.scenario.loader_pypsa import load_pypsa
+    from assume.scenario.loader_pypsa import load_pypsa_async
     from assume import World
     import pypsa
 
@@ -211,4 +211,4 @@ An example can be seen from the pypsa scigrid case:
 
 You can also create and use your own existing scenarios in pypsa format to convert these into a market simulation too.
 
-For more information consult the methods documentation :py:meth:`assume.scenario.loader_pypsa.load_pypsa`.
+For more information consult the methods documentation :py:meth:`assume.scenario.loader_pypsa.load_pypsa_async`.

--- a/docs/source/support_policies.rst
+++ b/docs/source/support_policies.rst
@@ -13,6 +13,8 @@ One can differentiate between support policies which influence the available mar
 
 If the product_type is `energy`, the volume used for the contract can not be additionally bid on the EOM.
 
+All the support policies are only available when using a Market with the MarketMechanism :meth:`assume.markets.clearing_algorithms.contracts.PayAsBidContractRole`
+
 
 Example Policies
 =====================================
@@ -61,7 +63,7 @@ It allows to influence the financial flow of plants which would not be profitabl
 Contract for Differences - CfD
 ------------------------------
 
-A fixed LCoE is set as a price, if an Agent accepts the CfD contract,
+A fixed LCoE (Levelized Cost of Energy) is set as a price, if an Agent accepts the CfD contract,
 it has to bid at the hourly EOM - the difference of the market result is paid/received to/from the contractor.
 
 


### PR DESCRIPTION
If you have `lualatex` and `inkscape` (for svg to pdf conversion) installed, you can create a pdf handbook version of the ASSUME documentation using:

`make -C docs latexpdf`

I don't think this will ever be printed, therefore the HTML version is probably much easier to use, though I tinkered with Sphinx last weekend and want to have this config in main too.

The current documentation for Assume 0.3.7 from this PR looks like this:
[assume.pdf](https://github.com/assume-framework/assume/files/15220223/assume.pdf)
