### PR TITLE
Update pyproject to use setuptools instead of Poetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,19 @@ To run pre-commit checks directly, use:
 pre-commit run --all-files
 ```
 
+### Release
+
+To release a new version, increase the version in `pyproject.toml` and create a git tag of the release commit and release notes in GitHub.
+To push to PyPi run:
+
+```
+rm -r dist
+python -m build .
+twine upload --repository pypi dist/*
+```
+
+See also: https://twine.readthedocs.io/en/stable/index.html#using-twine
+
 ## Creating Documentation
 
 First, create an environment that includes the documentation dependencies:

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -4,7 +4,7 @@
 
 from collections import defaultdict
 from datetime import datetime, timedelta
-from typing import TypedDict, Union
+from typing import TypedDict
 
 import numpy as np
 import pandas as pd
@@ -227,7 +227,7 @@ class BaseUnit:
         else:
             return self.outputs[product_type].at[dt - self.index.freq]
 
-    def as_dict(self) -> dict[str, Union[str, int]]:
+    def as_dict(self) -> dict[str, str | int]:
         """
         Returns a dictionary representation of the unit.
 

--- a/assume/common/market_objects.py
+++ b/assume/common/market_objects.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from numbers import Number
-from typing import Callable, NamedTuple, Optional, TypedDict
+from typing import NamedTuple, TypedDict
 
 from dateutil import rrule as rr
 from dateutil.relativedelta import relativedelta as rd
@@ -50,7 +51,7 @@ class Order(TypedDict):
     accepted_price: Number | dict[datetime, Number]
     agent_id: str
     node: str
-    only_hours: Optional[OnlyHours]
+    only_hours: OnlyHours | None
 
 
 Orderbook = list[Order]

--- a/assume/markets/clearing_algorithms/contracts.py
+++ b/assume/markets/clearing_algorithms/contracts.py
@@ -4,10 +4,10 @@
 
 import asyncio
 import logging
+from collections.abc import Callable
 from datetime import datetime
 from itertools import groupby
 from operator import itemgetter
-from typing import Callable
 
 import pandas as pd
 from dateutil import rrule as rr

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -7,7 +7,6 @@ import logging
 from collections import defaultdict
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Optional
 
 import dateutil.rrule as rr
 import numpy as np
@@ -35,7 +34,7 @@ def load_file(
     path: str,
     config: dict,
     file_name: str,
-    index: Optional[pd.DatetimeIndex] = None,
+    index: pd.DatetimeIndex | None = None,
 ) -> pd.DataFrame:
     """
     Loads a csv file from the given path and returns a dataframe.
@@ -147,7 +146,7 @@ def replace_paths(config: dict, inputs_path: str):
 
     if isinstance(config, dict):
         for key, value in config.items():
-            if isinstance(value, (dict, list)):
+            if isinstance(value, dict | list):
                 config[key] = replace_paths(value, inputs_path)
             elif isinstance(key, str) and key.endswith("_path") and value is not None:
                 if not value.startswith(inputs_path):

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -5,7 +5,6 @@
 import logging
 from datetime import datetime, timedelta
 from functools import lru_cache
-from typing import Tuple, Union
 
 import pandas as pd
 
@@ -59,12 +58,12 @@ class PowerPlant(SupportsMinMax):
         max_power: float,
         min_power: float = 0.0,
         efficiency: float = 1.0,
-        additional_cost: Union[float, pd.Series] = 0.0,
+        additional_cost: float | pd.Series = 0.0,
         partial_load_eff: bool = False,
         fuel_type: str = "others",
         emission_factor: float = 0.0,
-        ramp_up: Union[float, None] = None,
-        ramp_down: Union[float, None] = None,
+        ramp_up: float | None = None,
+        ramp_down: float | None = None,
         hot_start_cost: float = 0,
         warm_start_cost: float = 0,
         cold_start_cost: float = 0,
@@ -74,7 +73,7 @@ class PowerPlant(SupportsMinMax):
         downtime_warm_start: int = 48,  # hours
         heat_extraction: bool = False,
         max_heat_extraction: float = 0,
-        location: Tuple[float, float] = (0.0, 0.0),
+        location: tuple[float, float] = (0.0, 0.0),
         node: str = "node0",
         **kwargs,
     ):

--- a/assume/world.py
+++ b/assume/world.py
@@ -9,7 +9,6 @@ import time
 from datetime import datetime
 from pathlib import Path
 from sys import platform
-from typing import Optional, Union
 
 import nest_asyncio
 import pandas as pd
@@ -87,11 +86,11 @@ class World:
 
     def __init__(
         self,
-        addr: Union[tuple[str, int], str] = "world",
+        addr: tuple[str, int] | str = "world",
         database_uri: str = "",
         export_csv_path: str = "",
         log_level: str = "INFO",
-        distributed_role: Optional[bool] = None,
+        distributed_role: bool | None = None,
     ) -> None:
         logging.getLogger("assume").setLevel(log_level)
         self.logger = logging.getLogger(__name__)
@@ -167,7 +166,7 @@ class World:
         save_frequency_hours: int = 24,
         bidding_params: dict = {},
         learning_config: LearningConfig = {},
-        forecaster: Optional[Forecaster] = None,
+        forecaster: Forecaster | None = None,
         manager_address=None,
         **kwargs: dict,
     ) -> None:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,13 +7,13 @@
 import tomllib
 
 with open("../../pyproject.toml", "rb") as f:
-    pyproject_toml = tomllib.load(f)["tool"]["poetry"]
+    pyproject_toml = tomllib.load(f)["project"]
 
 # -- Project information
 
 project = "ASSUME"
 copyright = "2022-2024 ASSUME Developers"
-author = ",".join(pyproject_toml["authors"])
+author = ",".join([a["name"] for a in pyproject_toml["authors"]])
 
 version = pyproject_toml["version"]
 release = version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,17 +2,17 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-[tool.poetry]
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "assume-framework"
 version = "0.3.7"
 description = "ASSUME - Agent-Based Electricity Markets Simulation Toolbox"
-authors = ["ASSUME Developers <contact@assume-project.de>"]
-license = "AGPL-3.0-or-later"
+authors = [{ name = "ASSUME Developers", email = "contact@assume-project.de"}]
+license = {text = "AGPL-3.0-or-later"}
 readme = "README.md"
-
-homepage = "https://assume.readthedocs.io"
-repository = "https://github.com/assume-framework/assume"
-
 keywords = ["agent based simulation", "energy market", "reinforcement learning", "market simulation", "simulation"]
 
 classifiers=[
@@ -23,61 +23,58 @@ classifiers=[
     "Topic :: Scientific/Engineering",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-
-packages = [
-    { include="assume", from="." },
-    { include="assume_cli", from="." },
+requires-python = ">=3.10"
+dependencies = [
+    "argcomplete >=3.1.4",
+    "nest-asyncio >=1.5.6",
+    "mango-agents-assume >=1.1.1-8",
+    "numpy < 2", # Pyomo Incompatible
+    "tqdm >=4.64.1",
+    "python-dateutil >=2.8.2",
+    "sqlalchemy >=2.0.9",
+    "pandas >=2.0.0",
+    "psycopg2-binary >=2.9.5",
+    "pyyaml >=6.0",
+    "pyyaml-include >=1.3.1",
 ]
 
-[tool.poetry.dependencies]
-python = "^3.10"
-argcomplete = "^3.1.4"
-nest-asyncio = "^1.5.6"
-mango-agents-assume = "^1.1.1-8"
-numpy = "^1.26.4"
-tqdm = "^4.64.1"
-python-dateutil = "^2.8.2"
-sqlalchemy = "^2.0.9"
-pandas = {version = "^2.0.0"}
-psycopg2-binary = "^2.9.5"
-pyyaml = "^6.0"
-pyyaml-include = "^1.3.1"
-pyomo = {version = "^6.6.1", optional = true}
-ruff = {version = "^0.4.9", optional = true}
-mypy = {version = "^1.1.1", optional = true}
-matplotlib = {version = "^3.7.2", optional = true}
-pypsa = {version = "^0.26.3", optional = true}
-pytest = {version = "^7.2.2", optional = true}
-pytest-cov = {version = "^4.1.0", optional = true}
-pytest-asyncio = {version = "^0.21.1", optional = true}
-torch = {version = "^2.0.1", optional = true}
-glpk = {version = "^0.4.7", optional = true}
-windpowerlib = {version = "^0.2.1", optional = true}
-pvlib = {version = "^0.10.2", optional = true}
-holidays = {version = "^0.37", optional = true}
-demandlib = {version = "^0.1.9", optional = true}
+[project.optional-dependencies]
+learning = [
+    "torch >=2.0.1",
+]
+optimization = [
+    "glpk >=0.4.7",
+    "pyomo >=6.6.1",
+    "pypsa >=0.26.3",
+]
+oeds = [
+    "demandlib >=0.1.9",
+    "holidays >=0.37",
+    "pvlib >=0.10.2",
+    "windpowerlib >=0.2.1",
+]
+test = [
+    "ruff >=0.4.9",
+    "mypy >=1.1.1",
+    "matplotlib >=3.7.2",
+    "pytest >=7.2.2",
+    "pytest-cov >=4.1.0",
+    "pytest-asyncio >=0.21.1",
+    "glpk >=0.4.7",
+]
+all = [
+    "assume-framework[oeds, optimization, learning]",
+]
 
-[tool.poetry.group.dev.dependencies]
-ruff = "^0.4.9"
-mypy = "^1.1.1"
-pytest = "^7.2.2"
-pytest-cov = "^4.1.0"
-pytest-asyncio = "^0.21.1"
+[project.urls]
+homepage = "https://assume.readthedocs.io"
+repository = "https://github.com/assume-framework/assume"
 
-
-[tool.poetry.extras]
-learning = ["torch"]
-optimization = ["glpk","pyomo", "pypsa"]
-oeds = ["windpowerlib", "pvlib", "demandlib", "holidays"]
-full = ["torch", "glpk","pyomo", "pypsa", "windpowerlib", "pvlib", "demandlib", "holidays"]
-test = ["ruff", "matplotlib", "pytest", "pytest-cov", "pytest-asyncio", "glpk", "mypy"]
-
-[tool.poetry.scripts]
+[project.scripts]
 assume = "assume_cli.cli:cli"
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.setuptools]
+packages = ["assume", "assume_cli"]
 
 [tool.ruff]
 


### PR DESCRIPTION
Poetry does not correspond to PEP-621, so we are using setuptools now as recommended in https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/

The caret (`^`) version is not PEP508 compatible, therefore we are using >= now where possible, without any turnbacks.

This allows an easier definition of the `pip install assume-framework[all]` package and does not rely on poetry with its custom config options and installation anymore.

To push to pypi, use:

```
rm -r dist
python -m build .
twine upload --repository pypi dist/*
```