### PR TITLE
Add AC carrier to pypsa network to remove warnings in redispatch

### DIFF
--- a/assume/common/grid_utils.py
+++ b/assume/common/grid_utils.py
@@ -272,6 +272,7 @@ def read_pypsa_grid(
     # setup the network
     add_buses(network, grid_dict["buses"])
     add_lines(network, grid_dict["lines"])
+    network.add("Carrier", "AC")
     return network
 
 


### PR DESCRIPTION
The pypsa kept returning warnings, which is annoying, and this fixes that