### PR TITLE
Restructure setting obs and act observations and return unique observations

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -746,13 +746,20 @@ class LearningStrategy(BaseStrategy):
         **kwargs (dict): The keyword arguments.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(
+        self, obs_dim: int, act_dim: int, unique_obs_dim: int = 0, *args, **kwargs
+    ):
         """
         Initializes the learning strategy.
         """
         super().__init__(*args, **kwargs)
-        self.obs_dim = kwargs.get("observation_dimension", 50)
-        self.act_dim = kwargs.get("action_dimension", 2)
+
+        self.obs_dim = obs_dim
+        self.act_dim = act_dim
+
+        # this defines the number of unique observations, which are not the same for all units
+        # this is used by the centralised critic and will return an error if not matched
+        self.unique_obs_dim = unique_obs_dim
 
 
 class LearningConfig(TypedDict):
@@ -760,8 +767,6 @@ class LearningConfig(TypedDict):
     A class for the learning configuration.
     """
 
-    observation_dimension: int
-    action_dimension: int
     continue_learning: bool
     max_bid_price: float
     learning_mode: bool

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -737,9 +737,15 @@ class LearningStrategy(BaseStrategy):
     """
     A strategy which provides learning functionality, has a method to calculate the reward.
 
+    It is important to keep in mind, that the DRL method and the centralized critic relies on
+    unique observations of individual units. The algorithm is designed in such a way, that
+    the unique observations are always placed at the end of the observation space. Please follow this
+    convention when designing your create_observation method and the observation space.
+
     Attributes:
         obs_dim (int): The observation dimension.
         act_dim (int): The action dimension.
+        unique_obs_dim (int): The unique observation dimension.
 
     Args:
         *args (list): The arguments.

--- a/assume/reinforcement_learning/algorithms/base_algorithm.py
+++ b/assume/reinforcement_learning/algorithms/base_algorithm.py
@@ -57,13 +57,8 @@ class RLAlgorithm:
         self.target_noise_clip = target_noise_clip
         self.target_policy_noise = target_policy_noise
 
-        self.obs_dim = self.learning_role.obs_dim
-        self.act_dim = self.learning_role.act_dim
-
         self.device = self.learning_role.device
         self.float_type = self.learning_role.float_type
