### PR TITLE
Fix broken pypi builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,19 +46,19 @@ pip install assume-framework
 To install with reinforcement learning capabilities:
 
 ```bash
-pip install assume-framework[learning]
+pip install 'assume-framework[learning]'
 ```
 
 We also include market clearing algorithms for complex bids. These clearing algorithms require pyomo and a solver (we use GLPK). To install the package with these capabilities, use:
 
 ```bash
-pip install assume-framework[optimization]
+pip install 'assume-framework[optimization]'
 ```
 
 To install with testing capabilities:
 
 ```bash
-pip install assume-framework[test]
+pip install 'assume-framework[test]'
 ```
 
 ### Timescale Database and Grafana Dashboards

--- a/assume/units/__init__.py
+++ b/assume/units/__init__.py
@@ -5,5 +5,17 @@
 from assume.common.base import BaseUnit
 from assume.units.demand import Demand
 from assume.units.powerplant import PowerPlant
-from assume.units.steel_plant import SteelPlant
 from assume.units.storage import Storage
+
+unit_types: dict[str, BaseUnit] = {
+    "power_plant": PowerPlant,
+    "demand": Demand,
+    "storage": Storage,
+}
+
+try:
+    from assume.units.steel_plant import SteelPlant
+
+    unit_types["steel_plant"] = SteelPlant
+except ImportError:
+    pass

--- a/assume/world.py
+++ b/assume/world.py
@@ -33,7 +33,7 @@ from assume.common.base import LearningConfig
 from assume.common.utils import create_rrule, datetime2timestamp, timestamp2datetime
 from assume.markets import MarketRole, clearing_mechanisms
 from assume.strategies import LearningStrategy, bidding_strategies
-from assume.units import BaseUnit, Demand, PowerPlant, SteelPlant, Storage
+from assume.units import BaseUnit, unit_types
 
 file_handler = logging.FileHandler(filename="assume.log", mode="w+")
 stdout_handler = logging.StreamHandler(stream=sys.stdout)
@@ -126,18 +126,13 @@ class World:
         self.market_operators: dict[str, RoleAgent] = {}
         self.markets: dict[str, MarketConfig] = {}
         self.unit_operators: dict[str, UnitsOperator] = {}
-        self.unit_types = {
-            "power_plant": PowerPlant,
-            "demand": Demand,
-            "storage": Storage,
-            "steel_plant": SteelPlant,
-        }
+        self.unit_types = unit_types
 
         self.bidding_strategies = bidding_strategies
 
         if "pp_learning" not in bidding_strategies:
             logger.info(
-                "Learning Strategies not available. Check that you have all required packages installed (torch)."
+                "Learning Strategies are not available. Check that you have torch installed."
             )
 
         self.clearing_mechanisms: dict[str, MarketRole] = clearing_mechanisms

--- a/examples/world_script_policy.py
+++ b/examples/world_script_policy.py
@@ -30,7 +30,7 @@ async def init():
     index = pd.date_range(
         start=start,
         end=end + timedelta(hours=24),
-        freq="H",
+        freq="h",
     )
     sim_id = "world_script_policy"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "assume-framework"
-version = "0.4.0"
+version = "0.4.0.post2"
 description = "ASSUME - Agent-Based Electricity Markets Simulation Toolbox"
 authors = [{ name = "ASSUME Developers", email = "contact@assume-project.de"}]
 license = {text = "AGPL-3.0-or-later"}
@@ -75,7 +75,7 @@ repository = "https://github.com/assume-framework/assume"
 assume = "assume_cli.cli:cli"
 
 [tool.setuptools]
-packages = ["assume", "assume_cli"]
+packages = {find = {}}
 
 [tool.ruff]
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #[issue number] (if applicable)

## Description
The switch from poetry to setuptools has introduced a critical error into the building of the package and the latest release of ASSUME on pypi is broken as no files of the framework are provided and it doesn't work. This commit should fix this issue. The pypi release has also been updated using this update to ensure the functionality of the package. It also fixes the problem of importing steel_plant when no pyomo is installed. 

## Changes Proposed
- use [tool.setuptools]
packages = {find = {}}
- use units directly inside __init__.py for unit types to adress issues with pyomo
- fix smaller pandas things

## Testing
Created a new environment and ran the examples and notebooks

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [x] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
[Add screenshots to demonstrate visual changes]
