### PR TITLE
in the jupyter notebooks we only want a shallow clone with only the last commit

### DIFF
--- a/examples/notebooks/03_custom_unit_example.ipynb
+++ b/examples/notebooks/03_custom_unit_example.ipynb
@@ -149,7 +149,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/assume-framework/assume.git assume-repo"
+    "!git clone --depth=1 https://github.com/assume-framework/assume.git assume-repo"
    ]
   },
   {

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -182,7 +182,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/assume-framework/assume.git assume-repo"
+    "!git clone --depth=1 https://github.com/assume-framework/assume.git assume-repo"
    ]
   },
   {

--- a/examples/notebooks/05_market_comparison.ipynb
+++ b/examples/notebooks/05_market_comparison.ipynb
@@ -98,7 +98,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/assume-framework/assume.git assume-repo"
+    "!git clone --depth=1 https://github.com/assume-framework/assume.git assume-repo"
    ]
   },
   {

--- a/examples/notebooks/06_advanced_orders_example.ipynb
+++ b/examples/notebooks/06_advanced_orders_example.ipynb
@@ -172,7 +172,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/assume-framework/assume.git assume-repo"
+    "!git clone --depth=1 https://github.com/assume-framework/assume.git assume-repo"
    ]
   },
   {

--- a/examples/notebooks/07_interoperability_example.ipynb
+++ b/examples/notebooks/07_interoperability_example.ipynb
@@ -76,7 +76,7 @@
    },
    "outputs": [],
    "source": [
-    "!git clone https://github.com/assume-framework/assume.git assume-repo"
+    "!git clone --depth=1 https://github.com/assume-framework/assume.git assume-repo"
    ]
   },
   {


### PR DESCRIPTION
This reduces the compressed git repository size from 100MB to 10MB (but people can not easily checkout other branches)