### PR TITLE
Refactor unit operator setup logic to handle RL operator separately 

### DIFF
--- a/assume/reinforcement_learning/learning_unit_operator.py
+++ b/assume/reinforcement_learning/learning_unit_operator.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import logging
+
+import numpy as np
+import torch as th
+
+from assume.common import UnitsOperator
+from assume.common.market_objects import (
+    ClearingMessage,
+    MarketConfig,
+    MetaDict,
+    Orderbook,
+)
+from assume.common.utils import (
+    get_products_index,
+)
+from assume.strategies import BaseStrategy, LearningStrategy, RLAdvancedOrderStrategy
+from assume.units import BaseUnit
+
+logger = logging.getLogger(__name__)
+
+
+class RLUnitsOperator(UnitsOperator):
+    def __init__(
+        self,
+        available_markets: list[MarketConfig],
+        opt_portfolio: tuple[bool, BaseStrategy] | None = None,
+    ):
+        super().__init__(available_markets, opt_portfolio)
+
+        self.rl_units = []
+        self.learning_strategies = {
+            "obs_dim": 0,
+            "act_dim": 0,
+            "device": "cpu",
+        }
+
+    async def add_unit(
+        self,
+        unit: BaseUnit,
+    ) -> None:
+        """
+        Create a unit.
+
+        Args:
+            unit (BaseUnit): The unit to be added.
+        """
+        self.units[unit.id] = unit
+
+        # check if unit has learning strategy for any of the available markets
+        for market in self.available_markets:
+            strategy = unit.bidding_strategies.get(market.market_id)
+
+            if isinstance(strategy, LearningStrategy):
+                self.learning_strategies.update(
+                    {
+                        "obs_dim": strategy.obs_dim,
+                        "act_dim": strategy.act_dim,
+                        "device": strategy.device,
+                    }
+                )
+
+                self.rl_units.append(unit)
+                break
+
+        db_aid = self.context.data.get("output_agent_id")
+        db_addr = self.context.data.get("output_agent_addr")
+        if db_aid and db_addr:
+            # send unit data to db agent to store it
+            message = {
+                "context": "write_results",
+                "type": "store_units",
+                "data": self.units[unit.id].as_dict(),
+            }
+            await self.context.send_acl_message(
+                receiver_id=db_aid,
+                receiver_addr=db_addr,
+                content=message,
+                acl_metadata={
+                    "sender_addr": self.context.addr,
+                    "sender_id": self.context.aid,
+                },
+            )
+
+    def handle_market_feedback(self, content: ClearingMessage, meta: MetaDict) -> None:
+        """
+        Handles the feedback which is received from a market we did bid at.
+
+        Args:
+            content (ClearingMessage): The content of the clearing message.
+            meta (MetaDict): The meta data of the market.
+        """
+        logger.debug(f"{self.id} got market result: {content}")
+        accepted_orders: Orderbook = content["accepted_orders"]
+        rejected_orders: Orderbook = content["rejected_orders"]
+        orderbook = accepted_orders + rejected_orders
+
+        for order in orderbook:
+            order["market_id"] = content["market_id"]
+
+        marketconfig = self.registered_markets[content["market_id"]]
+        self.valid_orders[marketconfig.product_type].extend(orderbook)
+        self.set_unit_dispatch(orderbook, marketconfig)
+        self.write_learning_to_output(orderbook, marketconfig.market_id)
+        self.write_actual_dispatch(marketconfig.product_type)
+
+    def write_learning_to_output(self, orderbook: Orderbook, market_id: str) -> None:
+        """
+        Sends the current rl_strategy update to the output agent.
+
+        Args:
+            products_index (pandas.DatetimeIndex): The index of all products.
+            marketconfig (MarketConfig): The market configuration.
+        """
+
+        products_index = get_products_index(orderbook)
+
+        # should write learning results if at least one bidding_strategy is a learning strategy
+        if not (len(self.rl_units) and orderbook):
+            return
+
+        output_agent_list = []
+        start = products_index[0]
+
+        for unit in self.rl_units:
+            strategy = unit.bidding_strategies.get(market_id)
+
+            # rl only for energy market for now!
+            if isinstance(strategy, LearningStrategy):
+                output_dict = {
+                    "datetime": start,
+                    "unit": unit.id,
+                }
+
+                if isinstance(strategy, RLAdvancedOrderStrategy):
+                    output_dict.update(
+                        {
+                            "profit": unit.outputs["profit"].loc[products_index].sum(),
+                            "reward": unit.outputs["reward"].loc[products_index].sum()
+                            / 24,
+                            "regret": unit.outputs["regret"].loc[products_index].sum(),
+                        }
+                    )
+                else:
+                    output_dict.update(
+                        {
+                            "profit": unit.outputs["profit"].loc[start],
+                            "reward": unit.outputs["reward"].loc[start],
+                            "regret": unit.outputs["regret"].loc[start],
+                        }
+                    )
+
+                action_tuple = unit.outputs["actions"].loc[start]
+                noise_tuple = unit.outputs["exploration_noise"].loc[start]
+                action_dim = action_tuple.numel()
+
+                for i in range(action_dim):
+                    output_dict[f"exploration_noise_{i}"] = (
+                        noise_tuple[i] if action_dim > 1 else noise_tuple
+                    )
+                    output_dict[f"actions_{i}"] = (
+                        action_tuple[i] if action_dim > 1 else action_tuple
+                    )
+
+                output_agent_list.append(output_dict)
+
+        db_aid = self.context.data.get("learning_output_agent_id")
+        db_addr = self.context.data.get("learning_output_agent_addr")
+
+        if db_aid and db_addr and output_agent_list:
+            self.context.schedule_instant_acl_message(
+                receiver_id=db_aid,
+                receiver_addr=db_addr,
+                content={
+                    "context": "write_results",
+                    "type": "rl_learning_params",
+                    "data": output_agent_list,
+                },
+            )
+
+    async def write_to_learning_role(
+        self,
+    ) -> None:
+        """
+        Writes learning results to the learning agent.
+
+        """
+        if len(self.rl_units) == 0:
+            return
+
+        obs_dim = self.learning_strategies["obs_dim"]
+        act_dim = self.learning_strategies["act_dim"]
+        device = self.learning_strategies["device"]
+        learning_unit_count = len(self.rl_units)
+
+        values_len = len(self.rl_units[0].outputs["rl_rewards"])
+        # return if no data is available
+        if values_len == 0:
+            return
+
+        all_observations = th.zeros(
+            (values_len, learning_unit_count, obs_dim), device=device
+        )
+        all_actions = th.zeros(
+            (values_len, learning_unit_count, act_dim), device=device
+        )
+        all_rewards = []
+
+        for i, unit in enumerate(self.rl_units):
+            # Convert pandas Series to torch Tensor
+            obs_tensor = th.stack(unit.outputs["rl_observations"][:values_len], dim=0)
+            actions_tensor = th.stack(
+                unit.outputs["rl_actions"][:values_len], dim=0
+            ).reshape(-1, act_dim)
+
+            all_observations[:, i, :] = obs_tensor
+            all_actions[:, i, :] = actions_tensor
+            all_rewards.append(unit.outputs["rl_rewards"])
+
+            # reset the outputs
+            unit.reset_saved_rl_data()
+
+        # convert all_actions list of tensor to numpy 2D array
+        all_observations = (
+            all_observations.squeeze()
+            .cpu()
+            .numpy()
+            .reshape(-1, learning_unit_count, obs_dim)
+        )
+        all_actions = (
+            all_actions.squeeze()
+            .cpu()
+            .numpy()
+            .reshape(-1, learning_unit_count, act_dim)
+        )
+        all_rewards = np.array(all_rewards).reshape(-1, learning_unit_count)
+        rl_agent_data = (all_observations, all_actions, all_rewards)
+
+        learning_role_id = self.context.data.get("learning_agent_id")
+        learning_role_addr = self.context.data.get("learning_agent_addr")
+
+        if learning_role_id and learning_role_addr:
+            self.context.schedule_instant_acl_message(
+                receiver_id=learning_role_id,
+                receiver_addr=learning_role_addr,
+                content={
+                    "context": "rl_training",
+                    "type": "save_buffer_and_update",
+                    "data": rl_agent_data,
+                },
+            )

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -481,7 +481,10 @@ async def async_setup_world(
         all_operators = np.concatenate([all_operators, ["Operator-RL"]])
 
     for company_name in set(all_operators):
-        world.add_unit_operator(id=str(company_name))
+        if company_name == "Operator-RL" and world.learning_mode:
+            world.add_rl_unit_operator(id="Operator-RL")
+        else:
+            world.add_unit_operator(id=str(company_name))
 
     # add the units to corresponding unit operators
     add_units(

--- a/assume/world.py
+++ b/assume/world.py
@@ -302,8 +302,8 @@ class World:
     def add_unit_operator(self, id: str) -> None:
         """
         Add a unit operator to the simulation, creating a new role agent and applying the role of a unit operator to it.
-        The unit operator is then added to the list of existing operators. If in learning mode, additional context parameters
-        related to learning and output agents are set for the unit operator's role context.
+        The unit operator is then added to the list of existing operators. Unit operator receives the output agent address
+        if not in learning mode.
 
         Args:
             id (str): The identifier for the unit operator.
@@ -333,9 +333,12 @@ class World:
 
     def add_rl_unit_operator(self, id: str = "Operator-RL") -> None:
         """
-        Add a unit operator to the simulation, creating a new role agent and applying the role of a unit operator to it.
-        The unit operator is then added to the list of existing operators. If in learning mode, additional context parameters
-        related to learning and output agents are set for the unit operator's role context.
+        Add a RL unit operator to the simulation, creating a new role agent and applying the role of a unit operator to it.
+        The unit operator is then added to the list of existing operators.
+
+        The RL unit operator differs from the standard unit operator in that it is used to handle learning units. It has additional
+        functions such as writing to the learning role and scheduling recurrent tasks for writing to the learning role. It also
+        writes learning outputs to the output role.
 
         Args:
             id (str): The identifier for the unit operator.
@@ -450,6 +453,16 @@ class World:
                 self.learning_role.rl_strats[unit_id] = strategy
 
     def _prepare_bidding_strategies(self, unit_params, unit_id):
+        """
+        Prepare bidding strategies for the unit based on the specified parameters.
+
+        Args:
+            unit_params (dict): Parameters for configuring the unit.
+            unit_id (str): The identifier for the unit.
+
+        Returns:
+            dict[str, BaseStrategy]: The bidding strategies for the unit.
+        """
         bidding_strategies = {}
         for market_id, strategy in unit_params["bidding_strategies"].items():
             if not strategy:
@@ -474,6 +487,13 @@ class World:
         """
         Check if any of the bidding strategies are learning strategies.
         And change the unit operator to RL if learning strategies are found.
+
+        Args:
+            bidding_strategies (dict[str, str]): The bidding strategies for the unit.
+            unit_operator_id (str): The identifier of the unit operator.
+
+        Returns:
+            str: The corrected unit operator identifier.
 
         """
         for strategy in bidding_strategies.values():

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -23,7 +23,8 @@ from assume.units.powerplant import PowerPlant
 try:
     from assume.reinforcement_learning.learning_unit_operator import RLUnitsOperator
 except ImportError:
-    pass
+    # to suffice the type hint as best as possible
+    from assume.common.units_operator import UnitsOperator as RLUnitsOperator
 
 start = datetime(2020, 1, 1)
 end = datetime(2020, 12, 2)

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -16,10 +16,14 @@ from assume.common.forecasts import NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.units_operator import UnitsOperator
 from assume.common.utils import datetime2timestamp
-from assume.reinforcement_learning.learning_unit_operator import RLUnitsOperator
 from assume.strategies.naive_strategies import NaiveSingleBidStrategy
 from assume.units.demand import Demand
 from assume.units.powerplant import PowerPlant
+
+try:
+    from assume.reinforcement_learning.learning_unit_operator import RLUnitsOperator
+except ImportError:
+    pass
 
 start = datetime(2020, 1, 1)
 end = datetime(2020, 12, 2)

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -16,6 +16,7 @@ from assume.common.forecasts import NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.units_operator import UnitsOperator
 from assume.common.utils import datetime2timestamp
+from assume.reinforcement_learning.learning_unit_operator import RLUnitsOperator
 from assume.strategies.naive_strategies import NaiveSingleBidStrategy
 from assume.units.demand import Demand
 from assume.units.powerplant import PowerPlant
@@ -38,6 +39,46 @@ async def units_operator() -> UnitsOperator:
     container = await create_container(addr=("0.0.0.0", 9098), clock=clock)
     units_agent = RoleAgent(container, "test_operator")
     units_role = UnitsOperator(available_markets=[marketconfig])
+    units_agent.add_role(units_role)
+
+    index = pd.date_range(start=start, end=end + pd.Timedelta(hours=4), freq="1h")
+
+    params_dict = {
+        "bidding_strategies": {"EOM": NaiveSingleBidStrategy()},
+        "technology": "energy",
+        "unit_operator": "test_operator",
+        "max_power": 1000,
+        "min_power": 0,
+        "forecaster": NaiveForecast(index, demand=1000),
+    }
+    unit = Demand("testdemand", index=index, **params_dict)
+    await units_role.add_unit(unit)
+
+    start_ts = datetime2timestamp(start)
+    clock.set_time(start_ts)
+
+    yield units_role
+
+    end_ts = datetime2timestamp(end)
+    clock.set_time(end_ts)
+    await tasks_complete_or_sleeping(container)
+    await container.shutdown()
+
+
+@pytest.fixture
+async def rl_units_operator() -> RLUnitsOperator:
+    market_id = "EOM"
+    marketconfig = MarketConfig(
+        market_id=market_id,
+        opening_hours=rr.rrule(rr.HOURLY, dtstart=start, until=end),
+        opening_duration=rd(hours=1),
+        market_mechanism="pay_as_clear",
+        market_products=[MarketProduct(rd(hours=1), 1, rd(hours=1))],
+    )
+    clock = ExternalClock(0)
+    container = await create_container(addr=("0.0.0.0", 9098), clock=clock)
+    units_agent = RoleAgent(container, "test_operator")
+    units_role = RLUnitsOperator(available_markets=[marketconfig])
     units_agent.add_role(units_role)
 
     index = pd.date_range(start=start, end=end + pd.Timedelta(hours=4), freq="1h")
@@ -107,11 +148,11 @@ async def test_formulate_bids(units_operator: UnitsOperator):
 
 
 @pytest.mark.require_learning
-async def test_write_learning_params(units_operator: UnitsOperator):
+async def test_write_learning_params(rl_units_operator: RLUnitsOperator):
     from assume.strategies.learning_advanced_orders import RLAdvancedOrderStrategy
     from assume.strategies.learning_strategies import RLStrategy
 
-    marketconfig = units_operator.available_markets[0]
+    marketconfig = rl_units_operator.available_markets[0]
     start = datetime(2020, 1, 1)
     end = datetime(2020, 1, 2)
     index = pd.date_range(start=start, end=end + pd.Timedelta(hours=24), freq="1h")
@@ -130,12 +171,12 @@ async def test_write_learning_params(units_operator: UnitsOperator):
         "forecaster": NaiveForecast(index, powerplant=1000),
     }
     unit = PowerPlant("testplant", index=index, **params_dict)
-    await units_operator.add_unit(unit)
+    await rl_units_operator.add_unit(unit)
 
-    units_operator.learning_mode = True
-    units_operator.learning_data = {"test": 1}
+    rl_units_operator.learning_mode = True
+    rl_units_operator.learning_data = {"test": 1}
 
-    units_operator.context.data.update(
+    rl_units_operator.context.data.update(
         {
             "learning_output_agent_addr": "world",
             "learning_output_agent_id": "export_agent_1",
@@ -147,15 +188,17 @@ async def test_write_learning_params(units_operator: UnitsOperator):
     from assume.common.utils import get_available_products
 
     products = get_available_products(marketconfig.market_products, start)
-    orderbook = await units_operator.formulate_bids(marketconfig, products)
+    orderbook = await rl_units_operator.formulate_bids(marketconfig, products)
 
-    open_tasks = len(units_operator.context._scheduler._scheduled_tasks)
+    open_tasks = len(rl_units_operator.context._scheduler._scheduled_tasks)
 
-    units_operator.write_learning_to_output(orderbook, market_id=marketconfig.market_id)
+    rl_units_operator.write_learning_to_output(
+        orderbook, market_id=marketconfig.market_id
+    )
 
-    assert len(units_operator.context._scheduler._scheduled_tasks) == open_tasks + 1
+    assert len(rl_units_operator.context._scheduler._scheduled_tasks) == open_tasks + 1
 
-    units_operator.units["testplant"].bidding_strategies[
+    rl_units_operator.units["testplant"].bidding_strategies[
         "EOM"
     ].bidding_strategies = RLStrategy(
         unit_id="testplant",
@@ -164,16 +207,18 @@ async def test_write_learning_params(units_operator: UnitsOperator):
         action_dimension=2,
     )
 
-    units_operator.learning_data = {"test": 2}
+    rl_units_operator.learning_data = {"test": 2}
 
     products = get_available_products(marketconfig.market_products, start)
-    orderbook = await units_operator.formulate_bids(marketconfig, products)
+    orderbook = await rl_units_operator.formulate_bids(marketconfig, products)
 
-    open_tasks = len(units_operator.context._scheduler._scheduled_tasks)
+    open_tasks = len(rl_units_operator.context._scheduler._scheduled_tasks)
 
-    units_operator.write_learning_to_output(orderbook, market_id=marketconfig.market_id)
+    rl_units_operator.write_learning_to_output(
+        orderbook, market_id=marketconfig.market_id
+    )
 
-    assert len(units_operator.context._scheduler._scheduled_tasks) == open_tasks + 1
+    assert len(rl_units_operator.context._scheduler._scheduled_tasks) == open_tasks + 1
 
 
 async def test_get_actual_dispatch(units_operator: UnitsOperator):


### PR DESCRIPTION
As suggested by @kim-mskw we have split the unit operator:
- add rl_unit_operator to reinforcement learning part
- remove all learning related functions from base unit operator
- refactor add_unit function in the world for better readibility and maintanence

Tests done:
- [x] tests successfull
- [x] ordinary simulation operational
- [x] learning simulation with single agent operational
- [x] learning simulation with multiple agents operational