-
-        self.unique_obs_len = 8
 
     def update_policy(self):
         logger.error(

--- a/assume/reinforcement_learning/algorithms/matd3.py
+++ b/assume/reinforcement_learning/algorithms/matd3.py
@@ -424,6 +424,8 @@ class TD3(RLAlgorithm):
 
                 all_actions = actions.view(self.batch_size, -1)
 
+                # this takes the unique observations from all other agents assuming that
+                # the unique observations are at the end of the observation vector
                 temp = th.cat(
                     (
                         states[:, :i, self.obs_dim - self.unique_obs_dim :].reshape(
@@ -436,11 +438,14 @@ class TD3(RLAlgorithm):
                     axis=1,
                 )
 
+                # the final all_states vector now contains the current agent's observation
+                # and the unique observations from all other agents
                 all_states = th.cat(
                     (states[:, i, :].reshape(self.batch_size, -1), temp), axis=1
                 ).view(self.batch_size, -1)
                 # all_states = states[:, i, :].reshape(self.batch_size, -1)
 
+                # this is the same as above but for the next states
                 temp = th.cat(
                     (
                         next_states[
@@ -453,6 +458,8 @@ class TD3(RLAlgorithm):
                     axis=1,
                 )
 
+                # the final all_next_states vector now contains the current agent's observation
+                # and the unique observations from all other agents
                 all_next_states = th.cat(
                     (next_states[:, i, :].reshape(self.batch_size, -1), temp), axis=1
                 ).view(self.batch_size, -1)

--- a/assume/reinforcement_learning/algorithms/matd3.py
+++ b/assume/reinforcement_learning/algorithms/matd3.py
@@ -232,6 +232,11 @@ class TD3(RLAlgorithm):
         The actors are designed to map observations to action probabilities in a reinforcement learning setting.
 
         The created actor networks are associated with each unit strategy and stored as attributes.
+
+        Notes:
+            The observation dimension need to be the same, due to the centralized criic that all actors share.
+            If you have units with different observation dimensions. They need to have different critics and hence learning roles.
+
         """
 
         obs_dim_list = []
@@ -276,6 +281,10 @@ class TD3(RLAlgorithm):
         Create critic networks for reinforcement learning.
 
         This method initializes critic networks for each agent in the reinforcement learning setup.
+
+        Notes:
+            The observation dimension need to be the same, due to the centralized criic that all actors share.
+            If you have units with different observation dimensions. They need to have different critics and hence learning roles.
         """
         n_agents = len(self.learning_role.rl_strats)
         strategy: LearningStrategy

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -43,8 +43,6 @@ class Learning(Role):
 
         # how many learning roles do exist and how are they named
         self.buffer: ReplayBuffer = None
-        self.obs_dim = learning_config["observation_dimension"]
-        self.act_dim = learning_config["action_dimension"]
         self.episodes_done = 0
         self.rl_strats: dict[int, LearningStrategy] = {}
         self.rl_algorithm = learning_config["algorithm"]

--- a/assume/reinforcement_learning/learning_utils.py
+++ b/assume/reinforcement_learning/learning_utils.py
@@ -35,36 +35,36 @@ class CriticTD3(nn.Module):
         obs_dim: int,
         act_dim: int,
         float_type,
-        unique_obs_len: int = 16,
+        unique_obs_dim: int = 0,
     ):
         super(CriticTD3, self).__init__()
 
-        self.obs_dim = obs_dim  # + unique_obs_len * (n_agents - 1)
+        self.obs_dim = obs_dim + unique_obs_dim * (n_agents - 1)
         self.act_dim = act_dim * n_agents
 
         # Q1 architecture
-        # if n_agents <= 50:
-        self.FC1_1 = nn.Linear(self.obs_dim + self.act_dim, 512, dtype=float_type)
-        self.FC1_2 = nn.Linear(512, 256, dtype=float_type)
-        self.FC1_3 = nn.Linear(256, 128, dtype=float_type)
-        self.FC1_4 = nn.Linear(128, 1, dtype=float_type)
-        # else:
-        #     self.FC1_1 = nn.Linear(self.obs_dim + self.act_dim, 1024, dtype = float_type)
-        #     self.FC1_2 = nn.Linear(1024, 512, dtype = float_type)
-        #     self.FC1_3 = nn.Linear(512, 128, dtype = float_type)
-        #     self.FC1_4 = nn.Linear(128, 1, dtype = float_type)
+        if n_agents <= 50:
+            self.FC1_1 = nn.Linear(self.obs_dim + self.act_dim, 512, dtype=float_type)
+            self.FC1_2 = nn.Linear(512, 256, dtype=float_type)
+            self.FC1_3 = nn.Linear(256, 128, dtype=float_type)
+            self.FC1_4 = nn.Linear(128, 1, dtype=float_type)
+        else:
+            self.FC1_1 = nn.Linear(self.obs_dim + self.act_dim, 1024, dtype=float_type)
+            self.FC1_2 = nn.Linear(1024, 512, dtype=float_type)
+            self.FC1_3 = nn.Linear(512, 128, dtype=float_type)
+            self.FC1_4 = nn.Linear(128, 1, dtype=float_type)
 
         # Q2 architecture
-        # if n_agents <= 50:
-        self.FC2_1 = nn.Linear(self.obs_dim + self.act_dim, 512, dtype=float_type)
-        self.FC2_2 = nn.Linear(512, 256, dtype=float_type)
-        self.FC2_3 = nn.Linear(256, 128, dtype=float_type)
-        self.FC2_4 = nn.Linear(128, 1, dtype=float_type)
-        # else:
-        #     self.FC2_1 = nn.Linear(self.obs_dim + self.act_dim, 1024, dtype = float_type)
-        #     self.FC2_2 = nn.Linear(1024, 512, dtype = float_type)
-        #     self.FC2_3 = nn.Linear(512, 128, dtype = float_type)
-        #     self.FC2_4 = nn.Linear(128, 1, dtype = float_type)
+        if n_agents <= 50:
+            self.FC2_1 = nn.Linear(self.obs_dim + self.act_dim, 512, dtype=float_type)
+            self.FC2_2 = nn.Linear(512, 256, dtype=float_type)
+            self.FC2_3 = nn.Linear(256, 128, dtype=float_type)
+            self.FC2_4 = nn.Linear(128, 1, dtype=float_type)
+        else:
+            self.FC2_1 = nn.Linear(self.obs_dim + self.act_dim, 1024, dtype=float_type)
+            self.FC2_2 = nn.Linear(1024, 512, dtype=float_type)
+            self.FC2_3 = nn.Linear(512, 128, dtype=float_type)
+            self.FC2_4 = nn.Linear(128, 1, dtype=float_type)
 
     def forward(self, obs, actions):
         """

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -712,15 +712,18 @@ def run_learning(
     temp_csv_path = world.export_csv_path
     world.export_csv_path = ""
 
+    # initialize policies already here to set the obs_dim and act_dim in the learning role
+    actors_and_critics = None
+    world.learning_role.initialize_policy(actors_and_critics=actors_and_critics)
+
     buffer = ReplayBuffer(
         buffer_size=int(world.learning_config.get("replay_buffer_size", 5e5)),
-        obs_dim=world.learning_role.obs_dim,
-        act_dim=world.learning_role.act_dim,
+        obs_dim=world.learning_role.rl_algorithm.obs_dim,
+        act_dim=world.learning_role.rl_algorithm.act_dim,
         n_rl_units=len(world.learning_role.rl_strats),
         device=world.learning_role.device,
         float_type=world.learning_role.float_type,
     )
-    actors_and_critics = None
     world.output_role.del_similar_runs()
 
     validation_interval = min(

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -51,7 +51,7 @@ class RLAdvancedOrderStrategy(LearningStrategy):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(obs_dim=51, act_dim=2, unique_obs_dim=3, *args, **kwargs)
 
         self.unit_id = kwargs["unit_id"]
 

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -333,6 +333,11 @@ class RLAdvancedOrderStrategy(LearningStrategy):
         """
         Create observation.
 
+        It is important to keep in mind, that the DRL method and the centralized critic relies on
+        unique observation of individual units. The algorithm is designed in such a way, that
+        the unique observations are always placed at the end of the observation space. Please follow this
+        convention when adding new observations.
+
         Args:
             unit (SupportsMinMax): Unit to create observation for
             start (datetime.datetime): Start time

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -254,6 +254,11 @@ class RLStrategy(LearningStrategy):
         """
         Creates an observation.
 
+        It is important to keep in mind, that the DRL method and the centralized critic relies on
+        unique observation of individual units. The algorithm is designed in such a way, that
+        the unique observations are always placed at the end of the observation space. Please follow this
+        convention when adding new observations.
+
         Args:
             unit (SupportsMinMax): Unit to create observation for.
             start (datetime.datetime): Start time.

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -25,6 +25,10 @@ class RLStrategy(LearningStrategy):
     The agent submittes two price bids
     - one for the infelxible (P_min) and one for the flexible part (P_max-P_min) of ist capacity.
 
+    This strategy utilizes a total of 50 observations, which are used to calculate the actions.
+    The actions are then transformed into bids. Actions are formulated as 2 values.
+    The unique observation space is 2 comprising of marginal cost and current capacity.
+
     Attributes:
         foresight (int): Number of time steps to look ahead. Defaults to 24.
         max_bid_price (float): Maximum bid price. Defaults to 100.
@@ -43,7 +47,7 @@ class RLStrategy(LearningStrategy):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+        super().__init__(obs_dim=50, act_dim=2, unique_obs_dim=2, *args, **kwargs)
 
         self.unit_id = kwargs["unit_id"]
 

--- a/assume/world.py
+++ b/assume/world.py
@@ -411,7 +411,7 @@ class World:
 
                     # if we have learning strategy we need to assign the powerplant to one  unit_operator handling all leanring units
                     if unit_operator_id != "Operator-RL":
-                        self.logger.warning(
+                        self.logger.debug(
                             f"Your chosen unit-operator {unit_operator_id} for the learning unit {id} was overwritten with 'Operator-RL', since all learning units need to be handeled by one unit operator."
                         )
 

--- a/docs/source/learning_algorithm.rst
+++ b/docs/source/learning_algorithm.rst
@@ -28,8 +28,6 @@ The following table shows the options that can be adjusted and gives a short exp
  ======================================== ==========================================================================================================
   learning config item                    description
  ======================================== ==========================================================================================================
-  observation_dimension                   The dimension of the observations given to the actor in the bidding strategy.
-  action_dimension                        The dimension of the actors made by the actor, which equals the output neurons of the actor neural net.
   continue_learning                       Whether to use pre-learned strategies and then continue learning.
   trained_policies_save_path              Where to store the newly trained rl strategies - only needed when learning_mode is set
   trained_policies_load_path              If pre-learned strategies should be used, where are they stored? - only needed when continue_learning

--- a/examples/inputs/example_02a/config.yaml
+++ b/examples/inputs/example_02a/config.yaml
@@ -10,8 +10,6 @@ tiny:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 50
-    action_dimension: 2
     continue_learning: False
     trained_policies_save_path: null
     max_bid_price: 100
@@ -55,8 +53,6 @@ base:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 50
-    action_dimension: 2
     continue_learning: False
     trained_policies_save_path: null
     max_bid_price: 100
@@ -99,8 +95,6 @@ tiny:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 50
-    action_dimension: 2
     continue_learning: False
     trained_policies_save_path: null
     trained_policies_load_path: "./learned_strategies/example_02a_tiny/avg_reward"

--- a/examples/inputs/example_02b/config.yaml
+++ b/examples/inputs/example_02b/config.yaml
@@ -10,8 +10,6 @@ base:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 50
-    action_dimension: 2
     continue_learning: False
     trained_policies_save_path: learned_strategies/example_02b_base
     max_bid_price: 100

--- a/examples/inputs/example_02c/config.yaml
+++ b/examples/inputs/example_02c/config.yaml
@@ -10,8 +10,6 @@ dam:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 97
-    action_dimension: 2
     continue_learning: False
     trained_policies_save_path: null
     max_bid_price: 200
@@ -60,8 +58,6 @@ tiny:
   learning_mode: True
 
   learning_config:
-    observation_dimension: 50
-    action_dimension: 2
     continue_learning: True
     trained_policies_save_path: null
     max_bid_price: 100

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -1152,8 +1152,6 @@
    "outputs": [],
    "source": [
     "learning_config = {\n",
-    "    \"observation_dimension\": 50,\n",
-    "    \"action_dimension\": 2,\n",
     "    \"continue_learning\": False,\n",
     "    \"trained_policies_save_path\": \"None\",\n",
     "    \"max_bid_price\": 100,\n",

--- a/tests/test_learning_role.py
+++ b/tests/test_learning_role.py
@@ -24,8 +24,9 @@ end = datetime(2023, 7, 2)
 @pytest.mark.require_learning
 def test_learning_init():
     learning_config: LearningConfig = {
-        "observation_dimension": 3,
-        "action_dimension": 2,
+        "obs_dim": 3,
+        "act_dim": 2,
+        "unique_obs_dim": 0,
         "algorithm": "matd3",
         "learning_mode": False,
         "training_episodes": 3,

--- a/tests/test_rl_advanced_order_strategy.py
+++ b/tests/test_rl_advanced_order_strategy.py
@@ -44,8 +44,6 @@ def power_plant() -> PowerPlant:
 @pytest.mark.require_learning
 def test_learning_advanced_orders(mock_market_config, power_plant):
     learning_config: LearningConfig = {
-        "observation_dimension": 97,
-        "action_dimension": 2,
         "algorithm": "matd3",
         "learning_mode": True,
         "training_episodes": 3,

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -121,8 +121,6 @@ async def test_write_learning_params(units_operator: UnitsOperator):
             "EOM": RLAdvancedOrderStrategy(
                 unit_id="testplant",
                 learning_mode=True,
-                observation_dimension=2 + 2 * 23 + 3,
-                action_dimension=2,
             )
         },
         "technology": "energy",


### PR DESCRIPTION
-set obs_dim and act_dim as properties of bidding startegies
-remove these values from configs
-set them as fixed values in startegies
-learning role checks if all strategies have the same dimensions -raise an error if not the same dimensions
-include unique observations in the critic