### PR TITLE
Speed up simulation

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 from typing import TypedDict, Union
 
+import numpy as np
 import pandas as pd
 
 from assume.common.forecasts import Forecaster
@@ -176,14 +177,20 @@ class BaseUnit:
             start (datetime.datetime): The start time for the calculation.
             end (datetime.datetime): The end time for the calculation.
             product_type (str): The type of product for which the generation cost is to be calculated.
-
         """
-        if start not in self.index:
-            start = self.index[0]
+        if end != self.index[-1]:
+            return  # do nothing before the end of the simulation
+
+        start = self.index[0]
+
         product_type_mc = product_type + "_marginal_costs"
-        for t in self.outputs[product_type_mc][start:end].index:
-            mc = self.calculate_marginal_cost(t, self.outputs[product_type].loc[t])
-            self.outputs[product_type_mc][t] = abs(mc * self.outputs[product_type][t])
+        product_data = self.outputs[product_type].loc[start:end]
+
+        marginal_costs = product_data.index.map(
+            lambda t: self.calculate_marginal_cost(t, product_data.loc[t])
+        )
+        new_values = np.abs(marginal_costs * product_data.values)
+        self.outputs[product_type_mc].loc[start:end] = new_values
 
     def execute_current_dispatch(
         self,

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -107,7 +107,7 @@ def test_calculate_bids(base_unit, mock_market_config):
     # mock calculate_marginal_cost
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
-    base_unit.calculate_generation_cost(index[0], index[1], "energy")
+    base_unit.calculate_generation_cost(index[0], index[-1], "energy")
 
     # we apply the dispatch plan of 10 MW
     assert base_unit.outputs["energy"][start] == 10
@@ -117,7 +117,7 @@ def test_calculate_bids(base_unit, mock_market_config):
 
     # we somehow sold an additional 10 MW
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
-    base_unit.calculate_generation_cost(index[0], index[1], "energy")
+    base_unit.calculate_generation_cost(index[0], index[-1], "energy")
 
     # the final output should be 10+10
     assert base_unit.outputs["energy"][start] == 20
@@ -153,7 +153,7 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     # mock calculate_marginal_cost
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
-    base_unit.calculate_generation_cost(index[0], index[1], "energy")
+    base_unit.calculate_generation_cost(index[0], index[-1], "energy")
 
     assert base_unit.outputs["energy"][index[0]] == 10
     assert base_unit.outputs["energy_marginal_costs"][index[0]] == 100
@@ -163,7 +163,7 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     assert base_unit.outputs["energy_cashflow"][index[1]] == 110
 
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
-    base_unit.calculate_generation_cost(index[0], index[1], "energy")
+    base_unit.calculate_generation_cost(index[0], index[-1], "energy")
 
     # should be correctly applied for the sum, even if different hours are applied
     assert base_unit.outputs["energy"][index[0]] == 20


### PR DESCRIPTION
-refactor the function itself to use vectorization
-execute the funtion only once at the end of the simulation
-paralellize the call for all agents to improve performance

suggestion by @maurerle


The speed up is as follows (tested on small example):
current version - 24s
vectorized calculate_generation_cost function - 16s
execute calculation only at the end of the simulation - 8s

Using the small_learning_1 example:
current version - 36s
final tweaked version - 10s