### PR TITLE
This fixes the loading of actors

### DIFF
--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import copy
 import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
@@ -403,6 +404,8 @@ async def async_setup_world(
         ValueError: If the specified scenario or study case is not found in the provided inputs.
 
     """
+    # make a deep copy of the scenario data to avoid changing the original data
+    scenario_data = copy.deepcopy(scenario_data)
 
     sim_id = scenario_data["sim_id"]
     config = scenario_data["config"]
@@ -427,9 +430,12 @@ async def async_setup_world(
         learning_config["perform_evaluation"] = False
 
     if not learning_config.get("trained_policies_save_path"):
-        learning_config[
-            "trained_policies_save_path"
-        ] = f"learned_strategies/{study_case}"
+        if learning_config["learning_mode"]:
+            path = f"learned_strategies/{study_case}/"
+        else:
+            path = f"learned_strategies/{study_case}/last_policies/"
+
+        learning_config["trained_policies_save_path"] = path
 
     config = replace_paths(config, scenario_data["path"])
 

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -78,8 +78,7 @@ class RLAdvancedOrderStrategy(LearningStrategy):
         # define allowed order types
         self.order_types = kwargs.get("order_types", ["SB"])
 
-        if self.learning_mode:
-            self.learning_role = None
+        if self.learning_mode or self.perform_evaluation:
             self.collect_initial_experience_mode = kwargs.get(
                 "episodes_collecting_initial_experience", True
             )
@@ -94,6 +93,10 @@ class RLAdvancedOrderStrategy(LearningStrategy):
 
         elif Path(kwargs["trained_policies_save_path"]).is_dir():
             self.load_actor_params(load_path=kwargs["trained_policies_save_path"])
+        else:
+            raise FileNotFoundError(
+                f"No policies were provided for DRL unit {self.unit_id}!. Please provide a valid path to the trained policies."
+            )
 
     def calculate_bids(
         self,

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -91,7 +91,9 @@ class RLStrategy(LearningStrategy):
         elif Path(kwargs["trained_policies_save_path"]).is_dir():
             self.load_actor_params(load_path=kwargs["trained_policies_save_path"])
         else:
-            logger.error("did not have learning mode and folder did not exist")
+            raise FileNotFoundError(
+                f"No policies were provided for DRL unit {self.unit_id}!. Please provide a valid path to the trained policies."
+            )
 
     def calculate_bids(
         self,
@@ -462,7 +464,7 @@ class RLStrategy(LearningStrategy):
         Args:
             load_path (str): Path to load from.
         """
-        directory = f"{load_path}/last_policies/actors/actor_{self.unit_id}.pt"
+        directory = f"{load_path}/actors/actor_{self.unit_id}.pt"
 
         params = th.load(directory, map_location=self.device)
 


### PR DESCRIPTION
-screate a deepcopy of the scenario data to avoid changing it during the simulation 
-load last_policies by default if not policies are specified 
-raise an error if RL policy is selected but no policies are provided and learning is deactivated