### PR TITLE
Fix pypsa version

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -15,7 +15,7 @@ dependencies:
 - SQLAlchemy
 - matplotlib
 - pyomo
-- pypsa>=0.26.3
+- pypsa<=0.30.3
 - pyyaml
 
 - pip:

--- a/examples/notebooks/07_interoperability_example.ipynb
+++ b/examples/notebooks/07_interoperability_example.ipynb
@@ -54,7 +54,7 @@
     "# When running on your local machine, you can simply run pip install assume-framework[optimization]\n",
     "!pip install pyomo\n",
     "!apt-get install -y -qq glpk-utils\n",
-    "!pip install pypsa<=0.30.3\n",
+    "!pip install pypsa==0.30.3\n",
     "\n",
     "!pip install assume-framework"
    ]

--- a/examples/notebooks/07_interoperability_example.ipynb
+++ b/examples/notebooks/07_interoperability_example.ipynb
@@ -49,6 +49,13 @@
    },
    "outputs": [],
    "source": [
+    "# Install Pyomo, GLPK solver, and PyPSA\n",
+    "# This is needed only when running on Google Colab\n",
+    "# When running on your local machine, you can simply run pip install assume-framework[optimization]\n",
+    "!pip install pyomo\n",
+    "!apt-get install -y -qq glpk-utils\n",
+    "!pip install pypsa<=0.30.3\n",
+    "\n",
     "!pip install assume-framework"
    ]
   },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ learning = [
 optimization = [
     "glpk >=0.4.7",
     "pyomo >=6.6.1",
-    "pypsa >=0.26.3",
+    "pypsa <=0.30.3",
 ]
 oeds = [
     "demandlib >=0.1.9",


### PR DESCRIPTION
The lates pypsa release is not compatible with our framework and causes problems.

-fix the version to the 0.30.3 before we update the framework 
-update the notebook 7 to use the correct version of pypsa