### PR TITLE
downgrade pyyaml include for now

### DIFF
--- a/assume/scenario/loader_amiris.py
+++ b/assume/scenario/loader_amiris.py
@@ -10,7 +10,7 @@ import dateutil.rrule as rr
 import pandas as pd
 import yaml
 from dateutil.relativedelta import relativedelta as rd
-from yaml_include import Constructor
+from yamlinclude import YamlIncludeConstructor
 
 from assume.common.forecasts import NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
@@ -442,7 +442,9 @@ def add_agent_to_world(
 
 
 def read_amiris_yaml(base_path):
-    Constructor.add_to_loader_class(loader_class=yaml.FullLoader, base_dir=base_path)
+    YamlIncludeConstructor.add_to_loader_class(
+        loader_class=yaml.FullLoader, base_dir=base_path
+    )
 
     with open(base_path + "/scenario.yaml", "rb") as f:
         amiris_scenario = yaml.load(f, Loader=yaml.FullLoader)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,8 @@ dependencies = [
     "pandas >=2.0.0",
     "psycopg2-binary >=2.9.5",
     "pyyaml >=6.0",
-    "pyyaml-include >=2.0",
+    "pyyaml-include <2.0",
+    # until https://github.com/tanbro/pyyaml-include/pull/48 is released
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Pyyaml-Include does not like loading of the included Contracts in Amiris like `Contracts: !include ["contracts/*.yaml", "Contracts"]`.

see https://github.com/tanbro/pyyaml-include/pull/48

Once this PR is merged and released, we can update to pyyaml-include 2.x