### PR TITLE
Fix storages

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -613,9 +613,8 @@ class SupportsMinMaxCharge(BaseUnit):
         Returns:
             float: The discharging power adjusted to the ramping constraints.
         """
-        # vorher laden  -800 MW  möchte zu 200 MW - muss aber vorher gucken ob das vom Laden überhaupt klappt
-        # - 800 MW nach 0 mit charge ramp down und dann 200 MW mit discharge_ramp_up
-
+        # previously charging -800 MW wants to go to 200 MW - but must first check if charging is even possible
+        # - 800 MW to 0 with charge ramp down and then 200 MW with discharge ramp up
         # if storage was charging before we need to check if we can ramp back to zero
         # assert power_discharge >= 0
         if (

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -130,7 +130,8 @@ class flexableEOMStorage(BaseStrategy):
 
             # if price is higher than average price, discharge
             # if price is lower than average price, charge
-            if price_forecast[start] >= average_price:
+            # if price forecast favors discharge, but max discharge is zero, set a bid for charging
+            if price_forecast[start] >= average_price and max_power_discharge[start]:
                 price = average_price / unit.efficiency_discharge
                 bid_quantity = max_power_discharge[start]
             else:

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -130,18 +130,18 @@ class Storage(SupportsMinMaxCharge):
         # if ramp_up_charge == 0, the ramp_up_charge is set to the max_power_charge
         # else the ramp_up_charge is set to the negative value of the ramp_up_charge
         self.ramp_up_charge = (
-            self.max_power_charge if ramp_up_charge is None else -abs(ramp_up_charge)
+            self.max_power_charge - self.max_power_discharge if ramp_up_charge is None else -abs(ramp_up_charge)
         )
         self.ramp_down_charge = (
-            self.min_power_charge
+            self.max_power_charge - self.max_power_discharge
             if ramp_down_charge is None
             else -abs(ramp_down_charge)
         )
         self.ramp_up_discharge = (
-            self.max_power_discharge if ramp_up_discharge is None else ramp_up_discharge
+            self.max_power_discharge - self.max_power_charge if ramp_up_discharge is None else ramp_up_discharge
         )
         self.ramp_down_discharge = (
-            self.min_power_discharge
+            self.max_power_discharge - self.max_power_charge
             if ramp_down_discharge is None
             else ramp_down_discharge
         )

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -123,7 +123,7 @@ class Storage(SupportsMinMaxCharge):
         self.emission_factor = emission_factor
 
         # The ramp up/down rate of charging/discharging the storage unit.
-        # if ramp_up_charge == 0, the ramp_up_charge is set to the max_power_charge
+        # if ramp_up_charge == 0, the ramp_up_charge is set to enable ramping between full charge and discharge power
         # else the ramp_up_charge is set to the negative value of the ramp_up_charge
         self.ramp_up_charge = (
             self.max_power_charge - self.max_power_discharge

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -97,14 +97,10 @@ class Storage(SupportsMinMaxCharge):
             **kwargs,
         )
 
-        self.max_power_charge = (
-            max_power_charge if max_power_charge <= 0 else -max_power_charge
-        )
-        self.min_power_charge = (
-            min_power_charge if min_power_charge <= 0 else -min_power_charge
-        )
-        self.max_power_discharge = max_power_discharge
-        self.min_power_discharge = min_power_discharge
+        self.max_power_charge = -abs(max_power_charge)
+        self.min_power_charge = -abs(min_power_charge)
+        self.max_power_discharge = abs(max_power_discharge)
+        self.min_power_discharge = abs(min_power_discharge)
         self.initial_soc = initial_soc
         self.outputs["soc"] = pd.Series(self.initial_soc, index=self.index, dtype=float)
 
@@ -130,19 +126,23 @@ class Storage(SupportsMinMaxCharge):
         # if ramp_up_charge == 0, the ramp_up_charge is set to the max_power_charge
         # else the ramp_up_charge is set to the negative value of the ramp_up_charge
         self.ramp_up_charge = (
-            self.max_power_charge - self.max_power_discharge if ramp_up_charge is None else -abs(ramp_up_charge)
+            self.max_power_charge - self.max_power_discharge
+            if not ramp_up_charge
+            else -abs(ramp_up_charge)
         )
         self.ramp_down_charge = (
             self.max_power_charge - self.max_power_discharge
-            if ramp_down_charge is None
+            if not ramp_down_charge
             else -abs(ramp_down_charge)
         )
         self.ramp_up_discharge = (
-            self.max_power_discharge - self.max_power_charge if ramp_up_discharge is None else ramp_up_discharge
+            self.max_power_discharge - self.max_power_charge
+            if not ramp_up_discharge
+            else ramp_up_discharge
         )
         self.ramp_down_discharge = (
             self.max_power_discharge - self.max_power_charge
-            if ramp_down_discharge is None
+            if not ramp_down_discharge
             else ramp_down_discharge
         )
 
@@ -380,6 +380,8 @@ class Storage(SupportsMinMaxCharge):
     ) -> tuple[pd.Series]:
         """
         Calculates the min and max charging power for the given time period.
