### PR TITLE
Manual strategy for interactive market simulation

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ sphinx-apidoc -o docs/source -Fa assume
 To create and serve the documentation locally, use:
 
 ```bash
-cd docs/source && python -m sphinx . ../build && cd ../.. && python -m http.server --directory docs/build/html
+cd docs/source && python -m sphinx . ../build && cd ../.. && python -m http.server --directory docs/build
 ```
 
 ## Contributors and Funding

--- a/assume/strategies/__init__.py
+++ b/assume/strategies/__init__.py
@@ -20,6 +20,7 @@ from assume.strategies.naive_strategies import (
     NaiveRedispatchStrategy,
     NaiveSingleBidStrategy,
 )
+from assume.strategies.manual_strategies import SimpleManualTerminalStrategy
 
 bidding_strategies: dict[str, BaseStrategy] = {
     "naive_eom": NaiveSingleBidStrategy,
@@ -38,6 +39,7 @@ bidding_strategies: dict[str, BaseStrategy] = {
     "naive_redispatch": NaiveRedispatchStrategy,
     "naive_da_steelplant": NaiveDASteelplantStrategy,
     "naive_steel_redispatch": NaiveRedispatchSteelplantStrategy,
+    "manual_strategy": SimpleManualTerminalStrategy,
 }
 
 try:

--- a/assume/strategies/manual_strategies.py
+++ b/assume/strategies/manual_strategies.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from assume.common.base import BaseStrategy, SupportsMinMax
+from assume.common.market_objects import MarketConfig, Orderbook, Product
+
+
+class SimpleManualTerminalStrategy(BaseStrategy):
+    """
+    A simple strategy where the user can input the bids of an agent manually.
+    Only one agent should have this strategy in a simulation in one process, so that the terminal does not wait for multiple responses.
+
+    Methods
+    -------
+    """
+
+    def calculate_bids(
+        self,
+        unit: SupportsMinMax,
+        market_config: MarketConfig,
+        product_tuples: list[Product],
+        **kwargs,
+    ) -> Orderbook:
+        """
+        Takes information from a unit that the unit operator manages and
+        defines how it is dispatched to the market.
+
+        Args:
+            unit (SupportsMinMax): The unit to be dispatched.
+            market_config (MarketConfig): The market configuration.
+            product_tuples (list[Product]): The list of all products the unit can offer.
+
+        Returns:
+            Orderbook: The bids consisting of the start time, end time, only hours, price and volume.
+        """
+        start = product_tuples[0][0]  # start time of the first product
+        end_all = product_tuples[-1][1]  # end time of the last product
+        previous_power = unit.get_output_before(
+            start
+        )  # power output of the unit before the start time of the first product
+        op_time = unit.get_operation_time(start)
+        min_power, max_power = unit.calculate_min_max_power(
+            start, end_all
+        )  # minimum and maximum power output of the unit between the start time of the first product and the end time of the last product
+
+        bids = []
+        for product in product_tuples:
+            # for each product, calculate the marginal cost of the unit at the start time of the product
+            # and the volume of the product. Dispatch the order to the market.
+            start = product[0]
+            current_power = unit.outputs["energy"].at[
+                start
+            ]  # power output of the unit at the start time of the current product
+            marginal_cost = unit.calculate_marginal_cost(
+                start, previous_power
+            )  # calculation of the marginal costs
+            volume = unit.calculate_ramp(
+                op_time, previous_power, max_power[start], current_power
+            )
+            print(f"> requesting bid for time from {product[0]} to {product[1]}")
+            print(f"> power must be between {min_power[start]} and {max_power[start]}")
+            print(f"> {previous_power=}, {current_power=}, {marginal_cost=}")
+            prompt = input("> waiting for volume and price, space-separated with a dot as decimal point \n")
+            volume, price = prompt.split(" ")
+            volume, price = float(volume), float(price)
+
+            bids.append(
+                {
+                    "start_time": product[0],
+                    "end_time": product[1],
+                    "only_hours": product[2],
+                    "price": price,
+                    "volume": volume,
+                    "node": unit.node,
+                }
+            )
+
+            if "node" in market_config.additional_fields:
+                bids[-1]["max_power"] = unit.max_power if volume > 0 else unit.min_power
+                bids[-1]["min_power"] = (
+                    min_power[start] if volume > 0 else unit.max_power
+                )
+
+            previous_power = volume + current_power
+            if previous_power > 0:
+                op_time = max(op_time, 0) + 1
+            else:
+                op_time = min(op_time, 0) - 1
+
+        if "node" in market_config.additional_fields:
+            return bids
+        else:
+            return self.remove_empty_bids(bids)

--- a/assume/strategies/manual_strategies.py
+++ b/assume/strategies/manual_strategies.py
@@ -61,9 +61,12 @@ class SimpleManualTerminalStrategy(BaseStrategy):
             print(f"> requesting bid for time from {product[0]} to {product[1]}")
             print(f"> power must be between {min_power[start]} and {max_power[start]}")
             print(f"> {previous_power=}, {current_power=}, {marginal_cost=}")
-            prompt = input("> waiting for volume and price, space-separated with a dot as decimal point \n")
-            volume, price = prompt.split(" ")
-            volume, price = float(volume), float(price)
+            try:
+                prompt = input("> waiting for volume and price, space-separated with a dot as decimal point \n")
+                volume, price = prompt.split(" ")
+                volume, price = float(volume), float(price)
+            except ValueError:
+                volume, price = 0, 0
 
             bids.append(
                 {

--- a/docs/source/distributed_simulation.rst
+++ b/docs/source/distributed_simulation.rst
@@ -51,7 +51,7 @@ which starts the simulation in your terminal.
 
 Or use two separate terminals, start the first one using:
 
-    python -m distributed_simulation.world_agents
+    python -m distributed_simulation.world_agent
 
 The script tries to connect to the manager now.
 Next step is to start the manager.

--- a/docs/source/manual_simulation.rst
+++ b/docs/source/manual_simulation.rst
@@ -1,0 +1,40 @@
+.. SPDX-FileCopyrightText: ASSUME Developers
+..
+.. SPDX-License-Identifier: AGPL-3.0-or-later
+
+#################
+Manual Simulation
+#################
+
+You can also be part of the simulation by submitting the bids yourself.
+This can be done to test a specific behavior, challenge yourself or create a game using a distributed simulation, where everyone can participate.
+
+Single Manual Terminal Client
+-----------------------------
+
+You can test this by opening the `example_01a/powerplant_units.csv` and change the bidding_strategy of a single powerplant from `naive_eom` to `manual_strategy`.
+
+Now run `assume -c tiny` in your terminal to have a small local simulation with assume, which prompts you for the bids of this single agent.
+
+Distributed Game
+----------------
+
+As shown in :doc:`distributed_simulation` - one can also run a distributed simulation where each participant manages a single unit operator and is asked for the bids of a unit.
+
+To now use the manual strategy in a distributed simulation, you can edit the `world_agent.py` and replace `naive_eom` with `manual_strategy`.
+Then you can first start a terminal for the agent:
+
+    python -m distributed_simulation.world_agent
+
+And run the manager in a separate window:
+
+    python -m distributed_simulation.world_manager
+
+This asks for the bids in the world_agent terminal while the manager waits for all agents to submit the bids.
+This can be extended to include better multi user support, which would make this useable in a game environment.
+
+Future Work
+-----------
+
+A common idea in university is to have an interactive market simulation where users can simulate market participation.
+By extending this small setup, one could create a webserver or GUI for each client, which would also allow to embed Grafana results for decision making.

--- a/examples/distributed_simulation/config.py
+++ b/examples/distributed_simulation/config.py
@@ -49,10 +49,10 @@ sim_id = "handmade_simulation"
 marketdesign = [
     MarketConfig(
         market_id="EOM",
-        opening_hours=rr.rrule(rr.HOURLY, interval=24, dtstart=start, until=end),
+        opening_hours=rr.rrule(rr.HOURLY, interval=1, dtstart=start, until=end),
         opening_duration=timedelta(hours=1),
         market_mechanism="pay_as_clear",
-        market_products=[MarketProduct(timedelta(hours=1), 24, timedelta(hours=1))],
+        market_products=[MarketProduct(timedelta(hours=1), 1, timedelta(hours=1))],
         additional_fields=["block_id", "link", "exclusive_id"],
     )
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ requires-python = ">=3.10"
 dependencies = [
     "argcomplete >=3.1.4",
     "nest-asyncio >=1.5.6",
-    "mango-agents-assume >=1.1.1-8",
+    "mango-agents-assume >=1.1.4-6",
     "numpy < 2", # Pyomo Incompatible
     "tqdm >=4.64.1",
     "python-dateutil >=2.8.2",


### PR DESCRIPTION
This adds a simple strategy which waits for the user to give a volume and price interactively.

At the last project meeting, I discussed such an idea and had in mind to contribute this "poor mans simulation" strategy, while it would be much cooler to have a web interface to interact with this in the future.

I added some docs on how this can be used as well.
While not particularly useful at the moment, I think this is also a good showcase of how flexible the framework is and can also be used to debug behavior, by inserting the wanted bids directly to the market.