### PR TITLE
Fix cashflow calculation for single digit orders

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import TypedDict
 
 import numpy as np
@@ -273,9 +273,9 @@ class BaseUnit:
                 cashflow = float(
                     order.get("accepted_price", 0) * order.get("accepted_volume", 0)
                 )
-                hours = (end - start) / timedelta(hours=1)
+                elapsed_intervals = (end - start) / pd.Timedelta(self.index.freq)
                 self.outputs[f"{product_type}_cashflow"].loc[start:end_excl] += (
-                    cashflow * hours
+                    cashflow * elapsed_intervals
                 )
 
     def get_starting_costs(self, op_time: int) -> float:

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -34,10 +34,10 @@ class BasicStrategy(BaseStrategy):
         return bids
 
 
-@pytest.fixture
-def base_unit() -> BaseUnit:
+@pytest.fixture(params=["h", "15min"])
+def base_unit(request) -> BaseUnit:
     # Create a PowerPlant instance with some example parameters
-    index = pd.date_range("2022-01-01", periods=4, freq="h")
+    index = pd.date_range("2022-01-01", periods=4, freq=request.param)
     NaiveForecast(
         index, availability=1, fuel_price=[10, 11, 12, 13], co2_price=[10, 20, 30, 30]
     )
@@ -234,3 +234,7 @@ def test_clear_empty_bids(base_unit, mock_market_config):
         mock_market_config.market_id
     ].remove_empty_bids(mixed_bids)
     assert mixed_bids_result == [bid for bid in mixed_bids if bid["volume"] > 0]
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #450 

## Description
Previously the single digit cash flow was calculated based on the assumption that the index frequency is 1 hour. If not, the calculation leads to a wrong result.

## Changes Proposed
- Instead of using the timedelta of 1h all the time, use the one provided by the date index.

## Testing
Added parametrized test annotation to check for different index configuration in the `BaseUnit` 

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [x] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