+        This is relative to the already sold output on other markets for the same period.
+        It also adheres to reserved positive and negative capacities.
 
         Args:
             start (pandas.Timestamp): The start of the current dispatch.
@@ -428,6 +430,8 @@ class Storage(SupportsMinMaxCharge):
     ) -> tuple[pd.Series]:
         """
         Calculates the min and max discharging power for the given time period.
+        This is relative to the already sold output on other markets for the same period.
+        It also adheres to reserved positive and negative capacities.
 
         Args:
             start (pandas.Timestamp): The start of the current dispatch.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -99,6 +99,7 @@ Documentation
    buffers
    support_policies
    distributed_simulation
+   manual_simulation
    command_line_interface
    assume
 

--- a/docs/source/market_config.rst
+++ b/docs/source/market_config.rst
@@ -88,7 +88,7 @@ It then makes sense to reschedule the market clearing all 4 hours, but it would 
 
 
 Please note, Trade Convention
-----------------
+-----------------------------
 
 In our market trading system, we follow this convention for representing the volume and price of trades in any market:
 

--- a/tests/test_flexable_storage_strategies.py
+++ b/tests/test_flexable_storage_strategies.py
@@ -112,7 +112,7 @@ def test_flexable_eom_storage(mock_market_config, storage):
     ]
     storage.forecaster = NaiveForecast(index, availability=1, price_forecast=forecast)
     bids = strategy.calculate_bids(storage, mc, product_tuples=product_tuples)
-    assert len(bids) == 20
+    assert len(bids) == 24
     assert math.isclose(
         bids[0]["price"],
         np.mean(forecast[0:13]) * storage.efficiency_charge,
@@ -138,23 +138,23 @@ def test_flexable_eom_storage(mock_market_config, storage):
     )
     assert bids[3]["volume"] == -100
     assert math.isclose(
-        bids[7]["price"],
-        np.mean(forecast[0:21]) / storage.efficiency_discharge,
+        bids[4]["price"],
+        np.mean(forecast[0:17]) / storage.efficiency_discharge,
         abs_tol=0.01,
     )
-    assert math.isclose(bids[7]["volume"], 100, abs_tol=0.01)
+    assert math.isclose(bids[4]["volume"], 60, abs_tol=0.01)
     assert math.isclose(
-        bids[11]["price"],
+        bids[14]["price"],
         np.mean(forecast[2:]) * storage.efficiency_charge,
         abs_tol=0.01,
     )
-    assert bids[11]["volume"] == -60
+    assert bids[14]["volume"] == -100
     assert math.isclose(
-        bids[1]["price"],
-        np.mean(forecast[:14]) * storage.efficiency_charge,
+        bids[20]["price"],
+        np.mean(forecast[6:]) * storage.efficiency_charge,
         abs_tol=0.01,
     )
-    assert bids[1]["volume"] == -100
+    assert bids[20]["volume"] == -60
 
 
 def test_flexable_pos_crm_storage(mock_market_config, storage):
@@ -195,7 +195,7 @@ def test_flexable_pos_crm_storage(mock_market_config, storage):
         (start + pd.Timedelta(hours=1), end + pd.Timedelta(hours=1), None)
     ]
     bids = strategy.calculate_bids(storage, mc, product_tuples=product_tuples)
-    assert bids == []
+    assert len(bids) == 1
 
 
 def test_flexable_neg_crm_storage(mock_market_config, storage):
@@ -228,7 +228,7 @@ def test_flexable_neg_crm_storage(mock_market_config, storage):
         (start + pd.Timedelta(hours=1), end + pd.Timedelta(hours=1), None)
     ]
     bids = strategy.calculate_bids(storage, mc, product_tuples=product_tuples)
-    assert bids == []
+    assert len(bids) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_flexable_storage_strategies.py
+++ b/tests/test_flexable_storage_strategies.py
@@ -142,19 +142,19 @@ def test_flexable_eom_storage(mock_market_config, storage):
         np.mean(forecast[0:21]) / storage.efficiency_discharge,
         abs_tol=0.01,
     )
-    assert math.isclose(bids[7]["volume"], 14.444, abs_tol=0.01)
+    assert math.isclose(bids[7]["volume"], 100, abs_tol=0.01)
     assert math.isclose(
         bids[11]["price"],
-        np.mean(forecast[0:25]) / storage.efficiency_discharge,
+        np.mean(forecast[2:]) * storage.efficiency_charge,
         abs_tol=0.01,
     )
-    assert bids[11]["volume"] == 100
+    assert bids[11]["volume"] == -60
     assert math.isclose(
-        bids[14]["price"],
-        np.mean(forecast[4:]) * storage.efficiency_charge,
+        bids[1]["price"],
+        np.mean(forecast[:14]) * storage.efficiency_charge,
         abs_tol=0.01,
     )
-    assert bids[14]["volume"] == -100
+    assert bids[1]["volume"] == -100
 
 
 def test_flexable_pos_crm_storage(mock_market_config, storage):

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -276,7 +276,7 @@ def test_storage_ramping(storage_unit):
     )
 
     assert max_ramp_discharge == 100
-    assert max_ramp_charge == 0
+    assert max_ramp_charge == -60
 
     # chargin scenario
     storage_unit.outputs["energy"][start] = -60
@@ -298,7 +298,7 @@ def test_storage_ramping(storage_unit):
         0.5, -60, max_power_charge[start]
     )
 
-    assert max_ramp_discharge == 0
+    assert max_ramp_discharge == 60
     assert max_ramp_charge == -100
 
 
@@ -429,15 +429,7 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     product_tuples = [(start, end, None)]
 
     bids = strategy.calculate_bids(storage_unit, mc, product_tuples=product_tuples)
-    assert len(bids) == 0
-
-    storage_unit.outputs["energy"][start] = -100
-
-    storage_unit.set_dispatch_plan(mc, bids)
-    storage_unit.execute_current_dispatch(start, end)
-
-    assert storage_unit.outputs["energy"][start] == 0
-    assert math.isclose(storage_unit.outputs["soc"][end], 1, abs_tol=0.001)
+    assert len(bids) == 1
 
 
 if __name__ == "__main__":

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -109,11 +109,11 @@ def test_minmaxcharge():
         "Test", "TestOperator", "TestTechnology", {}, None, "empty"
     )
 
-    mmc.ramp_down_charge = 100
+    mmc.ramp_down_charge = -100
     mmc.ramp_down_discharge = 100
-    mmc.ramp_up_charge = 100
+    mmc.ramp_up_charge = -100
     mmc.ramp_up_discharge = 100
-    mmc.max_power_charge = 1000
+    mmc.max_power_charge = -1000
     mmc.max_power_discharge = 1000
     mmc.min_power_charge = 0
     mmc.min_power_discharge = 0
@@ -131,6 +131,39 @@ def test_minmaxcharge():
         )
         == 0
     )
+    # calculate ramping
+    # should be previous_power + 100
+    assert mmc.calculate_ramp_discharge(0, 992, 0) == 100
+    assert mmc.calculate_ramp_discharge(-10, 992, 0) == 90
+
+    assert mmc.calculate_ramp_charge(-10, -200, 0) == -110
+
+
+def test_minmaxcharge_unconstrained():
+    mmc = SupportsMinMaxCharge(
+        "Test", "TestOperator", "TestTechnology", {}, None, "empty"
+    )
+
+    # 1. wenn ramp nicht definiert ist, sollte es auch keine constraints erzeugen
+    # 2. alle maximal/minimal und ramp werte werden positiv angegeben
+    # 
+
+    mmc.max_power_charge = -1000 # MW
+    mmc.max_power_discharge = 1000 # MW
+    mmc.ramp_up_charge =  -2000  # None
+    mmc.ramp_down_charge = -2000
+    mmc.ramp_up_discharge = 2000
+    mmc.ramp_down_discharge = 2000
+    mmc.min_power_charge = -0
+    mmc.min_power_discharge = 0
+
+    # calculate ramping
+    # should be previous_power + max_power
+    assert mmc.calculate_ramp_discharge(previous_power=0, power_discharge=992, current_power=0) == 992
+    assert mmc.calculate_ramp_discharge(previous_power=-10, power_discharge=992, current_power=0) == 992
+
+    assert mmc.calculate_ramp_charge(0, -992, 0) == -992
+    assert mmc.calculate_ramp_charge(-10, -992, 0) == -992
 
 
 def test_minmax_operationtime():

--- a/tests/test_units.py
+++ b/tests/test_units.py
@@ -131,10 +131,11 @@ def test_minmaxcharge():
         )
         == 0
     )
+
     # calculate ramping
     # should be previous_power + 100
     assert mmc.calculate_ramp_discharge(0, 992, 0) == 100
-    assert mmc.calculate_ramp_discharge(-10, 992, 0) == 90
+    assert mmc.calculate_ramp_discharge(-10, 992, 0) == 100
 
     assert mmc.calculate_ramp_charge(-10, -200, 0) == -110
 
@@ -146,21 +147,23 @@ def test_minmaxcharge_unconstrained():
 
     # 1. wenn ramp nicht definiert ist, sollte es auch keine constraints erzeugen
     # 2. alle maximal/minimal und ramp werte werden positiv angegeben
-    # 
+    #
 
-    mmc.max_power_charge = -1000 # MW
-    mmc.max_power_discharge = 1000 # MW
-    mmc.ramp_up_charge =  -2000  # None
+    mmc.max_power_charge = -1000  # MW
+    mmc.max_power_discharge = 1000  # MW
+    # ramp constraints
+    mmc.ramp_up_charge = -2000
     mmc.ramp_down_charge = -2000
     mmc.ramp_up_discharge = 2000
     mmc.ramp_down_discharge = 2000
+    # min power
     mmc.min_power_charge = -0
     mmc.min_power_discharge = 0
 
     # calculate ramping
     # should be previous_power + max_power
-    assert mmc.calculate_ramp_discharge(previous_power=0, power_discharge=992, current_power=0) == 992
-    assert mmc.calculate_ramp_discharge(previous_power=-10, power_discharge=992, current_power=0) == 992
+    assert mmc.calculate_ramp_discharge(0, 992, 0) == 992
+    assert mmc.calculate_ramp_discharge(-10, 992, 0) == 992
 
     assert mmc.calculate_ramp_charge(0, -992, 0) == -992
     assert mmc.calculate_ramp_charge(-10, -992, 0) == -992


### PR DESCRIPTION
This includes various fixes to the current storage calculation:

* remove ramping constraints if non are set
* if price forecast favors discharge, but max discharge is zero, set a bid for charging (instead of a bid with a volume of 0)
* make sure that all `charge` properties are negative and all `discharge` properties are positive
* refactor calculate_ramp_charge/calculate_ramp_discharge in base.py

I discussed with @kim-mskw about changing this, so that all max_charge/discharge properties are positive, but I dropped this idea as I had a hard time chasing errors that arose from that.

Some tests had to be adjusted, I am quite sure that the ramping (which is actually not really used for now) works the way as intended now.

Background:

When adding a storage_unit to example_01a, one did have an hour in which no bid was set at all.
I tried to find that. As the market returns the rejected bids as well, this was not an issue of the market but of the bidding strategy. This is fixed by the second bullet.

This PR is not yet ready to be merged, Documentation is still missing