### PR TITLE
switch to ruff for linting

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -41,11 +41,11 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install -e .[test]
         python -m pip install pyomo
-    - name: Lint with black and isort
+    - name: Lint with ruff
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        black --check assume examples tests
-        isort --check assume examples tests
+        ruff check assume examples tests
+        ruff format assume examples tests
     - name: Test with pytest & integration tests
       run: |
         pytest -m "not require_learning"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,15 @@ repos:
       - id: reuse
         args: ["annotate", "--license", "AGPL-3.0-or-later", "--recursive", "--copyright", "ASSUME Developers", "--exclude-year", "--skip-unrecognised", "."]
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    # Ruff version.
+    rev: v0.4.9
     hooks:
-      - id: isort
-
-  - repo: https://github.com/psf/black
-    rev: 23.3.0
-    hooks:
-      - id: black
-
+      # Run the linter.
+      - id: ruff
+        args: [ --fix ]
+      # Run the formatter.
+      - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0
     hooks:

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -284,19 +284,6 @@ class BaseUnit:
         """
         return 0
 
-    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
-        """
-        Calculates the marginal cost for the given power.
-
-        Args:
-            start (pandas.Timestamp): The start time of the dispatch.
-            power (float): The power output of the unit.
-
-        Returns:
-            float: The marginal cost for the given power.
-        """
-        pass
-
 
 class SupportsMinMax(BaseUnit):
     """
@@ -327,7 +314,6 @@ class SupportsMinMax(BaseUnit):
         Returns:
             tuple[pandas.Series, pandas.Series]: The min and max power for the given time period.
         """
-        pass
 
     def calculate_ramp(
         self,
@@ -529,7 +515,6 @@ class SupportsMinMaxCharge(BaseUnit):
         Returns:
             tuple[pandas.Series, pandas.Series]: The min and max charging power for the given time period.
         """
-        pass
 
     def calculate_min_max_discharge(
         self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
@@ -545,7 +530,6 @@ class SupportsMinMaxCharge(BaseUnit):
         Returns:
             tuple[pandas.Series, pandas.Series]: The min and max discharging power for the given time period.
         """
-        pass
 
     def get_soc_before(self, dt: datetime) -> float:
         """
@@ -599,7 +583,7 @@ class SupportsMinMaxCharge(BaseUnit):
             return power_discharge
 
         # if storage was charging before and ramping for charging is defined
-        if previous_power < 0 and self.ramp_down_charge != None:
+        if previous_power < 0 and self.ramp_down_charge is not None:
             power_discharge = max(
                 previous_power - self.ramp_down_charge - current_power, 0
             )
@@ -612,7 +596,7 @@ class SupportsMinMaxCharge(BaseUnit):
                 max(0, previous_power + self.ramp_up_discharge - current_power),
             )
             # restrict only if ramping defined
