### PR TITLE
- added shuffling to all curved based clearing algos

### DIFF
--- a/assume/markets/clearing_algorithms/contracts.py
+++ b/assume/markets/clearing_algorithms/contracts.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from datetime import datetime
 from itertools import groupby
 from operator import itemgetter
+from random import shuffle
 
 import pandas as pd
 from dateutil import rrule as rr
@@ -152,6 +153,10 @@ class PayAsBidContractRole(MarketRole):
             product_orders = list(product_orders)
             demand_orders = list(filter(lambda x: x["volume"] < 0, product_orders))
             supply_orders = list(filter(lambda x: x["volume"] > 0, product_orders))
+
+            #shufle all orders to avoid always having the same order of bids with the same price
+            shuffle(supply_orders)
+            shuffle(demand_orders)
 
             # generation
             supply_orders.sort(key=lambda i: i["price"])

--- a/assume/markets/clearing_algorithms/contracts.py
+++ b/assume/markets/clearing_algorithms/contracts.py
@@ -4,11 +4,11 @@
 
 import asyncio
 import logging
+import random
 from collections.abc import Callable
 from datetime import datetime
 from itertools import groupby
 from operator import itemgetter
-from random import shuffle
 
 import pandas as pd
 from dateutil import rrule as rr
@@ -154,9 +154,13 @@ class PayAsBidContractRole(MarketRole):
             demand_orders = list(filter(lambda x: x["volume"] < 0, product_orders))
             supply_orders = list(filter(lambda x: x["volume"] > 0, product_orders))
 
-            #shufle all orders to avoid always having the same order of bids with the same price
-            shuffle(supply_orders)
-            shuffle(demand_orders)
+            # Sort supply orders by price with randomness for tie-breaking
+            supply_orders.sort(key=lambda x: (x["price"], random.random()))
+
+            # Sort demand orders by price in descending order with randomness for tie-breaking
+            demand_orders.sort(
+                key=lambda x: (x["price"], random.random()), reverse=True
+            )
 
             # generation
             supply_orders.sort(key=lambda i: i["price"])

--- a/assume/markets/clearing_algorithms/simple.py
+++ b/assume/markets/clearing_algorithms/simple.py
@@ -6,6 +6,7 @@ import logging
 from datetime import timedelta
 from itertools import groupby
 from operator import itemgetter
+from random import shuffle
 
 from assume.common.market_objects import MarketConfig, MarketProduct, Orderbook
 from assume.markets.base_market import MarketRole
@@ -77,6 +78,10 @@ class PayAsClearRole(MarketRole):
             supply_orders = [x for x in product_orders if x["volume"] > 0]
             demand_orders = [x for x in product_orders if x["volume"] < 0]
             # volume 0 is ignored/invalid
+
+            #shufle all orders to avoid always having the same order of bids with the same price
+            shuffle(supply_orders)
+            shuffle(demand_orders)
 
             # generation
             supply_orders.sort(key=itemgetter("price"))

--- a/assume/markets/clearing_algorithms/simple.py
+++ b/assume/markets/clearing_algorithms/simple.py
@@ -206,6 +206,14 @@ class PayAsBidRole(MarketRole):
             demand_orders = [x for x in product_orders if x["volume"] < 0]
             # volume 0 is ignored/invalid
 
+            # Sort supply orders by price with randomness for tie-breaking
+            supply_orders.sort(key=lambda x: (x["price"], random.random()))
+
+            # Sort demand orders by price in descending order with randomness for tie-breaking
+            demand_orders.sort(
+                key=lambda x: (x["price"], random.random()), reverse=True
+            )
+
             # generation
             supply_orders.sort(key=itemgetter("price"))
             # demand

--- a/assume/markets/clearing_algorithms/simple.py
+++ b/assume/markets/clearing_algorithms/simple.py
@@ -3,10 +3,10 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 import logging
+import random
 from datetime import timedelta
 from itertools import groupby
 from operator import itemgetter
-from random import shuffle
 
 from assume.common.market_objects import MarketConfig, MarketProduct, Orderbook
 from assume.markets.base_market import MarketRole
@@ -79,14 +79,14 @@ class PayAsClearRole(MarketRole):
             demand_orders = [x for x in product_orders if x["volume"] < 0]
             # volume 0 is ignored/invalid
 
-            #shufle all orders to avoid always having the same order of bids with the same price
-            shuffle(supply_orders)
-            shuffle(demand_orders)
+            # Sort supply orders by price with randomness for tie-breaking
+            supply_orders.sort(key=lambda x: (x["price"], random.random()))
 
-            # generation
-            supply_orders.sort(key=itemgetter("price"))
-            # demand
-            demand_orders.sort(key=itemgetter("price"), reverse=True)
+            # Sort demand orders by price in descending order with randomness for tie-breaking
+            demand_orders.sort(
+                key=lambda x: (x["price"], random.random()), reverse=True
+            )
+
             dem_vol, gen_vol = 0, 0
             # the following algorithm is inspired by one bar for generation and one for demand
             # add generation for currents demand price, until it matches demand

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -27,7 +27,7 @@ Upcoming Release 0.3.8
 - Refactored unit operator by adding a seperate unit operator for learning units
 - Enhanced learning output and path handling
 - Updated dashboard for better storage view
-- Improved clearing with shuffling of bids, to avoid bias in clearing of units early in order book 
+- Improved clearing with shuffling of bids, to avoid bias in clearing of units early in order book
 
 **Bug Fixes:**
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -27,6 +27,7 @@ Upcoming Release 0.3.8
 - Refactored unit operator by adding a seperate unit operator for learning units
 - Enhanced learning output and path handling
 - Updated dashboard for better storage view
+- Improved clearing with shuffling of bids, to avoid bias in clearing of units early in order book 
 
 **Bug Fixes:**
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #387 

## Description
see assigned issue

## Changes Proposed
- shuffle orders for supply and demand before sorting it 

## Testing
- tested it with example-02c without learning as there are multiple identical units presents
- in comparison to without the shuffling the profit is now split up between all identical units as it should 
- see issue

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [x] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [x] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
BEFORE:
![image](https://github.com/assume-framework/assume/assets/117921871/97e2383e-5ceb-401e-ad6e-1a130f645a3e)


AFTER:
![image](https://github.com/assume-framework/assume/assets/117921871/96b000a2-df63-452f-ab22-98dd0e626de1)
