### PR TITLE
move actor related method to AbstractLearningStrategy

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -812,38 +812,6 @@ class LearningStrategy(BaseStrategy):
         # them into suitable format for recurrent neural networks
         self.num_timeseries_obs_dim = num_timeseries_obs_dim
 
-    def load_actor_params(self, load_path):
-        """
-        Load actor parameters.
-
-        Args:
-            load_path (str): The path to load parameters from.
-        """
-        directory = f"{load_path}/actors/actor_{self.unit_id}.pt"
-
-        params = th.load(directory, map_location=self.device, weights_only=True)
-
-        self.actor = self.actor_architecture_class(
-            obs_dim=self.obs_dim,
-            act_dim=self.act_dim,
-            float_type=self.float_type,
-            unique_obs_dim=self.unique_obs_dim,
-            num_timeseries_obs_dim=self.num_timeseries_obs_dim,
-        ).to(self.device)
-        self.actor.load_state_dict(params["actor"])
-
-        if self.learning_mode:
-            self.actor_target = self.actor_architecture_class(
-                obs_dim=self.obs_dim,
-                act_dim=self.act_dim,
-                float_type=self.float_type,
-                unique_obs_dim=self.unique_obs_dim,
-                num_timeseries_obs_dim=self.num_timeseries_obs_dim,
-            ).to(self.device)
-            self.actor_target.load_state_dict(params["actor_target"])
-            self.actor_target.eval()
-            self.actor.optimizer.load_state_dict(params["actor_optimizer"])
-
 
 class LearningConfig(TypedDict):
     """


### PR DESCRIPTION
This adds the suggested change to #464  

We currently import `from assume.strategies.learning_strategies import RLStrategy` in learning_advanced_orders.py` as well, so its safe to move it the AbstractLearningStrategy to `learning_strategies.py`, 