-            if self.ramp_down_discharge != None:
+            if self.ramp_down_discharge is not None:
                 power_discharge = max(
                     power_discharge,
                     previous_power - self.ramp_down_discharge - current_power,
@@ -710,7 +694,6 @@ class BaseStrategy:
             marketconfig (MarketConfig): The market configuration.
             orderbook (Orderbook): The orderbook.
         """
-        pass
 
     def remove_empty_bids(self, bids: list) -> list:
         """

--- a/assume/common/forecasts.py
+++ b/assume/common/forecasts.py
@@ -204,14 +204,14 @@ class CsvForecaster(Forecaster):
                 continue
 
             if f"price_{market_id}" not in self.forecasts.columns:
-                self.forecasts[
-                    f"price_{market_id}"
-                ] = self.calculate_market_price_forecast(market_id=market_id)
+                self.forecasts[f"price_{market_id}"] = (
+                    self.calculate_market_price_forecast(market_id=market_id)
+                )
 
             if f"residual_load_{market_id}" not in self.forecasts.columns:
-                self.forecasts[
-                    f"residual_load_{market_id}"
-                ] = self.calculate_residual_load_forecast(market_id=market_id)
+                self.forecasts[f"residual_load_{market_id}"] = (
+                    self.calculate_residual_load_forecast(market_id=market_id)
+                )
 
     def get_registered_market_participants(self, market_id):
         """
@@ -228,7 +228,7 @@ class CsvForecaster(Forecaster):
 
         """
 
-        self.logger.warn(
+        self.logger.warning(
             "Functionality of using the different markets and specified registration for the price forecast is not implemented yet"
         )
         return self.powerplants_units

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import asyncio
 import logging
 import shutil
 from collections import defaultdict
@@ -557,7 +556,7 @@ class WriteOutput(Role):
 
         if self.db is not None and not df.empty:
             with self.db.begin() as db:
-                df.to_sql("kpis", self.db, if_exists="append", index=None)
+                df.to_sql("kpis", db, if_exists="append", index=None)
 
     def get_sum_reward(self):
         """

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -175,7 +175,7 @@ class UnitsOperator(Role):
                 "sender_id": self.context.aid,
                 "reply_with": market.market_id,
             },
-        ),
+        )
         logger.debug(f"{self.id} sent market registration to {market.market_id}")
 
     def handle_opening(self, opening: OpeningMessage, meta: MetaDict) -> None:

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -228,7 +228,6 @@ def visualize_orderbook(order_book: Orderbook):
 
         for j, o in groupby(bids_grouped, itemgetter("link")):
             s = pd.Series(0.0, index=start_times)
-            ys = np.zeros(24)
             o = list(o)
             for order in o:
                 s[order["start_time"]] += order["volume"]
@@ -299,7 +298,7 @@ def aggregate_step_amount(orderbook: Orderbook, begin=None, end=None, groupby=No
                 end = date + timedelta(hours=duration_hours)
                 deltas.append((start, bid["volume"]) + add)
                 deltas.append((end, -bid["volume"]) + add)
-    aggregation = defaultdict(lambda: [])
+    aggregation = defaultdict(list)
     # current_power is separated by group
     current_power = defaultdict(lambda: 0)
     for d_tuple in sorted(deltas, key=lambda i: i[0]):

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -4,7 +4,6 @@
 
 import logging
 import math
-from datetime import datetime
 from itertools import groupby
 from operator import itemgetter
 
@@ -333,7 +332,7 @@ class MarketRole(MarketMechanism, Role):
             next_opening_ts = datetime2timestamp(next_opening)
             self.context.schedule_timestamp_task(self.opening(), next_opening_ts)
             logger.debug(
-                f"market opening: %s - %s - %s",
+                "market opening: %s - %s - %s",
                 self.marketconfig.market_id,
                 market_open,
                 market_closing,

--- a/assume/markets/clearing_algorithms/complex_clearing_dmas.py
+++ b/assume/markets/clearing_algorithms/complex_clearing_dmas.py
@@ -5,7 +5,6 @@
 import logging
 import time
 from collections import defaultdict
-from datetime import timedelta
 
 import numpy as np
 import pandas as pd
@@ -186,7 +185,7 @@ class ComplexDmasClearingRole(MarketRole):
         # Step 6 set constraint: If parent block of an agent is used -> enable usage of child block
         model.enable_child_block = ConstraintList()
         model.mother_bid = ConstraintList()
-        orders_local = defaultdict(lambda: [])
+        orders_local = defaultdict(list)
         for block, hour, agent in orders["linked_ask"].keys():
             orders_local[(block, agent)].append(hour)
 

--- a/assume/markets/clearing_algorithms/contracts.py
+++ b/assume/markets/clearing_algorithms/contracts.py
@@ -4,7 +4,7 @@
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime
 from itertools import groupby
 from operator import itemgetter
 from typing import Callable
@@ -16,7 +16,6 @@ from dateutil.relativedelta import relativedelta as rd
 from assume.common.market_objects import (
     ClearingMessage,
     MarketConfig,
-    MarketProduct,
     MetaDict,
     Order,
     Orderbook,

--- a/assume/reinforcement_learning/algorithms/base_algorithm.py
+++ b/assume/reinforcement_learning/algorithms/base_algorithm.py
@@ -84,4 +84,3 @@ class RLAlgorithm:
         """
         Load learning params - abstract method to be implemented by the Learning Algorithm
         """
-        pass

--- a/assume/reinforcement_learning/algorithms/matd3.py
+++ b/assume/reinforcement_learning/algorithms/matd3.py
@@ -9,11 +9,11 @@ import torch as th
 from torch.nn import functional as F
 from torch.optim import Adam
 
-logger = logging.getLogger(__name__)
-
 from assume.common.base import LearningStrategy
 from assume.reinforcement_learning.algorithms.base_algorithm import RLAlgorithm
 from assume.reinforcement_learning.learning_utils import Actor, CriticTD3, polyak_update
+
+logger = logging.getLogger(__name__)
 
 
 class TD3(RLAlgorithm):
@@ -383,7 +383,7 @@ class TD3(RLAlgorithm):
             This function implements the TD3 algorithm's key step for policy improvement and exploration.
         """
 
-        logger.debug(f"Updating Policy")
+        logger.debug("Updating Policy")
         n_rl_agents = len(self.learning_role.rl_strats.keys())
         for _ in range(self.gradient_steps):
             self.n_updates += 1

--- a/assume/reinforcement_learning/learning_utils.py
+++ b/assume/reinforcement_learning/learning_utils.py
@@ -37,7 +37,7 @@ class CriticTD3(nn.Module):
         float_type,
         unique_obs_dim: int = 0,
     ):
-        super(CriticTD3, self).__init__()
+        super().__init__()
 
         self.obs_dim = obs_dim + unique_obs_dim * (n_agents - 1)
         self.act_dim = act_dim * n_agents
@@ -110,7 +110,7 @@ class Actor(nn.Module):
     """
 
     def __init__(self, obs_dim: int, act_dim: int, float_type):
-        super(Actor, self).__init__()
+        super().__init__()
 
         self.FC1 = nn.Linear(obs_dim, 256, dtype=float_type)
         self.FC2 = nn.Linear(256, 128, dtype=float_type)

--- a/assume/scenario/loader_amiris.py
+++ b/assume/scenario/loader_amiris.py
@@ -514,7 +514,7 @@ async def load_amiris_async(
         "MeritOrderForecaster",
     ]
     agents_sorted = sorted(
-        amiris_scenario["Agents"], key=lambda agent: keyorder.index((agent["Type"]))
+        amiris_scenario["Agents"], key=lambda agent: keyorder.index(agent["Type"])
     )
     for agent in agents_sorted:
         add_agent_to_world(

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -297,7 +297,7 @@ def load_config_and_create_forecaster(
     """
 
     path = f"{inputs_path}/{scenario}"
-    with open(f"{path}/config.yaml", "r") as f:
+    with open(f"{path}/config.yaml") as f:
         config = yaml.safe_load(f)
     if not study_case:
         study_case = list(config.keys())[0]
@@ -499,7 +499,7 @@ async def async_setup_world(
         )
 
     # add central RL unit operator that handels all RL units
-    if world.learning_mode == True and "Operator-RL" not in all_operators:
+    if world.learning_mode and "Operator-RL" not in all_operators:
         all_operators = np.concatenate([all_operators, ["Operator-RL"]])
 
     for company_name in set(all_operators):

--- a/assume/scenario/loader_oeds.py
+++ b/assume/scenario/loader_oeds.py
@@ -86,7 +86,7 @@ async def load_oeds_async(
         log.info(f"loading config {area} for {year}")
         config_path = Path.home() / ".assume" / f"{area}_{year}"
         if not config_path.is_dir():
-            log.info(f"query database time series")
+            log.info("query database time series")
             demand = infra_interface.get_demand_series_in_area(area, year)
             demand = demand.resample("h").mean()
             # demand in MW

--- a/assume/scenario/oeds/infrastructure.py
+++ b/assume/scenario/oeds/infrastructure.py
@@ -925,7 +925,7 @@ if __name__ == "__main__":
         with open("../agents.json", "w") as f:
             json.dump(agents, f, indent=2)
     else:
-        with open("../agents.json", "r") as f:
+        with open("../agents.json") as f:
             agents = json.load(f)
 
     dem = interface.get_demand_in_area(area="DE91C")

--- a/assume/strategies/dmas_powerplant.py
+++ b/assume/strategies/dmas_powerplant.py
@@ -12,7 +12,6 @@ from pyomo.environ import (
     ConcreteModel,
     Constraint,
     ConstraintList,
-    NonNegativeReals,
     Objective,
     Reals,
     Var,

--- a/assume/strategies/dmas_storage.py
+++ b/assume/strategies/dmas_storage.py
@@ -34,9 +34,8 @@ def shift(prc, type_: str = "first"):
       np.array: shifted price curve
 
     """
-    new_prices, num_prices = [], len(
-        prc
-    )  # new_prices is the list of prices after the shift
+    new_prices, num_prices = ([], len(prc))
+    # new_prices is the list of prices after the shift
 
     for p, index in zip(prc, range(num_prices)):
         if type_ == "first":
@@ -63,17 +62,17 @@ def shaping(prc, type_: str = "peak"):
 
     """
     if type_ == "peak":
-        prc[
-            8:20
-        ] *= 1.1  # between 8 and 20 hours, the price is multiplied by 1.1 (general production is high)
+        prc[8:20] *= (
+            1.1  # between 8 and 20 hours, the price is multiplied by 1.1 (general production is high)
+        )
     elif type_ == "pv":
-        prc[
-            10:14
-        ] *= 0.9  # between 10 and 14 hours, the price is multiplied by 0.9 (Pv production is high)
+        prc[10:14] *= (
+            0.9  # between 10 and 14 hours, the price is multiplied by 0.9 (Pv production is high)
+        )
     elif type_ == "demand":
-        prc[
-            6:9
-        ] *= 1.1  # between 6 and 9 hours, the price is multiplied by 1.1 (demand is high)
+        prc[6:9] *= (
+            1.1  # between 6 and 9 hours, the price is multiplied by 1.1 (demand is high)
+        )
         prc[17:20] *= 1.1  # between 17 and 20 hours, the price is multiplied by 1.1
     return prc
 
@@ -196,7 +195,8 @@ class DmasStorageStrategy(BaseStrategy):
             self.model.obj = Objective(
                 expr=quicksum(profit[t] for t in time_range), sense=maximize
             )
-            r = self.opt.solve(self.model)
+            self.opt.solve(self.model)
+
             power = np.asarray(
                 [
                     -self.model.p_minus[t].value * unit.efficiency_discharge

--- a/assume/strategies/extended.py
+++ b/assume/strategies/extended.py
@@ -47,7 +47,9 @@ class OTCStrategy(BaseStrategy):
             min_power, max_power = unit.calculate_min_max_power(
                 start, end
             )  # max_power describes the maximum power output of the unit
-            current_power = unit.outputs["energy"].at[
+            current_power = unit.outputs[
+                "energy"
+            ].at[
                 start
             ]  # current power output describes the power output at the start of the product
             volume = max_power[start]
@@ -209,7 +211,9 @@ class MarkupStrategy(BaseStrategy):
             min_power, max_power = unit.calculate_min_max_power(
                 start, end
             )  # max_power describes the maximum power output of the unit
-            current_power = unit.outputs["energy"].at[
+            current_power = unit.outputs[
+                "energy"
+            ].at[
                 start
             ]  # current power output describes the power output at the start of the product
             volume = max_power[start]

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -309,8 +309,6 @@ class flexableNegCRM(BaseStrategy):
         # check if kwargs contains crm_foresight argument
         self.foresight = pd.Timedelta(kwargs.get("crm_foresight", "4h"))
 
-        start = None
-
     def calculate_bids(
         self,
         unit: SupportsMinMax,

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -12,7 +12,6 @@ import torch as th
 
 from assume.common.base import LearningStrategy, SupportsMinMax
 from assume.common.market_objects import MarketConfig, Orderbook, Product
-from assume.common.utils import get_products_index
 from assume.reinforcement_learning.learning_utils import Actor, NormalActionNoise
 
 logger = logging.getLogger(__name__)

--- a/assume/strategies/naive_strategies.py
+++ b/assume/strategies/naive_strategies.py
@@ -302,7 +302,7 @@ class NaiveRedispatchStrategy(BaseStrategy):
         :rtype: Orderbook
         """
         start = product_tuples[0][0]
-        end_all = product_tuples[-1][1]
+        # end_all = product_tuples[-1][1]
         previous_power = unit.get_output_before(start)
         min_power, max_power = unit.min_power, unit.max_power
 

--- a/assume/units/demand.py
+++ b/assume/units/demand.py
@@ -41,7 +41,7 @@ class Demand(SupportsMinMax):
         node: str = "node0",
         price: float | pd.Series = 3000.0,
         location: tuple[float, float] = (0.0, 0.0),
-        **kwargs
+        **kwargs,
     ):
         super().__init__(
             id=id,

--- a/assume/world.py
+++ b/assume/world.py
@@ -142,9 +142,9 @@ class World:
 
             self.bidding_strategies["learning"] = RLStrategy
             self.bidding_strategies["pp_learning"] = RLStrategy
-            self.bidding_strategies[
-                "learning_advanced_orders"
-            ] = RLAdvancedOrderStrategy
+            self.bidding_strategies["learning_advanced_orders"] = (
+                RLAdvancedOrderStrategy
+            )
 
         except ImportError as e:
             self.logger.info(
@@ -305,7 +305,7 @@ class World:
                     suspendable_tasks=False,
                 )
                 agent.add_role(self.output_role)
-                clock_agent = DistributedClockAgent(container)
+                DistributedClockAgent(container)
 
             await self.container.as_agent_process(agent_creator=creator)
         else:
@@ -417,7 +417,7 @@ class World:
 
                         unit_operator_id = "Operator-RL"
 
-            except KeyError as e:
+            except KeyError:
                 self.logger.error(
                     f"Bidding strategy {strategy} not registered, could not add {id}"
                 )

--- a/assume_cli/cli.py
+++ b/assume_cli/cli.py
@@ -47,7 +47,7 @@ def config_case_completer(prefix, parsed_args, **kwargs):
         Path(parsed_args.input_path) / Path(parsed_args.scenario) / "config.yaml"
     )
     if config_file.is_file():
-        with open(str(config_file), "r") as f:
+        with open(str(config_file)) as f:
             config = yaml.safe_load(f)
         return list(config.keys())
     return [""]

--- a/examples/distributed_simulation/world_manager.py
+++ b/examples/distributed_simulation/world_manager.py
@@ -3,12 +3,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 from config import (
-    agent_adress,
-    agent_adresses,
     db_uri,
     index,
     manager_addr,
-    market_operator_addr,
     market_operator_aid,
     marketdesign,
     worker,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,8 +43,7 @@ psycopg2-binary = "^2.9.5"
 pyyaml = "^6.0"
 pyyaml-include = "^1.3.1"
 pyomo = {version = "^6.6.1", optional = true}
-black = {version = "^23.3.0", optional = true}
-isort = {version = "^5.12.0", optional = true}
+ruff = {version = "^0.4.9", optional = true}
 mypy = {version = "^1.1.1", optional = true}
 matplotlib = {version = "^3.7.2", optional = true}
 pypsa = {version = "^0.26.3", optional = true}
@@ -59,8 +58,7 @@ holidays = {version = "^0.37", optional = true}
 demandlib = {version = "^0.1.9", optional = true}
 
 [tool.poetry.group.dev.dependencies]
-black = "^23.3.0"
-isort = "^5.12.0"
+ruff = "^0.4.9"
 mypy = "^1.1.1"
 pytest = "^7.2.2"
 pytest-cov = "^4.1.0"
@@ -72,7 +70,7 @@ learning = ["torch"]
 optimization = ["glpk","pyomo", "pypsa"]
 oeds = ["windpowerlib", "pvlib", "demandlib", "holidays"]
 full = ["torch", "glpk","pyomo", "pypsa", "windpowerlib", "pvlib", "demandlib", "holidays"]
-test = ["black", "isort", "matplotlib", "pytest", "pytest-cov", "pytest-asyncio", "glpk", "mypy"]
+test = ["ruff", "matplotlib", "pytest", "pytest-cov", "pytest-asyncio", "glpk", "mypy"]
 
 [tool.poetry.scripts]
 assume = "assume_cli.cli:cli"
@@ -81,8 +79,22 @@ assume = "assume_cli.cli:cli"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
-[tool.isort]
-profile = "black"
+[tool.ruff]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "G", "PIE"]
+ignore = ["E501", "G004", "E731"]
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = [
+    "I001", # allow unsorted imports in __init__.py
+    "F401", # allow unused imports in __init__.py
+]
+"tests/*" = [
+    "S101", # allow assert statements for pytest
+    "ARG",  # allow unused arguments for pytest fixtures
+    "F841", # allow unused local variables
+]
 
 [tool.pytest]
 testpaths = "tests"

--- a/tests/test_advanced_order_strategy.py
+++ b/tests/test_advanced_order_strategy.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import math
 from datetime import datetime
 
 import pandas as pd
@@ -10,11 +9,8 @@ import pytest
 
 from assume.common.forecasts import NaiveForecast
 from assume.strategies import (
-    flexableEOM,
     flexableEOMBlock,
     flexableEOMLinked,
-    flexableNegCRM,
-    flexablePosCRM,
 )
 from assume.units import PowerPlant
 

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-from datetime import datetime, timedelta
+from datetime import timedelta
 
 import pandas as pd
 import pytest
@@ -38,7 +38,7 @@ class BasicStrategy(BaseStrategy):
 def base_unit() -> BaseUnit:
     # Create a PowerPlant instance with some example parameters
     index = pd.date_range("2022-01-01", periods=4, freq="h")
-    ff = NaiveForecast(
+    NaiveForecast(
         index, availability=1, fuel_price=[10, 11, 12, 13], co2_price=[10, 20, 30, 30]
     )
     return BaseUnit(

--- a/tests/test_flexable_strategies.py
+++ b/tests/test_flexable_strategies.py
@@ -11,8 +11,6 @@ import pytest
 from assume.common.forecasts import NaiveForecast
 from assume.strategies import (
     flexableEOM,
-    flexableEOMBlock,
-    flexableEOMLinked,
     flexableNegCRM,
     flexablePosCRM,
 )

--- a/tests/test_learning_role.py
+++ b/tests/test_learning_role.py
@@ -4,7 +4,6 @@
 
 from datetime import datetime
 
-import numpy as np
 import pytest
 
 try:
@@ -37,25 +36,25 @@ def test_learning_init():
         "early_stopping_threshold": 0.05,
     }
     # test init
-    l = Learning(learning_config, start, end)
-    assert len(l.rl_strats) == 0
+    learn = Learning(learning_config, start, end)
+    assert len(learn.rl_strats) == 0
 
     # we need to add learning strategies first
-    l.rl_strats["test_id"] = LearningStrategy(**learning_config)
+    learn.rl_strats["test_id"] = LearningStrategy(**learning_config)
 
     # test creating actors
-    l.initialize_policy()
+    learn.initialize_policy()
     # now we have an actor for every strategy
-    for strategy in l.rl_strats.values():
+    for strategy in learn.rl_strats.values():
         assert isinstance(strategy.actor, Actor)
         assert isinstance(strategy.actor_target, Actor)
 
     # now we have a critic for every strategy
-    for str_id in l.rl_strats.keys():
-        assert isinstance(l.critics[str_id], CriticTD3)
-        assert isinstance(l.target_critics[str_id], CriticTD3)
+    for str_id in learn.rl_strats.keys():
+        assert isinstance(learn.critics[str_id], CriticTD3)
+        assert isinstance(learn.target_critics[str_id], CriticTD3)
 
-    ac = l.rl_algorithm.extract_policy()
+    ac = learn.rl_algorithm.extract_policy()
 
-    assert ac["target_critics"] == l.target_critics
-    assert ac["critics"] == l.critics
+    assert ac["target_critics"] == learn.target_critics
+    assert ac["critics"] == learn.critics

--- a/tests/test_outputs.py
+++ b/tests/test_outputs.py
@@ -7,7 +7,6 @@ from datetime import datetime
 
 import pandas as pd
 from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
 
 from assume.common.outputs import WriteOutput
 

--- a/tests/test_policies_contracts.py
+++ b/tests/test_policies_contracts.py
@@ -2,26 +2,16 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-import asyncio
 from datetime import datetime
 
 import pandas as pd
 from dateutil import rrule as rr
-from dateutil.relativedelta import relativedelta as rd
-from mango import Agent, RoleAgent, create_container
-from mango.util.clock import ExternalClock
 
-from assume.common.forecasts import NaiveForecast
-from assume.common.market_objects import MarketConfig, MarketProduct
-from assume.common.units_operator import UnitsOperator
-from assume.markets.base_market import MarketRole
 from assume.markets.clearing_algorithms.contracts import (
     available_contracts,
     market_premium,
 )
 from assume.strategies.extended import is_co2emissionless
-from assume.strategies.naive_strategies import NaiveSingleBidStrategy
-from assume.units.demand import Demand
 
 
 def test_contract_functions():


### PR DESCRIPTION
Ruff is a new linter written in Rust, being super fast and joining the existing configurations of pylint, isort, black and other linting tools.
This PR switches to it and adjusts files accordingly

- ruff includes isort and black
- it also includes code linting for typical improvements
- removes unused imports
- configurable through rules