### PR TITLE
Fixing of drl tutorial bugs

### DIFF
--- a/examples/inputs/example_02a/config.yaml
+++ b/examples/inputs/example_02a/config.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
 base:
   end_date: 2019-03-31 00:00
   learning_config:

--- a/examples/inputs/example_02a/config.yaml
+++ b/examples/inputs/example_02a/config.yaml
@@ -1,137 +1,121 @@
-# SPDX-FileCopyrightText: ASSUME Developers
-#
-# SPDX-License-Identifier: AGPL-3.0-or-later
-
-tiny:
-  start_date: 2019-01-01 00:00
-  end_date: 2019-01-05 00:00
-  time_step: 1h
-  save_frequency_hours: null
-  learning_mode: True
-
-  learning_config:
-    continue_learning: False
-    trained_policies_save_path: null
-    max_bid_price: 100
-    algorithm: matd3
-    actor_architecture: mlp
-    learning_rate: 0.001
-    training_episodes: 10
-    episodes_collecting_initial_experience: 3
-    train_freq: 24h
-    gradient_steps: -1
-    batch_size: 64
-    gamma: 0.99
-    device: cpu
-    noise_sigma: 0.1
-    noise_scale: 1
-    noise_dt: 1
-    validation_episodes_interval: 5
-
-  markets_config:
-    EOM:
-      operator: EOM_operator
-      product_type: energy
-      products:
-        - duration: 1h
-          count: 1
-          first_delivery: 1h
-      opening_frequency: 1h
-      opening_duration: 1h
-      volume_unit: MWh
-      maximum_bid_volume: 100000
-      maximum_bid_price: 3000
-      minimum_bid_price: -500
-      price_unit: EUR/MWh
-      market_mechanism: pay_as_clear
-
-
 base:
-  start_date: 2019-03-01 00:00
   end_date: 2019-03-31 00:00
-  time_step: 1h
-  save_frequency_hours: null
-  learning_mode: True
-
   learning_config:
-    continue_learning: False
-    trained_policies_save_path: null
-    max_bid_price: 100
     algorithm: matd3
-    actor_architecture: mlp
-    learning_rate: 0.001
-    training_episodes: 50
-    episodes_collecting_initial_experience: 5
-    train_freq: 24h
-    gradient_steps: -1
     batch_size: 256
-    gamma: 0.99
+    continue_learning: false
     device: cpu
-    noise_sigma: 0.1
-    noise_scale: 1
+    episodes_collecting_initial_experience: 5
+    gamma: 0.99
+    gradient_steps: -1
+    learning_rate: 0.001
+    max_bid_price: 100
     noise_dt: 1
+    noise_scale: 1
+    noise_sigma: 0.1
+    train_freq: 24h
+    trained_policies_save_path: null
+    training_episodes: 100
     validation_episodes_interval: 5
-    early_stopping_steps: 10
-    early_stopping_threshold: 0.05
-
+  learning_mode: true
   markets_config:
     EOM:
+      market_mechanism: pay_as_clear
+      maximum_bid_price: 3000
+      maximum_bid_volume: 100000
+      minimum_bid_price: -500
+      opening_duration: 1h
+      opening_frequency: 1h
       operator: EOM_operator
+      price_unit: EUR/MWh
       product_type: energy
       products:
-        - duration: 1h
-          count: 1
-          first_delivery: 1h
-      opening_frequency: 1h
-      opening_duration: 1h
+      - count: 1
+        duration: 1h
+        first_delivery: 1h
       volume_unit: MWh
-      maximum_bid_volume: 100000
-      maximum_bid_price: 3000
-      minimum_bid_price: -500
-      price_unit: EUR/MWh
-      market_mechanism: pay_as_clear
-
+  save_frequency_hours: null
+  start_date: 2019-03-01 00:00
+  time_step: 1h
 base_lstm:
-  start_date: 2019-03-01 00:00
   end_date: 2019-03-31 00:00
-  time_step: 1h
-  save_frequency_hours: null
-  learning_mode: True
-
   learning_config:
-    continue_learning: False
-    trained_policies_save_path: null
-    max_bid_price: 100
-    algorithm: matd3
     actor_architecture: lstm
-    learning_rate: 0.001
-    training_episodes: 50
-    episodes_collecting_initial_experience: 5
-    train_freq: 24h
-    gradient_steps: -1
+    algorithm: matd3
     batch_size: 256
-    gamma: 0.99
+    continue_learning: false
     device: cpu
-    noise_sigma: 0.1
-    noise_scale: 1
-    noise_dt: 1
-    validation_episodes_interval: 5
     early_stopping_steps: 10
     early_stopping_threshold: 0.05
-
+    episodes_collecting_initial_experience: 5
+    gamma: 0.99
+    gradient_steps: -1
+    learning_rate: 0.001
+    max_bid_price: 100
+    noise_dt: 1
+    noise_scale: 1
+    noise_sigma: 0.1
+    train_freq: 24h
+    trained_policies_save_path: null
+    training_episodes: 50
+    validation_episodes_interval: 5
+  learning_mode: true
   markets_config:
     EOM:
+      market_mechanism: pay_as_clear
+      maximum_bid_price: 3000
+      maximum_bid_volume: 100000
+      minimum_bid_price: -500
+      opening_duration: 1h
+      opening_frequency: 1h
       operator: EOM_operator
+      price_unit: EUR/MWh
       product_type: energy
       products:
-        - duration: 1h
-          count: 1
-          first_delivery: 1h
-      opening_frequency: 1h
-      opening_duration: 1h
+      - count: 1
+        duration: 1h
+        first_delivery: 1h
       volume_unit: MWh
-      maximum_bid_volume: 100000
-      maximum_bid_price: 3000
-      minimum_bid_price: -500
-      price_unit: EUR/MWh
+  save_frequency_hours: null
+  start_date: 2019-03-01 00:00
+  time_step: 1h
+tiny:
+  end_date: 2019-01-05 00:00
+  learning_config:
+    actor_architecture: mlp
+    algorithm: matd3
+    batch_size: 64
+    continue_learning: false
+    device: cpu
+    episodes_collecting_initial_experience: 3
+    gamma: 0.99
+    gradient_steps: -1
+    learning_rate: 0.001
+    max_bid_price: 100
+    noise_dt: 1
+    noise_scale: 1
+    noise_sigma: 0.1
+    train_freq: 24h
+    trained_policies_save_path: null
+    training_episodes: 10
+    validation_episodes_interval: 5
+  learning_mode: true
+  markets_config:
+    EOM:
       market_mechanism: pay_as_clear
+      maximum_bid_price: 3000
+      maximum_bid_volume: 100000
+      minimum_bid_price: -500
+      opening_duration: 1h
+      opening_frequency: 1h
+      operator: EOM_operator
+      price_unit: EUR/MWh
+      product_type: energy
+      products:
+      - count: 1
+        duration: 1h
+        first_delivery: 1h
+      volume_unit: MWh
+  save_frequency_hours: null
+  start_date: 2019-01-01 00:00
+  time_step: 1h

--- a/examples/notebooks/04_reinforcement_learning_algorithm_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_algorithm_example.ipynb
@@ -37,7 +37,47 @@
     "id": "m0DaRwFA7VgW",
     "outputId": "5655adad-5b7a-4fe3-9067-6b502a06136b"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: assume-framework[learning] in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (0.4.3)\n",
+      "Requirement already satisfied: argcomplete>=3.1.4 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (3.5.1)\n",
+      "Requirement already satisfied: nest-asyncio>=1.5.6 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (1.6.0)\n",
+      "Requirement already satisfied: mango-agents>=2.1.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.1.1)\n",
+      "Requirement already satisfied: numpy>=1.26.4 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (1.26.4)\n",
+      "Requirement already satisfied: tqdm>=4.64.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (4.66.6)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.9.0)\n",
+      "Requirement already satisfied: sqlalchemy>=2.0.9 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.0.36)\n",
+      "Requirement already satisfied: pandas>=2.0.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.2.3)\n",
+      "Requirement already satisfied: psycopg2-binary>=2.9.5 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.9.10)\n",
+      "Requirement already satisfied: pyyaml>=6.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (6.0.2)\n",
+      "Requirement already satisfied: pyyaml-include>=2.2a in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.2a1)\n",
+      "Requirement already satisfied: pyomo>=6.8.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (6.8.0)\n",
+      "Requirement already satisfied: highspy in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (1.8.0)\n",
+      "Requirement already satisfied: torch>=2.0.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from assume-framework[learning]) (2.5.1)\n",
+      "Requirement already satisfied: paho-mqtt>=2.1.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from mango-agents>=2.1.1->assume-framework[learning]) (2.1.0)\n",
+      "Requirement already satisfied: dill>=0.3.8 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from mango-agents>=2.1.1->assume-framework[learning]) (0.3.9)\n",
+      "Requirement already satisfied: protobuf==5.27.2 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from mango-agents>=2.1.1->assume-framework[learning]) (5.27.2)\n",
+      "Requirement already satisfied: networkx>=3.4.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from mango-agents>=2.1.1->assume-framework[learning]) (3.4.2)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pandas>=2.0.0->assume-framework[learning]) (2024.2)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pandas>=2.0.0->assume-framework[learning]) (2024.2)\n",
+      "Requirement already satisfied: ply in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pyomo>=6.8.0->assume-framework[learning]) (3.11)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from python-dateutil>=2.8.2->assume-framework[learning]) (1.16.0)\n",
+      "Requirement already satisfied: fsspec>=2021.04.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pyyaml-include>=2.2a->assume-framework[learning]) (2024.10.0)\n",
+      "Requirement already satisfied: typing-extensions>=4.6.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from sqlalchemy>=2.0.9->assume-framework[learning]) (4.12.2)\n",
+      "Requirement already satisfied: greenlet!=0.4.17 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from sqlalchemy>=2.0.9->assume-framework[learning]) (3.1.1)\n",
+      "Requirement already satisfied: filelock in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from torch>=2.0.1->assume-framework[learning]) (3.16.1)\n",
+      "Requirement already satisfied: jinja2 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from torch>=2.0.1->assume-framework[learning]) (3.1.4)\n",
+      "Requirement already satisfied: setuptools in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from torch>=2.0.1->assume-framework[learning]) (75.1.0)\n",
+      "Requirement already satisfied: sympy==1.13.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from torch>=2.0.1->assume-framework[learning]) (1.13.1)\n",
+      "Requirement already satisfied: mpmath<1.4,>=1.1.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from sympy==1.13.1->torch>=2.0.1->assume-framework[learning]) (1.3.0)\n",
+      "Requirement already satisfied: colorama in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from tqdm>=4.64.1->assume-framework[learning]) (0.4.6)\n",
+      "Requirement already satisfied: MarkupSafe>=2.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from jinja2->torch>=2.0.1->assume-framework[learning]) (3.0.2)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install assume-framework[learning]"
    ]
@@ -112,11 +152,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7d9899ff",
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import importlib.util\n",
@@ -159,10 +195,7 @@
    "execution_count": null,
    "id": "ade14744",
    "metadata": {
-    "id": "xUsbeZdPJ_2Q",
-    "vscode": {
-     "languageId": "python"
-    }
+    "id": "xUsbeZdPJ_2Q"
    },
    "outputs": [],
    "source": [
@@ -219,10 +252,7 @@
    "execution_count": null,
    "id": "94517a3e",
    "metadata": {
-    "id": "UXYSesx4Ifp5",
-    "vscode": {
-     "languageId": "python"
-    }
+    "id": "UXYSesx4Ifp5"
    },
    "outputs": [],
    "source": [
@@ -424,11 +454,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "daed035c",
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class Learning(Learning):\n",
@@ -521,10 +547,7 @@
    "execution_count": null,
    "id": "632844c2",
    "metadata": {
-    "id": "0ww-L9fABnw3",
-    "vscode": {
-     "languageId": "python"
-    }
+    "id": "0ww-L9fABnw3"
    },
    "outputs": [],
    "source": [
@@ -582,11 +605,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c715f90e",
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TD3(TD3):\n",
@@ -654,11 +673,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "753dbab1",
-   "metadata": {
-    "vscode": {
-     "languageId": "python"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "class TD3(TD3):\n",
@@ -853,16 +868,13 @@
    "execution_count": null,
    "id": "6bb09b5b",
    "metadata": {
-    "id": "moZ_UD7FfkOh",
-    "vscode": {
-     "languageId": "python"
-    }
+    "id": "moZ_UD7FfkOh"
    },
    "outputs": [],
    "source": [
     "learning_config = {\n",
     "    \"continue_learning\": False,\n",
-    "    \"trained_policies_save_path\": \"None\",\n",
+    "    \"trained_policies_save_path\": None,\n",
     "    \"max_bid_price\": 100,\n",
     "    \"algorithm\": \"matd3\",\n",
     "    \"learning_rate\": 0.001,\n",
@@ -885,15 +897,12 @@
    "execution_count": null,
    "id": "5cff2f6a",
    "metadata": {
-    "id": "iPz8v4N5hpfr",
-    "vscode": {
-     "languageId": "python"
-    }
+    "id": "iPz8v4N5hpfr"
    },
    "outputs": [],
    "source": [
     "# Read the YAML file\n",
-    "with open(\"assume/examples/inputs/example_02a/config.yaml\") as file:\n",
+    "with open(f\"{inputs_path}/example_02a/config.yaml\") as file:\n",
     "    data = yaml.safe_load(file)\n",
     "\n",
     "# store our modifications to the config file\n",
@@ -901,7 +910,7 @@
     "data[\"base\"][\"learning_config\"] = learning_config\n",
     "\n",
     "# Write the modified data back to the file\n",
-    "with open(\"assume/examples/inputs/example_02a/config.yaml\", \"w\") as file:\n",
+    "with open(f\"{inputs_path}/example_02a/config.yaml\", \"w\") as file:\n",
     "    yaml.safe_dump(data, file)"
    ]
   },
@@ -926,12 +935,63 @@
     },
     "id": "ZlWxXxZr54WV",
     "lines_to_next_cell": 0,
-    "outputId": "e30f4279-7a4e-4efc-9cfb-61416e4fe2f1",
-    "vscode": {
-     "languageId": "python"
-    }
+    "outputId": "e30f4279-7a4e-4efc-9cfb-61416e4fe2f1"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.world:connected to db\n",
+      "INFO:assume.scenario.loader_csv:Starting Scenario example_02a/base from ../inputs\n",
+      "INFO:assume.scenario.loader_csv:storage_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:industrial_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:residential_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:forecasts_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:Downsampling demand_df successful.\n",
+      "INFO:assume.scenario.loader_csv:cross_border_flows not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:availability_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:electricity_prices not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:price_forecasts not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:temperature not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.scenario.loader_csv:storage_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:industrial_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:residential_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:forecasts_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:Downsampling demand_df successful.\n",
+      "INFO:assume.scenario.loader_csv:cross_border_flows not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:availability_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:electricity_prices not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:price_forecasts not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:temperature not found. Returning None\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Training Episodes:   0%|          | 0/100 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": []
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
@@ -955,7 +1015,7 @@
     "    elif data_format == \"timescale\":\n",
     "        db_uri = \"postgresql://assume:assume@localhost:5432/assume\"\n",
     "\n",
-    "    input_path = \"assume/examples/inputs\"\n",
+    "    input_path = inputs_path\n",
     "    scenario = \"example_02a\"\n",
     "    study_case = \"base\"\n",
     "\n",
@@ -995,10 +1055,7 @@
    "execution_count": null,
    "id": "df2ba59b",
    "metadata": {
-    "lines_to_next_cell": 2,
-    "vscode": {
-     "languageId": "python"
-    }
+    "lines_to_next_cell": 2
    },
    "outputs": [],
    "source": []

--- a/examples/notebooks/09_example_Sim_and_xRL.ipynb
+++ b/examples/notebooks/09_example_Sim_and_xRL.ipynb
@@ -188,7 +188,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "b7c91474",
    "metadata": {
     "id": "e62e00c9"
@@ -203,17 +203,7 @@
     "import plotly.graph_objects as go\n",
     "\n",
     "# import yaml for reading and writing YAML files\n",
-    "import yaml\n",
-    "\n",
-    "# Check if 'google.colab' is available\n",
-    "IN_COLAB = importlib.util.find_spec(\"google.colab\") is not None\n",
-    "\n",
-    "colab_inputs_path = \"inputs\"\n",
-    "local_inputs_path = \"../inputs\"\n",
-    "\n",
-    "inputs_path = colab_inputs_path if IN_COLAB else local_inputs_path\n",
-    "\n",
-    "print(inputs_path)"
+    "import yaml"
    ]
   },
   {
@@ -234,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "85fdfe19",
    "metadata": {
     "lines_to_next_cell": 2,
@@ -242,7 +232,32 @@
      "languageId": "shellscript"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[WinError 3] Das System kann den angegebenen Pfad nicht finden: 'assume/examples/notebooks/'\n",
+      "c:\\Users\\AEppl\\OneDrive\\Dokumente\\Studium\\2024-25 Winersemester\\Hiwi IISM\\assume\\examples\\notebooks\n",
+      "[WinError 3] Das System kann den angegebenen Pfad nicht finden: 'assume-repo/examples/notebooks/'\n",
+      "c:\\Users\\AEppl\\OneDrive\\Dokumente\\Studium\\2024-25 Winersemester\\Hiwi IISM\\assume\\examples\\notebooks\n",
+      "[WinError 2] Das System kann die angegebene Datei nicht finden: '/content'\n",
+      "c:\\Users\\AEppl\\OneDrive\\Dokumente\\Studium\\2024-25 Winersemester\\Hiwi IISM\\assume\\examples\\notebooks\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "[NbConvertApp] Converting notebook 08_market_zone_coupling.ipynb to notebook\n",
+      "C:\\Users\\AEppl\\.conda\\envs\\assume\\Lib\\site-packages\\zmq\\_future.py:693: RuntimeWarning: Proactor event loop does not implement add_reader family of methods required for zmq. Registering an additional selector thread for add_reader support via tornado. Use `asyncio.set_event_loop_policy(WindowsSelectorEventLoopPolicy())` to avoid this warning.\n",
+      "  self._get_loop()\n",
+      "[NbConvertApp] Writing 199589 bytes to output.ipynb\n",
+      "Der Befehl \"cp\" ist entweder falsch geschrieben oder\n",
+      "konnte nicht gefunden werden.\n"
+     ]
+    }
+   ],
    "source": [
     "# For local execution:\n",
     "%cd assume/examples/notebooks/\n",
@@ -262,7 +277,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "1ca7eab9",
    "metadata": {
     "colab": {
@@ -271,12 +286,20 @@
     "id": "233f315b",
     "outputId": "f98da7d4-0080-4546-c642-838f722965b0"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Input CSV files have been read from 'inputs/tutorial_08'.\n"
+     ]
+    }
+   ],
    "source": [
     "import os\n",
     "\n",
     "# Define the input directory\n",
-    "input_dir = os.path.join(inputs_path, \"tutorial_08\")\n",
+    "input_dir = os.path.join(\"inputs\", \"tutorial_08\")\n",
     "\n",
     "\n",
     "# Read the DataFrames from CSV files\n",
@@ -304,7 +327,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "8c4153fa",
    "metadata": {
     "colab": {
@@ -314,7 +337,221 @@
     "id": "b205256f",
     "outputId": "b9bb887b-f534-4a50-dd5b-229be1012600"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>technology</th>\n",
+       "      <th>bidding_zonal</th>\n",
+       "      <th>fuel_type</th>\n",
+       "      <th>emission_factor</th>\n",
+       "      <th>max_power</th>\n",
+       "      <th>min_power</th>\n",
+       "      <th>efficiency</th>\n",
+       "      <th>additional_cost</th>\n",
+       "      <th>node</th>\n",
+       "      <th>unit_operator</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>name</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>Unit 11</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>15</td>\n",
+       "      <td>north_2</td>\n",
+       "      <td>Operator North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 12</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>16</td>\n",
+       "      <td>north_2</td>\n",
+       "      <td>Operator North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 13</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>17</td>\n",
+       "      <td>north_2</td>\n",
+       "      <td>Operator North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 14</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>18</td>\n",
+       "      <td>north_2</td>\n",
+       "      <td>Operator North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 15</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>19</td>\n",
+       "      <td>north_2</td>\n",
+       "      <td>Operator North</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 16</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>20</td>\n",
+       "      <td>south</td>\n",
+       "      <td>Operator South</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 17</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>21</td>\n",
+       "      <td>south</td>\n",
+       "      <td>Operator South</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 18</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>22</td>\n",
+       "      <td>south</td>\n",
+       "      <td>Operator South</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 19</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>naive_eom</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>23</td>\n",
+       "      <td>south</td>\n",
+       "      <td>Operator South</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Unit 20</th>\n",
+       "      <td>nuclear</td>\n",
+       "      <td>pp_learning</td>\n",
+       "      <td>uranium</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>5000.0</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>0.3</td>\n",
+       "      <td>24</td>\n",
+       "      <td>south</td>\n",
+       "      <td>Operator-RL</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        technology bidding_zonal fuel_type  emission_factor  max_power  \\\n",
+       "name                                                                     \n",
+       "Unit 11    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 12    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 13    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 14    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 15    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 16    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 17    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 18    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 19    nuclear     naive_eom   uranium              0.0     1000.0   \n",
+       "Unit 20    nuclear   pp_learning   uranium              0.0     5000.0   \n",
+       "\n",
+       "         min_power  efficiency  additional_cost     node   unit_operator  \n",
+       "name                                                                      \n",
+       "Unit 11        0.0         0.3               15  north_2  Operator North  \n",
+       "Unit 12        0.0         0.3               16  north_2  Operator North  \n",
+       "Unit 13        0.0         0.3               17  north_2  Operator North  \n",
+       "Unit 14        0.0         0.3               18  north_2  Operator North  \n",
+       "Unit 15        0.0         0.3               19  north_2  Operator North  \n",
+       "Unit 16        0.0         0.3               20    south  Operator South  \n",
+       "Unit 17        0.0         0.3               21    south  Operator South  \n",
+       "Unit 18        0.0         0.3               22    south  Operator South  \n",
+       "Unit 19        0.0         0.3               23    south  Operator South  \n",
+       "Unit 20        0.0         0.3               24    south     Operator-RL  "
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# Create scarcity in southern Germany by limiting the number of power plants\n",
     "powerplant_units = powerplant_units[:20]\n",
@@ -392,7 +629,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "f6c64dc2",
    "metadata": {
     "colab": {
@@ -401,7 +638,15 @@
     "id": "9c555ce9",
     "outputId": "473126ae-3c3e-4698-e3a5-347cc00e5108"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Configuration YAML file has been saved to 'inputs\\tutorial_08\\config.yaml'.\n"
+     ]
+    }
+   ],
    "source": [
     "# YAML configuration for the RL training\n",
     "config = {\n",
@@ -471,7 +716,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "a01977d5",
    "metadata": {
     "cellView": "form",
@@ -695,7 +940,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "0c1c9334",
    "metadata": {
     "colab": {
@@ -705,7 +950,555 @@
     "id": "bfadf522",
     "outputId": "7c91ab13-a3c2-4e89-d8ac-d20be95391f6"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.world:connected to db\n",
+      "INFO:assume.scenario.loader_csv:Starting Scenario tutorial_08/zonal_case from inputs\n",
+      "INFO:assume.scenario.loader_csv:storage_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:industrial_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:residential_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:forecasts_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:cross_border_flows not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:availability_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:electricity_prices not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:price_forecasts not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:temperature not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:save_frequency_hours is disabled due to CSV export being enabled. Data will be stored in the CSV files at the end of the simulation.\n",
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.scenario.loader_csv:storage_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:industrial_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:residential_dsm_units not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:forecasts_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:cross_border_flows not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:availability_df not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:electricity_prices not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:price_forecasts not found. Returning None\n",
+      "INFO:assume.scenario.loader_csv:temperature not found. Returning None\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Training Episodes:   0%|          | 0/15 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_1 2019-01-01 23:00:00: : 82801.0it [00:02, 31967.24it/s]                         \n",
+      "Training Episodes:   7%|▋         | 1/15 [00:02<00:38,  2.72s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_2 2019-01-01 23:00:00: : 82801.0it [00:02, 30502.06it/s]                         \n",
+      "Training Episodes:  13%|█▎        | 2/15 [00:05<00:36,  2.80s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_3 2019-01-01 23:00:00: : 82801.0it [00:02, 32180.68it/s]\n",
+      "Training Episodes:  20%|██        | 3/15 [00:08<00:33,  2.77s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_4 2019-01-01 23:00:00: : 82801.0it [00:02, 30579.39it/s]                         \n",
+      "Training Episodes:  27%|██▋       | 4/15 [00:11<00:30,  2.79s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_5 2019-01-01 23:00:00: : 82801.0it [00:03, 24050.61it/s]                         \n",
+      "Training Episodes:  33%|███▎      | 5/15 [00:14<00:30,  3.07s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_6 2019-01-01 23:00:00: : 82801.0it [00:03, 26408.84it/s]                         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "tutorial_08_zonal_case_eval_1 2019-01-01 23:00:00: : 82801.0it [00:02, 30411.76it/s]                         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.reinforcement_learning.learning_role:New best policy saved, episode: 1, metric='avg_reward', value=4180.41\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Training Episodes:  40%|████      | 6/15 [00:20<00:36,  4.10s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_7 2019-01-01 23:00:00: : 82801.0it [00:03, 27077.76it/s]                         \n",
+      "Training Episodes:  47%|████▋     | 7/15 [00:23<00:30,  3.79s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_8 2019-01-01 23:00:00: : 82801.0it [00:03, 23950.45it/s]                         \n",
+      "Training Episodes:  53%|█████▎    | 8/15 [00:27<00:26,  3.73s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_9 2019-01-01 23:00:00: : 82801.0it [00:03, 25209.52it/s]                         \n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_eval_2 2019-01-01 23:00:00: : 82801.0it [00:02, 33235.56it/s]                         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.reinforcement_learning.learning_role:New best policy saved, episode: 2, metric='avg_reward', value=4186.15\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Training Episodes:  60%|██████    | 9/15 [00:33<00:26,  4.44s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_10 2019-01-01 23:00:00: : 82801.0it [00:03, 25664.48it/s]\n",
+      "Training Episodes:  67%|██████▋   | 10/15 [00:36<00:20,  4.09s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_11 2019-01-01 23:00:00: : 82801.0it [00:05, 15532.78it/s]                         \n",
+      "Training Episodes:  73%|███████▎  | 11/15 [00:42<00:18,  4.50s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_12 2019-01-01 23:00:00: : 82801.0it [00:05, 14237.22it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_eval_3 2019-01-01 23:00:00: : 82801.0it [00:03, 24225.07it/s]                         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.reinforcement_learning.learning_role:New best policy saved, episode: 3, metric='avg_reward', value=4186.91\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Training Episodes:  80%|████████  | 12/15 [00:51<00:18,  6.04s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_13 2019-01-01 23:00:00: : 82801.0it [00:03, 26351.15it/s]                         \n",
+      "Training Episodes:  87%|████████▋ | 13/15 [00:55<00:10,  5.20s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_14 2019-01-01 23:00:00: : 82801.0it [00:03, 27199.86it/s]                         \n",
+      "Training Episodes:  93%|█████████▎| 14/15 [00:58<00:04,  4.58s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_15 2019-01-01 23:00:00: : 82801.0it [00:03, 26622.42it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Adding markets\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case_eval_4 2019-01-01 23:00:00: : 82801.0it [00:02, 28226.20it/s]                         "
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.reinforcement_learning.learning_role:New best policy saved, episode: 4, metric='avg_reward', value=4187.12\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "Training Episodes: 100%|██████████| 15/15 [01:22<00:00,  5.49s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.scenario.loader_csv:save_frequency_hours is disabled due to CSV export being enabled. Data will be stored in the CSV files at the end of the simulation.\n",
+      "INFO:assume.scenario.loader_csv:Adding markets\n",
+      "INFO:assume.scenario.loader_csv:Read units from file\n",
+      "INFO:assume.scenario.loader_csv:Adding power_plant units\n",
+      "INFO:assume.scenario.loader_csv:Adding demand units\n",
+      "INFO:assume.scenario.loader_csv:Adding unit operators and units\n",
+      "INFO:assume.world:activating container\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:assume.common.outputs:tried writing grid data to non postGIS database\n",
+      "INFO:assume.world:all agents up - starting simulation\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "tutorial_08_zonal_case 2019-01-01 23:00:00: : 82801it [00:02, 29966.62it/s]                         \n"
+     ]
+    }
+   ],
    "source": [
     "# Import necessary classes and functions from the Assume framework\n",
     "from assume import World\n",
@@ -737,7 +1530,7 @@
     "# - study_case: Which configuration (case) to use for the simulation\n",
     "load_scenario_folder(\n",
     "    world,\n",
-    "    inputs_path=inputs_path,\n",
+    "    inputs_path=\"inputs\",\n",
     "    scenario=\"tutorial_08\",\n",
     "    study_case=\"zonal_case\",\n",
     ")\n",
@@ -746,7 +1539,7 @@
     "if world.learning_config.get(\"learning_mode\", False):\n",
     "    run_learning(\n",
     "        world,\n",
-    "        inputs_path=inputs_path,\n",
+    "        inputs_path=\"inputs\",\n",
     "        scenario=\"tutorial_08\",\n",
     "        study_case=\"zonal_case\",\n",
     "    )\n",
@@ -769,13 +1562,984 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "762acdfe",
    "metadata": {
     "id": "bdb21cbe",
     "lines_to_next_cell": 2
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.plotly.v1+json": {
+       "config": {
+        "plotlyServerURL": "https://plot.ly"
+       },
+       "data": [
+        {
+         "line": {
+          "width": 2
+         },
+         "mode": "lines",
+         "name": "DE_1 - Simulation",
+         "type": "scatter",
+         "x": [
+          "2019-01-01T01:00:00",
+          "2019-01-01T02:00:00",
+          "2019-01-01T03:00:00",
+          "2019-01-01T04:00:00",
+          "2019-01-01T05:00:00",
+          "2019-01-01T06:00:00",
+          "2019-01-01T07:00:00",
+          "2019-01-01T08:00:00",
+          "2019-01-01T09:00:00",
+          "2019-01-01T10:00:00",
+          "2019-01-01T11:00:00",
+          "2019-01-01T12:00:00",
+          "2019-01-01T13:00:00",
+          "2019-01-01T14:00:00",
+          "2019-01-01T15:00:00",
+          "2019-01-01T16:00:00",
+          "2019-01-01T17:00:00",
+          "2019-01-01T18:00:00",
+          "2019-01-01T19:00:00",
+          "2019-01-01T20:00:00",
+          "2019-01-01T21:00:00",
+          "2019-01-01T22:00:00",
+          "2019-01-01T23:00:00"
+         ],
+         "y": [
+          98.929,
+          98.938,
+          98.939,
+          98.942,
+          98.944,
+          98.943,
+          98.945,
+          98.946,
+          98.951,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000
+         ]
+        },
+        {
+         "line": {
+          "width": 2
+         },
+         "mode": "lines",
+         "name": "DE_2 - Simulation",
+         "type": "scatter",
+         "x": [
+          "2019-01-01T01:00:00",
+          "2019-01-01T02:00:00",
+          "2019-01-01T03:00:00",
+          "2019-01-01T04:00:00",
+          "2019-01-01T05:00:00",
+          "2019-01-01T06:00:00",
+          "2019-01-01T07:00:00",
+          "2019-01-01T08:00:00",
+          "2019-01-01T09:00:00",
+          "2019-01-01T10:00:00",
+          "2019-01-01T11:00:00",
+          "2019-01-01T12:00:00",
+          "2019-01-01T13:00:00",
+          "2019-01-01T14:00:00",
+          "2019-01-01T15:00:00",
+          "2019-01-01T16:00:00",
+          "2019-01-01T17:00:00",
+          "2019-01-01T18:00:00",
+          "2019-01-01T19:00:00",
+          "2019-01-01T20:00:00",
+          "2019-01-01T21:00:00",
+          "2019-01-01T22:00:00",
+          "2019-01-01T23:00:00"
+         ],
+         "y": [
+          98.929,
+          98.938,
+          98.939,
+          98.942,
+          98.944,
+          98.943,
+          98.945,
+          98.946,
+          98.951,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000,
+          3000
+         ]
+        }
+       ],
+       "layout": {
+        "height": 600,
+        "hovermode": "x unified",
+        "legend": {
+         "title": {
+          "text": "Market Zones"
+         }
+        },
+        "template": {
+         "data": {
+          "bar": [
+           {
+            "error_x": {
+             "color": "#2a3f5f"
+            },
+            "error_y": {
+             "color": "#2a3f5f"
+            },
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "bar"
+           }
+          ],
+          "barpolar": [
+           {
+            "marker": {
+             "line": {
+              "color": "white",
+              "width": 0.5
+             },
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "barpolar"
+           }
+          ],
+          "carpet": [
+           {
+            "aaxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "baxis": {
+             "endlinecolor": "#2a3f5f",
+             "gridcolor": "#C8D4E3",
+             "linecolor": "#C8D4E3",
+             "minorgridcolor": "#C8D4E3",
+             "startlinecolor": "#2a3f5f"
+            },
+            "type": "carpet"
+           }
+          ],
+          "choropleth": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "choropleth"
+           }
+          ],
+          "contour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "contour"
+           }
+          ],
+          "contourcarpet": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "contourcarpet"
+           }
+          ],
+          "heatmap": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmap"
+           }
+          ],
+          "heatmapgl": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "heatmapgl"
+           }
+          ],
+          "histogram": [
+           {
+            "marker": {
+             "pattern": {
+              "fillmode": "overlay",
+              "size": 10,
+              "solidity": 0.2
+             }
+            },
+            "type": "histogram"
+           }
+          ],
+          "histogram2d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2d"
+           }
+          ],
+          "histogram2dcontour": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "histogram2dcontour"
+           }
+          ],
+          "mesh3d": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "type": "mesh3d"
+           }
+          ],
+          "parcoords": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "parcoords"
+           }
+          ],
+          "pie": [
+           {
+            "automargin": true,
+            "type": "pie"
+           }
+          ],
+          "scatter": [
+           {
+            "fillpattern": {
+             "fillmode": "overlay",
+             "size": 10,
+             "solidity": 0.2
+            },
+            "type": "scatter"
+           }
+          ],
+          "scatter3d": [
+           {
+            "line": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatter3d"
+           }
+          ],
+          "scattercarpet": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattercarpet"
+           }
+          ],
+          "scattergeo": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergeo"
+           }
+          ],
+          "scattergl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattergl"
+           }
+          ],
+          "scattermapbox": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scattermapbox"
+           }
+          ],
+          "scatterpolar": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolar"
+           }
+          ],
+          "scatterpolargl": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterpolargl"
+           }
+          ],
+          "scatterternary": [
+           {
+            "marker": {
+             "colorbar": {
+              "outlinewidth": 0,
+              "ticks": ""
+             }
+            },
+            "type": "scatterternary"
+           }
+          ],
+          "surface": [
+           {
+            "colorbar": {
+             "outlinewidth": 0,
+             "ticks": ""
+            },
+            "colorscale": [
+             [
+              0,
+              "#0d0887"
+             ],
+             [
+              0.1111111111111111,
+              "#46039f"
+             ],
+             [
+              0.2222222222222222,
+              "#7201a8"
+             ],
+             [
+              0.3333333333333333,
+              "#9c179e"
+             ],
+             [
+              0.4444444444444444,
+              "#bd3786"
+             ],
+             [
+              0.5555555555555556,
+              "#d8576b"
+             ],
+             [
+              0.6666666666666666,
+              "#ed7953"
+             ],
+             [
+              0.7777777777777778,
+              "#fb9f3a"
+             ],
+             [
+              0.8888888888888888,
+              "#fdca26"
+             ],
+             [
+              1,
+              "#f0f921"
+             ]
+            ],
+            "type": "surface"
+           }
+          ],
+          "table": [
+           {
+            "cells": {
+             "fill": {
+              "color": "#EBF0F8"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "header": {
+             "fill": {
+              "color": "#C8D4E3"
+             },
+             "line": {
+              "color": "white"
+             }
+            },
+            "type": "table"
+           }
+          ]
+         },
+         "layout": {
+          "annotationdefaults": {
+           "arrowcolor": "#2a3f5f",
+           "arrowhead": 0,
+           "arrowwidth": 1
+          },
+          "autotypenumbers": "strict",
+          "coloraxis": {
+           "colorbar": {
+            "outlinewidth": 0,
+            "ticks": ""
+           }
+          },
+          "colorscale": {
+           "diverging": [
+            [
+             0,
+             "#8e0152"
+            ],
+            [
+             0.1,
+             "#c51b7d"
+            ],
+            [
+             0.2,
+             "#de77ae"
+            ],
+            [
+             0.3,
+             "#f1b6da"
+            ],
+            [
+             0.4,
+             "#fde0ef"
+            ],
+            [
+             0.5,
+             "#f7f7f7"
+            ],
+            [
+             0.6,
+             "#e6f5d0"
+            ],
+            [
+             0.7,
+             "#b8e186"
+            ],
+            [
+             0.8,
+             "#7fbc41"
+            ],
+            [
+             0.9,
+             "#4d9221"
+            ],
+            [
+             1,
+             "#276419"
+            ]
+           ],
+           "sequential": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ],
+           "sequentialminus": [
+            [
+             0,
+             "#0d0887"
+            ],
+            [
+             0.1111111111111111,
+             "#46039f"
+            ],
+            [
+             0.2222222222222222,
+             "#7201a8"
+            ],
+            [
+             0.3333333333333333,
+             "#9c179e"
+            ],
+            [
+             0.4444444444444444,
+             "#bd3786"
+            ],
+            [
+             0.5555555555555556,
+             "#d8576b"
+            ],
+            [
+             0.6666666666666666,
+             "#ed7953"
+            ],
+            [
+             0.7777777777777778,
+             "#fb9f3a"
+            ],
+            [
+             0.8888888888888888,
+             "#fdca26"
+            ],
+            [
+             1,
+             "#f0f921"
+            ]
+           ]
+          },
+          "colorway": [
+           "#636efa",
+           "#EF553B",
+           "#00cc96",
+           "#ab63fa",
+           "#FFA15A",
+           "#19d3f3",
+           "#FF6692",
+           "#B6E880",
+           "#FF97FF",
+           "#FECB52"
+          ],
+          "font": {
+           "color": "#2a3f5f"
+          },
+          "geo": {
+           "bgcolor": "white",
+           "lakecolor": "white",
+           "landcolor": "white",
+           "showlakes": true,
+           "showland": true,
+           "subunitcolor": "#C8D4E3"
+          },
+          "hoverlabel": {
+           "align": "left"
+          },
+          "hovermode": "closest",
+          "mapbox": {
+           "style": "light"
+          },
+          "paper_bgcolor": "white",
+          "plot_bgcolor": "white",
+          "polar": {
+           "angularaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "radialaxis": {
+            "gridcolor": "#EBF0F8",
+            "linecolor": "#EBF0F8",
+            "ticks": ""
+           }
+          },
+          "scene": {
+           "xaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "yaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           },
+           "zaxis": {
+            "backgroundcolor": "white",
+            "gridcolor": "#DFE8F3",
+            "gridwidth": 2,
+            "linecolor": "#EBF0F8",
+            "showbackground": true,
+            "ticks": "",
+            "zerolinecolor": "#EBF0F8"
+           }
+          },
+          "shapedefaults": {
+           "line": {
+            "color": "#2a3f5f"
+           }
+          },
+          "ternary": {
+           "aaxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "baxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           },
+           "bgcolor": "white",
+           "caxis": {
+            "gridcolor": "#DFE8F3",
+            "linecolor": "#A2B1C6",
+            "ticks": ""
+           }
+          },
+          "title": {
+           "x": 0.05
+          },
+          "xaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          },
+          "yaxis": {
+           "automargin": true,
+           "gridcolor": "#EBF0F8",
+           "linecolor": "#EBF0F8",
+           "ticks": "",
+           "title": {
+            "standoff": 15
+           },
+           "zerolinecolor": "#EBF0F8",
+           "zerolinewidth": 2
+          }
+         }
+        },
+        "title": {
+         "text": "Clearing Prices per Zone Over Time: Simulation Results"
+        },
+        "width": 1000,
+        "xaxis": {
+         "tickangle": 45,
+         "title": {
+          "text": "Time"
+         },
+         "type": "date"
+        },
+        "yaxis": {
+         "title": {
+          "text": "Clearing Price (EUR/MWh)"
+         }
+        }
+       }
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Import Plotly for creating interactive visualizations\n",
     "import plotly.graph_objects as go\n",
@@ -886,7 +2650,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "id": "55e097c0",
    "metadata": {
     "id": "ae266ecb",
@@ -894,7 +2658,48 @@
      "languageId": "shellscript"
     }
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Requirement already satisfied: matplotlib in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (3.9.2)\n",
+      "Requirement already satisfied: contourpy>=1.0.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (1.3.0)\n",
+      "Requirement already satisfied: cycler>=0.10 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (0.12.1)\n",
+      "Requirement already satisfied: fonttools>=4.22.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (4.54.1)\n",
+      "Requirement already satisfied: kiwisolver>=1.3.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (1.4.7)\n",
+      "Requirement already satisfied: numpy>=1.23 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (1.26.4)\n",
+      "Requirement already satisfied: packaging>=20.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (24.1)\n",
+      "Requirement already satisfied: pillow>=8 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (11.0.0)\n",
+      "Requirement already satisfied: pyparsing>=2.3.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (3.2.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.7 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from matplotlib) (2.9.0)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from python-dateutil>=2.7->matplotlib) (1.16.0)\n",
+      "Requirement already satisfied: shap==0.42.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (0.42.1)\n",
+      "Requirement already satisfied: numpy in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (1.26.4)\n",
+      "Requirement already satisfied: scipy in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (1.14.1)\n",
+      "Requirement already satisfied: scikit-learn in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (1.3.0)\n",
+      "Requirement already satisfied: pandas in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (2.2.3)\n",
+      "Requirement already satisfied: tqdm>=4.27.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (4.66.6)\n",
+      "Requirement already satisfied: packaging>20.9 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (24.1)\n",
+      "Requirement already satisfied: slicer==0.0.7 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (0.0.7)\n",
+      "Requirement already satisfied: numba in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (0.60.0)\n",
+      "Requirement already satisfied: cloudpickle in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from shap==0.42.1) (3.1.0)\n",
+      "Requirement already satisfied: colorama in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from tqdm>=4.27.0->shap==0.42.1) (0.4.6)\n",
+      "Requirement already satisfied: llvmlite<0.44,>=0.43.0dev0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from numba->shap==0.42.1) (0.43.0)\n",
+      "Requirement already satisfied: python-dateutil>=2.8.2 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pandas->shap==0.42.1) (2.9.0)\n",
+      "Requirement already satisfied: pytz>=2020.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pandas->shap==0.42.1) (2024.2)\n",
+      "Requirement already satisfied: tzdata>=2022.7 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from pandas->shap==0.42.1) (2024.2)\n",
+      "Requirement already satisfied: joblib>=1.1.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn->shap==0.42.1) (1.4.2)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn->shap==0.42.1) (3.5.0)\n",
+      "Requirement already satisfied: six>=1.5 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from python-dateutil>=2.8.2->pandas->shap==0.42.1) (1.16.0)\n",
+      "Requirement already satisfied: scikit-learn==1.3.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (1.3.0)\n",
+      "Requirement already satisfied: numpy>=1.17.3 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn==1.3.0) (1.26.4)\n",
+      "Requirement already satisfied: scipy>=1.5.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn==1.3.0) (1.14.1)\n",
+      "Requirement already satisfied: joblib>=1.1.1 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn==1.3.0) (1.4.2)\n",
+      "Requirement already satisfied: threadpoolctl>=2.0.0 in c:\\users\\aeppl\\.conda\\envs\\assume\\lib\\site-packages (from scikit-learn==1.3.0) (3.5.0)\n"
+     ]
+    }
+   ],
    "source": [
     "!pip install matplotlib\n",
     "!pip install shap==0.42.1\n",
@@ -1030,12 +2835,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "id": "26c6f33b",
    "metadata": {
     "id": "b6ee4f28"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n"
+     ]
+    }
+   ],
    "source": [
     "import matplotlib.pyplot as plt\n",
     "import pandas as pd\n",
@@ -1056,7 +2869,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 12,
    "id": "ab89d972",
    "metadata": {
     "id": "44862f06"
@@ -1112,12 +2925,448 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 13,
    "id": "6e142be2",
    "metadata": {
     "id": "d522969d"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "inputs\\tutorial_08/learned_strategies/zonal_case/buffer_obs/buffer_obs.json\n",
+      "500000\n",
+      "270\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>price forecast t+1</th>\n",
+       "      <th>price forecast t+2</th>\n",
+       "      <th>price forecast t+3</th>\n",
+       "      <th>price forecast t+4</th>\n",
+       "      <th>price forecast t+5</th>\n",
+       "      <th>price forecast t+6</th>\n",
+       "      <th>price forecast t+7</th>\n",
+       "      <th>price forecast t+8</th>\n",
+       "      <th>price forecast t+9</th>\n",
+       "      <th>price forecast t+10</th>\n",
+       "      <th>...</th>\n",
+       "      <th>residual load forecast t+17</th>\n",
+       "      <th>residual load forecast t+18</th>\n",
+       "      <th>residual load forecast t+19</th>\n",
+       "      <th>residual load forecast t+20</th>\n",
+       "      <th>residual load forecast t+21</th>\n",
+       "      <th>residual load forecast t+22</th>\n",
+       "      <th>residual load forecast t+23</th>\n",
+       "      <th>residual load forecast t+24</th>\n",
+       "      <th>total capacity t-1</th>\n",
+       "      <th>marginal costs t-1</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2.24</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>2.28</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>2.32</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>2.36</td>\n",
+       "      <td>2.38</td>\n",
+       "      <td>2.40</td>\n",
+       "      <td>2.42</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.26</td>\n",
+       "      <td>2.28</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>2.32</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>2.36</td>\n",
+       "      <td>2.38</td>\n",
+       "      <td>2.40</td>\n",
+       "      <td>2.42</td>\n",
+       "      <td>2.44</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.68</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.28</td>\n",
+       "      <td>2.30</td>\n",
+       "      <td>2.32</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>2.36</td>\n",
+       "      <td>2.38</td>\n",
+       "      <td>2.40</td>\n",
+       "      <td>2.42</td>\n",
+       "      <td>2.44</td>\n",
+       "      <td>2.46</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.72</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.30</td>\n",
+       "      <td>2.32</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>2.36</td>\n",
+       "      <td>2.38</td>\n",
+       "      <td>2.40</td>\n",
+       "      <td>2.42</td>\n",
+       "      <td>2.44</td>\n",
+       "      <td>2.46</td>\n",
+       "      <td>2.48</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.76</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2.32</td>\n",
+       "      <td>2.34</td>\n",
+       "      <td>2.36</td>\n",
+       "      <td>2.38</td>\n",
+       "      <td>2.40</td>\n",
+       "      <td>2.42</td>\n",
+       "      <td>2.44</td>\n",
+       "      <td>2.46</td>\n",
+       "      <td>2.48</td>\n",
+       "      <td>2.50</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.80</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>265</th>\n",
+       "      <td>2.50</td>\n",
+       "      <td>2.52</td>\n",
+       "      <td>2.54</td>\n",
+       "      <td>2.56</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>2.64</td>\n",
+       "      <td>2.66</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>266</th>\n",
+       "      <td>2.52</td>\n",
+       "      <td>2.54</td>\n",
+       "      <td>2.56</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>2.64</td>\n",
+       "      <td>2.66</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>2.22</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>267</th>\n",
+       "      <td>2.54</td>\n",
+       "      <td>2.56</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>2.64</td>\n",
+       "      <td>2.66</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>2.22</td>\n",
+       "      <td>2.24</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.406667</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>268</th>\n",
+       "      <td>2.56</td>\n",
+       "      <td>2.58</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>2.64</td>\n",
+       "      <td>2.66</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>2.22</td>\n",
+       "      <td>2.24</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>269</th>\n",
+       "      <td>2.58</td>\n",
+       "      <td>2.60</td>\n",
+       "      <td>2.62</td>\n",
+       "      <td>2.64</td>\n",
+       "      <td>2.66</td>\n",
+       "      <td>2.68</td>\n",
+       "      <td>2.22</td>\n",
+       "      <td>2.24</td>\n",
+       "      <td>2.26</td>\n",
+       "      <td>2.28</td>\n",
+       "      <td>...</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>0.000000</td>\n",
+       "      <td>1.00</td>\n",
+       "      <td>0.406667</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>270 rows × 50 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     price forecast t+1  price forecast t+2  price forecast t+3  \\\n",
+       "0                  2.24                2.26                2.28   \n",
+       "1                  2.26                2.28                2.30   \n",
+       "2                  2.28                2.30                2.32   \n",
+       "3                  2.30                2.32                2.34   \n",
+       "4                  2.32                2.34                2.36   \n",
+       "..                  ...                 ...                 ...   \n",
+       "265                2.50                2.52                2.54   \n",
+       "266                2.52                2.54                2.56   \n",
+       "267                2.54                2.56                2.58   \n",
+       "268                2.56                2.58                2.60   \n",
+       "269                2.58                2.60                2.62   \n",
+       "\n",
+       "     price forecast t+4  price forecast t+5  price forecast t+6  \\\n",
+       "0                  2.30                2.32                2.34   \n",
+       "1                  2.32                2.34                2.36   \n",
+       "2                  2.34                2.36                2.38   \n",
+       "3                  2.36                2.38                2.40   \n",
+       "4                  2.38                2.40                2.42   \n",
+       "..                  ...                 ...                 ...   \n",
+       "265                2.56                2.58                2.60   \n",
+       "266                2.58                2.60                2.62   \n",
+       "267                2.60                2.62                2.64   \n",
+       "268                2.62                2.64                2.66   \n",
+       "269                2.64                2.66                2.68   \n",
+       "\n",
+       "     price forecast t+7  price forecast t+8  price forecast t+9  \\\n",
+       "0                  2.36                2.38                2.40   \n",
+       "1                  2.38                2.40                2.42   \n",
+       "2                  2.40                2.42                2.44   \n",
+       "3                  2.42                2.44                2.46   \n",
+       "4                  2.44                2.46                2.48   \n",
+       "..                  ...                 ...                 ...   \n",
+       "265                2.62                2.64                2.66   \n",
+       "266                2.64                2.66                2.68   \n",
+       "267                2.66                2.68                2.22   \n",
+       "268                2.68                2.22                2.24   \n",
+       "269                2.22                2.24                2.26   \n",
+       "\n",
+       "     price forecast t+10  ...  residual load forecast t+17  \\\n",
+       "0                   2.42  ...                     0.000000   \n",
+       "1                   2.44  ...                     0.000000   \n",
+       "2                   2.46  ...                     0.000000   \n",
+       "3                   2.48  ...                     0.000000   \n",
+       "4                   2.50  ...                     0.000000   \n",
+       "..                   ...  ...                          ...   \n",
+       "265                 2.68  ...                     0.406667   \n",
+       "266                 2.22  ...                     0.406667   \n",
+       "267                 2.24  ...                     0.406667   \n",
+       "268                 2.26  ...                     0.000000   \n",
+       "269                 2.28  ...                     0.000000   \n",
+       "\n",
+       "     residual load forecast t+18  residual load forecast t+19  \\\n",
+       "0                       0.000000                     0.000000   \n",
+       "1                       0.000000                     0.000000   \n",
+       "2                       0.000000                     0.000000   \n",
+       "3                       0.000000                     0.000000   \n",
+       "4                       0.000000                     0.000000   \n",
+       "..                           ...                          ...   \n",
+       "265                     0.406667                     0.406667   \n",
+       "266                     0.406667                     0.000000   \n",
+       "267                     0.000000                     0.000000   \n",
+       "268                     0.000000                     0.000000   \n",
+       "269                     0.000000                     0.000000   \n",
+       "\n",
+       "     residual load forecast t+20  residual load forecast t+21  \\\n",
+       "0                       0.000000                     0.000000   \n",
+       "1                       0.000000                     0.000000   \n",
+       "2                       0.000000                     0.000000   \n",
+       "3                       0.000000                     0.406667   \n",
+       "4                       0.406667                     0.406667   \n",
+       "..                           ...                          ...   \n",
+       "265                     0.000000                     0.000000   \n",
+       "266                     0.000000                     0.000000   \n",
+       "267                     0.000000                     0.000000   \n",
+       "268                     0.000000                     0.000000   \n",
+       "269                     0.000000                     0.000000   \n",
+       "\n",
+       "     residual load forecast t+22  residual load forecast t+23  \\\n",
+       "0                       0.000000                     0.000000   \n",
+       "1                       0.000000                     0.406667   \n",
+       "2                       0.406667                     0.406667   \n",
+       "3                       0.406667                     0.406667   \n",
+       "4                       0.406667                     0.406667   \n",
+       "..                           ...                          ...   \n",
+       "265                     0.000000                     0.000000   \n",
+       "266                     0.000000                     0.000000   \n",
+       "267                     0.000000                     0.000000   \n",
+       "268                     0.000000                     0.000000   \n",
+       "269                     0.000000                     0.000000   \n",
+       "\n",
+       "     residual load forecast t+24  total capacity t-1  marginal costs t-1  \n",
+       "0                       0.406667                0.00            0.406667  \n",
+       "1                       0.406667                0.68            0.406667  \n",
+       "2                       0.406667                0.72            0.406667  \n",
+       "3                       0.406667                0.76            0.406667  \n",
+       "4                       0.406667                0.80            0.406667  \n",
+       "..                           ...                 ...                 ...  \n",
+       "265                     0.000000                1.00            0.406667  \n",
+       "266                     0.000000                1.00            0.406667  \n",
+       "267                     0.000000                1.00            0.406667  \n",
+       "268                     0.000000                1.00            0.406667  \n",
+       "269                     0.000000                1.00            0.406667  \n",
+       "\n",
+       "[270 rows x 50 columns]"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# path to extra loggedobservation values\n",
     "path = input_dir + \"/learned_strategies/zonal_case/buffer_obs\"\n",
@@ -1155,7 +3404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 14,
    "id": "cca85e13",
    "metadata": {
     "id": "4da4de57"
@@ -1172,12 +3421,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 15,
    "id": "1cd3b7e6",
    "metadata": {
     "id": "37adecfa"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<All keys matched successfully>"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "# which actor is the RL actor\n",
     "ACTOR_NUM = len(powerplant_units)  # 20\n",
@@ -1205,7 +3472,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 16,
    "id": "c507d331",
    "metadata": {
     "id": "e6460cfb"
@@ -1235,10 +3502,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 17,
    "id": "b0758eb5",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n",
+      "To copy construct from a tensor, it is recommended to use sourceTensor.clone().detach() or sourceTensor.clone().detach().requires_grad_(True), rather than torch.tensor(sourceTensor).\n"
+     ]
+    }
+   ],
    "source": [
     "# @ Title Split the data into training and testing sets\n",
     "X_train, X_test, y_train, y_test = train_test_split(\n",
@@ -1268,7 +3544,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 18,
    "id": "40e12192",
    "metadata": {
     "id": "6d9be211"
@@ -1285,12 +3561,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 19,
    "id": "56a32f41",
    "metadata": {
     "id": "84bb96cf"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING:shap:Using 229 background data samples could cause slower run times. Consider using shap.sample(data, K) or shap.kmeans(data, K) to summarize the background as K samples.\n"
+     ]
+    }
+   ],
    "source": [
     "# Create the SHAP Kernel Explainer\n",
     "explainer = shap.KernelExplainer(model_predict, X_train)"
@@ -1298,12 +3582,2070 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 20,
    "id": "4279910b",
    "metadata": {
     "id": "2a7929e4"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  0%|          | 0/41 [00:00<?, ?it/s]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.79784418e-05  1.15468817e-05  1.30166301e-05  1.15300818e-05\n",
+      "  1.18711091e-05  1.39488074e-05  1.52748890e-05  2.16141688e-05\n",
+      "  3.58958362e-05  3.66234805e-05  4.17826653e-05 -4.65696405e-05\n",
+      " -4.55380381e-05 -3.73971195e-05 -2.33595427e-05 -2.19386591e-05\n",
+      " -2.51031245e-05 -1.52225905e-05 -1.29019921e-05 -7.01071330e-06\n",
+      "  0.00000000e+00  0.00000000e+00  8.48229473e-06  1.42535630e-05\n",
+      " -2.45349519e-05 -1.87689750e-05 -2.28358595e-05 -1.69830426e-05\n",
+      " -9.95167072e-06 -8.15149525e-06 -1.07152648e-05 -1.21238727e-05\n",
+      " -1.31964561e-05 -1.43323496e-05 -2.20271510e-05  3.08123480e-05\n",
+      "  3.51450596e-05  3.95801072e-05  3.73199662e-05  4.00925265e-05\n",
+      "  3.67645624e-05  3.45077654e-05  2.45146370e-05  2.84710586e-05\n",
+      " -2.98761783e-05 -3.39429493e-05 -2.99043829e-05 -1.76598811e-05\n",
+      "  2.05466312e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.60813647e-05  1.01639247e-05  1.12449445e-05  9.66270112e-06\n",
+      "  1.03094898e-05  1.21483033e-05  1.32066076e-05  1.86221358e-05\n",
+      "  3.13443530e-05  3.20561282e-05  3.65428985e-05 -4.11468008e-05\n",
+      " -4.00994805e-05 -3.25910400e-05 -2.06168887e-05 -1.93300952e-05\n",
+      " -2.24048795e-05 -1.32944758e-05 -1.15391636e-05  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  6.96583312e-06  1.25287214e-05\n",
+      " -2.16617668e-05 -1.67701864e-05 -2.02612259e-05 -1.58411421e-05\n",
+      " -9.16458904e-06 -7.32875862e-06 -9.51136610e-06 -1.05813433e-05\n",
+      " -1.19556374e-05 -1.26924837e-05 -1.87674468e-05  2.72833955e-05\n",
+      "  3.14958012e-05  3.53732989e-05  3.29700385e-05  3.51306332e-05\n",
+      "  3.21253517e-05  3.09017854e-05  2.09224109e-05  2.51110592e-05\n",
+      " -2.65662136e-05 -3.01424743e-05 -2.64135554e-05 -1.60368927e-05\n",
+      "  1.78866871e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  2%|▏         | 1/41 [00:02<01:42,  2.57s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  7.85603363e-06\n",
+      "  1.74014080e-05  1.99943098e-05  2.57524140e-05  2.91721698e-05\n",
+      "  3.60388978e-05  3.76928028e-05  3.07497950e-05 -3.47657027e-05\n",
+      " -4.20721949e-05 -2.81602343e-05 -2.84848342e-05 -2.09079102e-05\n",
+      " -1.63421120e-05 -1.20607805e-05 -8.05081316e-06  0.00000000e+00\n",
+      " -2.46519307e-05 -1.92875579e-05 -2.26793130e-05 -1.72355703e-05\n",
+      " -1.02099404e-05 -8.13666615e-06 -1.09581983e-05 -1.22551143e-05\n",
+      " -1.33884271e-05 -1.47172317e-05 -2.22860305e-05 -1.62446277e-05\n",
+      " -2.26706986e-05 -3.13393270e-05 -3.70139412e-05  3.99225309e-05\n",
+      "  3.65751169e-05  3.42096082e-05  2.46579773e-05  2.79597587e-05\n",
+      "  3.18820989e-05  3.44257366e-05  2.93447141e-05  1.71734162e-05\n",
+      "  1.34511689e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  6.92631242e-06\n",
+      "  1.51897106e-05  1.75733562e-05  2.27678737e-05  2.56485973e-05\n",
+      "  3.17052048e-05  3.32835066e-05  2.70283166e-05 -3.06654932e-05\n",
+      " -3.70373245e-05 -2.47557292e-05 -2.53108787e-05 -1.82028996e-05\n",
+      " -1.45146667e-05 -1.07523589e-05 -6.99518806e-06  0.00000000e+00\n",
+      " -2.18450800e-05 -1.71074602e-05 -1.99008861e-05 -1.56107466e-05\n",
+      " -9.08894881e-06 -7.35982984e-06 -9.40014526e-06 -1.06493891e-05\n",
+      " -1.17373287e-05 -1.30834544e-05 -1.93597490e-05 -1.45317264e-05\n",
+      " -2.04230342e-05 -2.78913917e-05 -3.27777032e-05  3.51336384e-05\n",
+      "  3.22437120e-05  3.06624881e-05  2.14922292e-05  2.47520098e-05\n",
+      "  2.80570387e-05  3.04280561e-05  2.58287001e-05  1.53954354e-05\n",
+      "  1.19194013e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  5%|▍         | 2/41 [00:04<01:18,  2.02s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-7.79726549e-06 -4.99442460e-06 -5.77849312e-06 -5.01089590e-06\n",
+      " -5.18629131e-06 -6.06464738e-06  0.00000000e+00  4.77271207e-06\n",
+      "  1.33646935e-05  1.64195891e-05  2.17270983e-05  2.56735534e-05\n",
+      "  3.24290451e-05  3.41780715e-05  2.83023630e-05  3.57318017e-05\n",
+      " -4.61834408e-05 -3.12861201e-05 -3.17259957e-05 -2.42697144e-05\n",
+      " -1.96344841e-05 -1.53195342e-05 -1.17946174e-05 -6.19032812e-06\n",
+      "  3.02989098e-05 -1.90666531e-05 -2.28279979e-05 -1.69990729e-05\n",
+      " -9.93111543e-06 -8.25428152e-06 -1.08262681e-05 -1.22169939e-05\n",
+      " -1.32388852e-05 -1.43472173e-05 -2.21239244e-05 -1.61358708e-05\n",
+      " -2.26377759e-05 -3.11318053e-05 -3.67527909e-05 -3.82840042e-05\n",
+      "  3.69544152e-05  3.46737046e-05  2.47894010e-05  2.86583469e-05\n",
+      "  3.18910593e-05  3.44949939e-05  2.97101869e-05  1.76875802e-05\n",
+      "  8.04295729e-06]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-6.64632076e-06 -4.21243981e-06 -5.19475504e-06  0.00000000e+00\n",
+      " -4.95987313e-06 -5.37079653e-06  0.00000000e+00  0.00000000e+00\n",
+      "  1.12861368e-05  1.46362500e-05  1.92873831e-05  2.24976856e-05\n",
+      "  2.85987213e-05  3.07436322e-05  2.43554554e-05  3.14704933e-05\n",
+      " -4.09700781e-05 -2.75762125e-05 -2.82116613e-05 -2.11980112e-05\n",
+      " -1.71664222e-05 -1.37443063e-05 -1.04500045e-05 -5.45169849e-06\n",
+      "  2.67864557e-05 -1.66328153e-05 -2.01828617e-05 -1.53542030e-05\n",
+      " -8.83362583e-06 -7.32772227e-06 -9.61767787e-06 -1.04851004e-05\n",
+      " -1.18643919e-05 -1.29431363e-05 -1.92016343e-05 -1.43631697e-05\n",
+      " -2.00283737e-05 -2.79084715e-05 -3.26509144e-05 -3.34593802e-05\n",
+      "  3.24336965e-05  3.09263398e-05  2.14144309e-05  2.52643096e-05\n",
+      "  2.80306785e-05  3.08387452e-05  2.67471588e-05  1.59273401e-05\n",
+      "  7.26416146e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "  7%|▋         | 3/41 [00:05<01:11,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-3.90789932e-05 -2.51371600e-05 -2.89946291e-05 -2.49639059e-05\n",
+      " -2.58381864e-05 -3.03570292e-05 -1.82698170e-05 -1.57130520e-05\n",
+      " -1.36567178e-05 -8.01459211e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.77411174e-06  1.15976408e-05  1.21082827e-05  1.76316816e-05\n",
+      "  3.01677949e-05  2.66331271e-05  3.57503928e-05  3.83806645e-05\n",
+      "  4.32997320e-05  5.14230230e-05 -3.65096261e-05 -3.10452701e-05\n",
+      "  3.04866252e-05  2.96967023e-05  4.38277904e-05  4.18301409e-05\n",
+      "  3.36755409e-05  3.98256712e-05  5.11721444e-05 -1.23188865e-05\n",
+      " -1.36516677e-05 -1.48087549e-05 -2.20775747e-05 -1.63690285e-05\n",
+      " -2.29415089e-05 -3.13901636e-05 -3.71225475e-05 -3.84918507e-05\n",
+      " -3.53009728e-05 -3.09669678e-05 -2.31777837e-05 -2.68938910e-05\n",
+      " -3.00309600e-05 -3.46334373e-05  2.99111490e-05  1.78936994e-05\n",
+      " -3.02466588e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-3.42814564e-05 -2.23507496e-05 -2.55462934e-05 -2.18696868e-05\n",
+      " -2.29431053e-05 -2.67918520e-05 -1.58426403e-05 -1.38544907e-05\n",
+      " -1.19193128e-05 -7.04297241e-06  0.00000000e+00  0.00000000e+00\n",
+      "  6.83880102e-06  1.02390732e-05  1.06413384e-05  1.55514242e-05\n",
+      "  2.65493126e-05  2.34046407e-05  3.17659052e-05  3.34002349e-05\n",
+      "  3.84485378e-05  4.58531499e-05 -3.16749489e-05 -2.71717992e-05\n",
+      "  2.70084262e-05  2.63358880e-05  3.84464927e-05  3.78974966e-05\n",
+      "  2.99798415e-05  3.59977024e-05  4.38589237e-05 -1.07019559e-05\n",
+      " -1.19650613e-05 -1.31643440e-05 -1.91663269e-05 -1.46358687e-05\n",
+      " -2.06594299e-05 -2.79302284e-05 -3.28686728e-05 -3.38676404e-05\n",
+      " -3.11182602e-05 -2.77496018e-05 -2.02039014e-05 -2.38007433e-05\n",
+      " -2.64226476e-05 -3.06068642e-05  2.63226685e-05  1.60264059e-05\n",
+      " -2.67894070e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 10%|▉         | 4/41 [00:07<01:08,  1.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 3.83867703e-05  2.46254770e-05  2.84039519e-05  2.44677765e-05\n",
+      "  2.55377582e-05  2.97735557e-05  2.73539589e-05 -4.56688530e-05\n",
+      " -5.37472416e-05 -4.46304343e-05 -3.87474198e-05 -3.11754499e-05\n",
+      " -2.94067476e-05 -2.25785535e-05 -1.26482504e-05 -9.81088023e-06\n",
+      " -8.04538934e-06  0.00000000e+00  0.00000000e+00  6.68385665e-06\n",
+      "  1.14923880e-05  1.74994433e-05  2.47124551e-05  3.06126772e-05\n",
+      " -2.45594551e-05 -1.90343595e-05 -2.26555650e-05 -1.67645594e-05\n",
+      " -9.93049138e-06 -8.10102804e-06 -1.07928848e-05  5.53351558e-05\n",
+      "  5.71401859e-05  4.77025266e-05  5.47223503e-05  3.05256764e-05\n",
+      "  3.49545323e-05  3.96511512e-05  3.73121792e-05  3.99883958e-05\n",
+      " -3.48488763e-05 -3.03079289e-05 -2.26048467e-05 -2.65211382e-05\n",
+      " -2.97587473e-05 -3.40857059e-05 -2.97240214e-05 -1.78449533e-05\n",
+      "  2.04408886e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 3.36807750e-05  2.19029761e-05  2.50305433e-05  2.14381843e-05\n",
+      "  2.26809066e-05  2.62814279e-05  2.37260510e-05 -4.02771635e-05\n",
+      " -4.69217860e-05 -3.92318742e-05 -3.42621443e-05 -2.74129614e-05\n",
+      " -2.58720148e-05 -1.99380579e-05 -1.11183535e-05 -8.65456128e-06\n",
+      " -7.08179978e-06  0.00000000e+00  0.00000000e+00  5.81767330e-06\n",
+      "  1.02080660e-05  1.56084936e-05  2.14411656e-05  2.67996339e-05\n",
+      " -2.17592000e-05 -1.68810295e-05 -1.98757972e-05 -1.51933487e-05\n",
+      " -8.84281894e-06 -7.32360798e-06 -9.25334370e-06  4.80751205e-05\n",
+      "  5.00807020e-05  4.24204441e-05  4.75246653e-05  2.73102693e-05\n",
+      "  3.14874086e-05  3.52879503e-05  3.30441535e-05  3.51932998e-05\n",
+      " -3.07253373e-05 -2.71648326e-05 -1.97114642e-05 -2.34732993e-05\n",
+      " -2.61907601e-05 -3.01287528e-05 -2.61613919e-05 -1.59898284e-05\n",
+      "  1.81102308e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 12%|█▏        | 5/41 [00:09<01:08,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.27401066e-05  8.16863439e-06  9.41993939e-06  8.16290177e-06\n",
+      "  8.48076671e-06  9.86875742e-06  1.21925543e-05  1.81404308e-05\n",
+      "  3.10601312e-05  3.24545365e-05  3.76029782e-05  4.05896314e-05\n",
+      " -4.95971166e-05 -4.13181074e-05 -2.61102711e-05 -2.50198686e-05\n",
+      " -2.90271315e-05 -1.83454221e-05 -1.66452953e-05 -1.03504602e-05\n",
+      " -5.70651289e-06  0.00000000e+00  4.45540801e-06  1.00798979e-05\n",
+      " -2.44632064e-05 -1.88992922e-05 -2.26187197e-05 -1.68911167e-05\n",
+      " -9.85779784e-06 -8.20658121e-06 -1.07485803e-05 -1.21100206e-05\n",
+      " -1.31204172e-05 -1.42765338e-05 -2.19377908e-05 -1.60240419e-05\n",
+      "  3.50052417e-05  3.95424412e-05  3.72421055e-05  4.00975888e-05\n",
+      "  3.65900343e-05  3.43530287e-05  2.45467311e-05  2.83991457e-05\n",
+      "  3.16297426e-05 -3.40153031e-05 -2.99133410e-05 -1.79360673e-05\n",
+      "  2.05331723e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.11925868e-05  7.07688992e-06  8.41038462e-06  7.21287117e-06\n",
+      "  7.49144490e-06  8.59608326e-06  1.07451440e-05  1.62084857e-05\n",
+      "  2.70955758e-05  2.86532538e-05  3.33469460e-05  3.59205331e-05\n",
+      " -4.34024957e-05 -3.66464872e-05 -2.29008010e-05 -2.22942695e-05\n",
+      " -2.56604504e-05 -1.58441805e-05 -1.47471553e-05 -8.71569461e-06\n",
+      " -4.73851525e-06  0.00000000e+00  0.00000000e+00  9.09247046e-06\n",
+      " -2.16446415e-05 -1.68150273e-05 -1.98589773e-05 -1.51153108e-05\n",
+      " -8.75843915e-06 -7.26141176e-06 -9.19458787e-06 -1.03267938e-05\n",
+      " -1.16085633e-05 -1.28341871e-05 -1.89337639e-05 -1.42096254e-05\n",
+      "  3.16926046e-05  3.52951615e-05  3.32077239e-05  3.54043393e-05\n",
+      "  3.22965756e-05  3.10755680e-05  2.16445477e-05  2.52046338e-05\n",
+      "  2.76821501e-05 -2.98366424e-05 -2.63080622e-05 -1.58529878e-05\n",
+      "  1.82705448e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 15%|█▍        | 6/41 [00:11<01:04,  1.84s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.25533686e-05  7.98797446e-06  9.12664275e-06  8.02128300e-06\n",
+      "  8.19726876e-06  9.41619252e-06  1.21906794e-05  1.79862743e-05\n",
+      "  3.15498557e-05  3.21749926e-05  3.76657590e-05  4.02226269e-05\n",
+      " -4.98270205e-05 -4.15636665e-05 -2.68042209e-05 -2.48083054e-05\n",
+      " -2.89144588e-05 -1.85475889e-05 -1.63156208e-05 -1.03978714e-05\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  9.79381441e-06\n",
+      " -2.42991422e-05 -1.87922621e-05 -2.25923565e-05 -1.68421661e-05\n",
+      " -9.96461944e-06 -8.15880036e-06 -1.03907083e-05 -1.21851880e-05\n",
+      " -1.31944395e-05 -1.42845947e-05 -2.14040081e-05 -1.57978616e-05\n",
+      "  3.47205277e-05  3.95182807e-05  3.71667507e-05  4.00581235e-05\n",
+      "  3.61977245e-05  3.47101549e-05  2.49306211e-05  2.83054817e-05\n",
+      "  3.18675530e-05 -3.39526575e-05 -2.99859827e-05 -1.79499386e-05\n",
+      "  2.08284397e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.10128229e-05  7.10221522e-06  8.03963401e-06  7.02065225e-06\n",
+      "  7.27395802e-06  8.30640189e-06  1.05724444e-05  1.58563028e-05\n",
+      "  2.75424652e-05  2.82878872e-05  3.32970863e-05  3.53566767e-05\n",
+      " -4.38442594e-05 -3.67024414e-05 -2.35544448e-05 -2.18871639e-05\n",
+      " -2.54414390e-05 -1.63047340e-05 -1.45074648e-05 -9.04964688e-06\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  8.56369561e-06\n",
+      " -2.15307939e-05 -1.66698432e-05 -1.98207158e-05 -1.52646733e-05\n",
+      " -8.87483007e-06 -7.37438734e-06 -8.89954481e-06 -1.05885089e-05\n",
+      " -1.15716205e-05 -1.27015097e-05 -1.85854855e-05 -1.41368649e-05\n",
+      "  3.12664588e-05  3.51746705e-05  3.29093814e-05  3.52560983e-05\n",
+      "  3.19206913e-05  3.10884999e-05  2.17379217e-05  2.50470069e-05\n",
+      "  2.80388649e-05 -3.00073243e-05 -2.63997455e-05 -1.60917983e-05\n",
+      "  1.84448522e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 17%|█▋        | 7/41 [00:13<01:03,  1.86s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  1.14032298e-05\n",
+      "  2.24293048e-05  2.44472972e-05  2.93722603e-05  3.36749418e-05\n",
+      "  4.03069044e-05  4.15114880e-05 -3.13297683e-05 -3.02717217e-05\n",
+      " -3.70256762e-05 -2.40966525e-05 -2.35214094e-05 -1.67627103e-05\n",
+      " -1.21613351e-05 -7.04528141e-06  0.00000000e+00  0.00000000e+00\n",
+      " -2.41549397e-05 -1.80887062e-05 -2.23459991e-05 -1.59819071e-05\n",
+      " -8.96298398e-06 -8.15938173e-06 -1.03828424e-05 -1.15590507e-05\n",
+      " -1.23940175e-05 -1.35194055e-05 -2.17690568e-05 -1.56203691e-05\n",
+      " -2.19373607e-05 -3.08413383e-05  3.74595064e-05  4.08202698e-05\n",
+      "  3.67061033e-05  3.43709025e-05  2.52927705e-05  2.86674732e-05\n",
+      "  3.23838556e-05  3.47254159e-05  2.97472834e-05 -1.73789644e-05\n",
+      "  2.04607811e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  1.00596412e-05\n",
+      "  1.95841571e-05  2.14931475e-05  2.59803736e-05  2.96128802e-05\n",
+      "  3.54654696e-05  3.66598690e-05 -2.75381158e-05 -2.67083104e-05\n",
+      " -3.25885314e-05 -2.11824399e-05 -2.09073078e-05 -1.45882423e-05\n",
+      " -1.08032475e-05 -6.29660950e-06  0.00000000e+00  0.00000000e+00\n",
+      " -2.14038945e-05 -1.60498702e-05 -1.96039981e-05 -1.45086412e-05\n",
+      " -7.99770464e-06 -7.37250597e-06 -8.89671717e-06 -1.00376764e-05\n",
+      " -1.08676776e-05 -1.20328437e-05 -1.89017291e-05 -1.39779585e-05\n",
+      " -1.97673983e-05 -2.74484545e-05  3.31731104e-05  3.59221058e-05\n",
+      "  3.23676210e-05  3.08016268e-05  2.20604591e-05  2.53696864e-05\n",
+      "  2.84993954e-05  3.06883339e-05  2.61900227e-05 -1.55807061e-05\n",
+      "  1.81291284e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 20%|█▉        | 8/41 [00:15<01:04,  1.96s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.81297003e-05  1.80476820e-05  2.09427008e-05  1.83499784e-05\n",
+      "  1.87112809e-05  2.19407924e-05  2.13821423e-05  2.82902835e-05\n",
+      "  4.44294884e-05 -5.24835230e-05 -4.66686212e-05 -3.84423107e-05\n",
+      " -3.73348849e-05 -2.99681111e-05 -1.80446837e-05 -1.57490309e-05\n",
+      " -1.61704854e-05 -8.69348652e-06 -5.42296503e-06  0.00000000e+00\n",
+      "  0.00000000e+00  1.05769615e-05  1.66451379e-05  2.24177071e-05\n",
+      " -2.41502203e-05 -1.88040893e-05 -2.26677951e-05 -1.65373601e-05\n",
+      " -9.80429308e-06 -8.24770267e-06 -1.07997279e-05 -1.20390408e-05\n",
+      " -1.30623348e-05  4.76993382e-05  5.48925422e-05  3.07477186e-05\n",
+      "  3.50730833e-05  3.97498349e-05  3.72665302e-05  4.04205935e-05\n",
+      "  3.64453738e-05  3.43367268e-05 -2.26385279e-05 -2.66817041e-05\n",
+      " -2.96067035e-05 -3.35844442e-05 -2.96303197e-05 -1.82220753e-05\n",
+      "  2.04540106e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.46788969e-05  1.60514815e-05  1.84539373e-05  1.60792876e-05\n",
+      "  1.66167550e-05  1.93652730e-05  1.85457151e-05  2.49481028e-05\n",
+      "  3.87806654e-05 -4.61253764e-05 -4.12615739e-05 -3.37957939e-05\n",
+      " -3.28422727e-05 -2.64593208e-05 -1.58584957e-05 -1.38879506e-05\n",
+      " -1.42283423e-05 -7.63839897e-06 -4.81721596e-06  0.00000000e+00\n",
+      "  0.00000000e+00  9.43203869e-06  1.44418330e-05  1.96223357e-05\n",
+      " -2.13940665e-05 -1.66744765e-05 -1.98849958e-05 -1.49875859e-05\n",
+      " -8.72759422e-06 -7.45332963e-06 -9.25936999e-06 -1.04572364e-05\n",
+      " -1.14462453e-05  4.24094178e-05  4.76708463e-05  2.75009054e-05\n",
+      "  3.15869489e-05  3.53713679e-05  3.29986059e-05  3.55717522e-05\n",
+      "  3.21266479e-05  3.07707801e-05 -1.97380453e-05 -2.36107414e-05\n",
+      " -2.60503631e-05 -2.96786378e-05 -2.60751500e-05 -1.63229671e-05\n",
+      "  1.81184460e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 22%|██▏       | 9/41 [00:17<01:01,  1.91s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.31728949e-05  1.46179359e-05  1.69345594e-05  1.47367402e-05\n",
+      "  1.52049663e-05  1.77337542e-05  1.82191447e-05  2.44705829e-05\n",
+      "  3.97966614e-05  4.05928324e-05 -5.09073705e-05 -4.26151581e-05\n",
+      " -4.14082344e-05 -3.37963116e-05 -2.08575701e-05 -1.89370681e-05\n",
+      " -2.07538185e-05 -1.20483324e-05 -9.37463635e-06  0.00000000e+00\n",
+      "  0.00000000e+00  6.65084799e-06  1.25895411e-05  1.81936470e-05\n",
+      " -2.45413612e-05 -1.87790583e-05 -2.25113783e-05 -1.68180674e-05\n",
+      " -9.86396348e-06 -8.47160436e-06 -1.08912458e-05 -1.23211489e-05\n",
+      " -1.32017293e-05 -1.41634793e-05  5.46778529e-05  3.05854413e-05\n",
+      "  3.49915948e-05  3.94736629e-05  3.70293946e-05  4.00542882e-05\n",
+      "  3.68142163e-05  3.42898878e-05  2.48316403e-05 -2.65997200e-05\n",
+      " -2.98223187e-05 -3.42183170e-05 -3.00462095e-05 -1.77101826e-05\n",
+      "  2.04116895e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.03291180e-05  1.30031084e-05  1.49233381e-05  1.29125685e-05\n",
+      "  1.35044058e-05  1.56551900e-05  1.58018985e-05  2.15878261e-05\n",
+      "  3.47397511e-05  3.56773879e-05 -4.50129021e-05 -3.74755088e-05\n",
+      " -3.64283081e-05 -2.98448249e-05 -1.83316285e-05 -1.67042117e-05\n",
+      " -1.82661866e-05 -1.05879682e-05 -8.32663222e-06  0.00000000e+00\n",
+      "  0.00000000e+00  5.93243797e-06  1.09216663e-05  1.59279813e-05\n",
+      " -2.17432358e-05 -1.66561573e-05 -1.97499664e-05 -1.52390964e-05\n",
+      " -8.78108535e-06 -7.64802914e-06 -9.33704082e-06 -1.07037648e-05\n",
+      " -1.15705404e-05 -1.25946444e-05  4.74791683e-05  2.73602998e-05\n",
+      "  3.15210050e-05  3.51306732e-05  3.27957928e-05  3.52501266e-05\n",
+      "  3.24550658e-05  3.07351505e-05  2.16470354e-05 -2.35446485e-05\n",
+      " -2.62418864e-05 -3.02432528e-05 -2.64435571e-05 -1.58715679e-05\n",
+      "  1.80848419e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 24%|██▍       | 10/41 [00:19<00:58,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-2.85698480e-05 -1.83126147e-05 -2.11735334e-05 -1.83992793e-05\n",
+      " -1.90231148e-05 -2.22395632e-05 -1.20478289e-05 -8.83136632e-06\n",
+      " -4.65885529e-06  0.00000000e+00  5.55397896e-06  1.04456839e-05\n",
+      "  1.60103507e-05  1.90949147e-05  1.74591412e-05  2.36506422e-05\n",
+      "  3.86328442e-05  3.30093200e-05  4.31958120e-05  4.51000891e-05\n",
+      " -3.37106479e-05 -3.01767137e-05 -2.82030477e-05 -2.27218982e-05\n",
+      "  3.04399466e-05  2.97554533e-05  4.38127280e-05  4.16331647e-05\n",
+      "  3.34892622e-05 -8.29492052e-06 -1.08743986e-05 -1.22874111e-05\n",
+      " -1.33051728e-05 -1.44149925e-05 -2.22283288e-05 -1.62192691e-05\n",
+      " -2.27462591e-05 -3.12743729e-05 -3.69442860e-05 -3.84793104e-05\n",
+      " -3.51978786e-05 -3.08603646e-05 -2.29047307e-05 -2.70172680e-05\n",
+      "  3.20481699e-05  3.46581380e-05  2.98421075e-05  1.77726458e-05\n",
+      " -1.73815614e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-2.48139885e-05 -1.64646864e-05 -1.86361465e-05 -1.65600230e-05\n",
+      " -1.68092598e-05 -1.92722039e-05 -1.01360585e-05 -7.55594057e-06\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  9.25211339e-06\n",
+      "  1.42769467e-05  1.70226585e-05  1.51164879e-05  2.08334279e-05\n",
+      "  3.45503577e-05  2.90642168e-05  3.83843988e-05  3.91443014e-05\n",
+      " -2.97312358e-05 -2.69755960e-05 -2.41211282e-05 -1.99116478e-05\n",
+      "  2.70110283e-05  2.59437845e-05  3.83297258e-05  3.76572163e-05\n",
+      "  2.99558637e-05 -7.81105832e-06 -9.61575444e-06 -1.07333754e-05\n",
+      " -1.17247258e-05 -1.22336522e-05 -1.94820419e-05 -1.50701168e-05\n",
+      " -2.00971346e-05 -2.79823234e-05 -3.29610310e-05 -3.37269216e-05\n",
+      " -3.10641399e-05 -2.74521310e-05 -2.00402684e-05 -2.40444530e-05\n",
+      "  2.83324033e-05  3.06803911e-05  2.62549835e-05  1.58907757e-05\n",
+      " -1.52256449e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 27%|██▋       | 11/41 [00:20<00:56,  1.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 3.84763146e-05  2.48387479e-05  2.84445471e-05  2.47054570e-05\n",
+      "  2.55088230e-05  2.98147011e-05  2.74517648e-05 -4.57941967e-05\n",
+      " -5.38439352e-05 -4.47376566e-05 -3.88004706e-05 -3.16725531e-05\n",
+      " -2.90255120e-05 -2.25231011e-05 -1.26509693e-05 -9.90290892e-06\n",
+      " -8.11047763e-06  0.00000000e+00  0.00000000e+00  6.81232289e-06\n",
+      "  1.15179761e-05  1.75670623e-05  2.48175714e-05  3.05421394e-05\n",
+      " -2.44310812e-05 -1.90788163e-05 -2.26383146e-05 -1.67119576e-05\n",
+      " -9.82721815e-06 -8.23916694e-06 -1.06279282e-05  5.54306554e-05\n",
+      "  5.71073646e-05  4.76290174e-05  5.44505370e-05  3.06402894e-05\n",
+      "  3.52151530e-05  3.95427901e-05  3.72075758e-05  4.01814496e-05\n",
+      " -3.48217763e-05 -3.04716370e-05 -2.26131450e-05 -2.68491830e-05\n",
+      " -2.98876501e-05 -3.40929849e-05 -2.98053671e-05 -1.79131636e-05\n",
+      "  2.04982417e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 3.37596642e-05  2.20920096e-05  2.50655270e-05  2.16468837e-05\n",
+      "  2.26550364e-05  2.63176805e-05  2.38130341e-05 -4.03889861e-05\n",
+      " -4.70068357e-05 -3.93261275e-05 -3.43080656e-05 -2.78524634e-05\n",
+      " -2.55366259e-05 -1.98898938e-05 -1.11199926e-05 -8.73592090e-06\n",
+      " -7.14045079e-06  0.00000000e+00  0.00000000e+00  5.93107720e-06\n",
+      "  1.02302169e-05  1.56699519e-05  2.15354533e-05  2.67391381e-05\n",
+      " -2.16477795e-05 -1.69205745e-05 -1.98623417e-05 -1.51455936e-05\n",
+      " -8.75000571e-06 -7.44699851e-06 -9.10790801e-06  4.81589507e-05\n",
+      "  5.00517398e-05  4.23531435e-05  4.72858261e-05  2.74116360e-05\n",
+      "  3.17168131e-05  3.51924534e-05  3.29520569e-05  3.53625890e-05\n",
+      " -3.07013208e-05 -2.73086066e-05 -1.97170242e-05 -2.37627462e-05\n",
+      " -2.63029396e-05 -3.01352208e-05 -2.62344892e-05 -1.60496396e-05\n",
+      "  1.81622807e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 29%|██▉       | 12/41 [00:22<00:55,  1.91s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.28183710e-05  8.24989935e-06  9.59996796e-06  8.19557618e-06\n",
+      "  8.82999305e-06  1.01969009e-05  1.24307975e-05  1.80109990e-05\n",
+      "  3.13127052e-05  3.24161910e-05  3.74939624e-05  4.04698225e-05\n",
+      " -4.93919407e-05 -4.15187577e-05 -2.61179069e-05 -2.48722559e-05\n",
+      " -2.87837654e-05 -1.85273771e-05 -1.64403155e-05 -1.01965240e-05\n",
+      " -5.75753884e-06  0.00000000e+00  0.00000000e+00  1.01537524e-05\n",
+      " -2.42901539e-05 -1.90403011e-05 -2.26971669e-05 -1.67026409e-05\n",
+      " -9.76987802e-06 -8.10102280e-06 -1.06811532e-05 -1.19764466e-05\n",
+      " -1.30711266e-05 -1.41272525e-05 -2.15950251e-05 -1.59234966e-05\n",
+      "  3.52491453e-05  3.97392293e-05  3.72731629e-05  4.03721566e-05\n",
+      "  3.69757999e-05  3.43921165e-05  2.46969745e-05  2.83863231e-05\n",
+      "  3.12975202e-05 -3.37818271e-05 -2.97176886e-05 -1.77812001e-05\n",
+      "  2.05183060e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.12458500e-05  7.33430941e-06  8.45244065e-06  7.17532813e-06\n",
+      "  7.83427427e-06  8.99185635e-06  1.07847578e-05  1.58821035e-05\n",
+      "  2.73385820e-05  2.85023004e-05  3.31472695e-05  3.55780069e-05\n",
+      " -4.34611631e-05 -3.66585565e-05 -2.29515818e-05 -2.19460174e-05\n",
+      " -2.53267659e-05 -1.62802713e-05 -1.46144979e-05 -8.87489310e-06\n",
+      " -5.10985809e-06  0.00000000e+00  0.00000000e+00  8.88495598e-06\n",
+      " -2.15255045e-05 -1.68864623e-05 -1.99116294e-05 -1.51404588e-05\n",
+      " -8.69997999e-06 -7.32506024e-06 -9.15638200e-06 -1.04088527e-05\n",
+      " -1.14582144e-05 -1.25646652e-05 -1.87540730e-05 -1.42475987e-05\n",
+      "  3.17299829e-05  3.53672117e-05  3.30039628e-05  3.55298999e-05\n",
+      "  3.26049390e-05  3.08155411e-05  2.15345425e-05  2.51163680e-05\n",
+      "  2.75428727e-05 -2.98555204e-05 -2.61623526e-05 -1.59426470e-05\n",
+      "  1.81730991e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 32%|███▏      | 13/41 [00:24<00:53,  1.92s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 7.42995390e-06  5.01676528e-06  5.66543656e-06  0.00000000e+00\n",
+      "  5.04584089e-06  5.93079736e-06  9.05451997e-06  1.46919290e-05\n",
+      "  2.67808849e-05  2.85349375e-05  3.33546486e-05  3.66324843e-05\n",
+      "  4.39788736e-05 -4.46762732e-05 -2.84392246e-05 -2.78287666e-05\n",
+      " -3.33625759e-05 -2.17227759e-05 -2.02615519e-05 -1.37868587e-05\n",
+      " -9.32228592e-06  0.00000000e+00  0.00000000e+00  6.37349732e-06\n",
+      " -2.48456949e-05 -1.83577042e-05 -2.25901192e-05 -1.66033386e-05\n",
+      " -9.71890361e-06 -8.13999621e-06 -1.08101508e-05 -1.20274158e-05\n",
+      " -1.29029152e-05 -1.40085798e-05 -2.20352373e-05 -1.60560484e-05\n",
+      " -2.24944838e-05  3.92035983e-05  3.72351997e-05  4.02361955e-05\n",
+      "  3.66127887e-05  3.44481640e-05  2.44082547e-05  2.84200547e-05\n",
+      "  3.16671224e-05  3.42052557e-05 -2.99942837e-05 -1.78586137e-05\n",
+      "  2.09222481e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 6.51778672e-06  4.45599050e-06  4.98942007e-06  0.00000000e+00\n",
+      "  4.48142345e-06  5.23301818e-06  7.85494387e-06  1.29587428e-05\n",
+      "  2.33782803e-05  2.50834202e-05  2.94892570e-05  3.22101018e-05\n",
+      "  3.86915618e-05 -3.94531327e-05 -2.49992939e-05 -2.45492429e-05\n",
+      " -2.93651680e-05 -1.90932178e-05 -1.80051570e-05 -1.20022842e-05\n",
+      " -8.27594940e-06  0.00000000e+00  0.00000000e+00  5.58383910e-06\n",
+      " -2.20122697e-05 -1.62817029e-05 -1.98214303e-05 -1.50556924e-05\n",
+      " -8.65610178e-06 -7.35928302e-06 -9.27414618e-06 -1.04501112e-05\n",
+      " -1.13083451e-05 -1.24598232e-05 -1.91421423e-05 -1.43630217e-05\n",
+      " -2.02592418e-05  3.48900010e-05  3.29724569e-05  3.54144537e-05\n",
+      "  3.22793161e-05  3.08679202e-05  2.12768459e-05  2.51498597e-05\n",
+      "  2.78676595e-05  3.02311608e-05 -2.63999420e-05 -1.60050586e-05\n",
+      "  1.85322334e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 34%|███▍      | 14/41 [00:26<00:51,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-2.85656018e-05 -1.83109354e-05 -2.11735749e-05 -1.83958576e-05\n",
+      " -1.90245703e-05 -2.22389963e-05 -1.20524284e-05 -8.82408813e-06\n",
+      " -4.65852671e-06  0.00000000e+00  5.55605432e-06  1.04452710e-05\n",
+      "  1.60129669e-05  1.90881961e-05  1.74570573e-05  2.36484870e-05\n",
+      "  3.86359234e-05  3.30056813e-05  4.31949869e-05  4.51021795e-05\n",
+      " -3.37080501e-05 -3.01783564e-05 -2.82028767e-05 -2.27210091e-05\n",
+      "  3.04377926e-05  2.97478620e-05  4.38150797e-05  4.16331638e-05\n",
+      "  3.34864589e-05 -8.29556869e-06 -1.08801428e-05 -1.22838779e-05\n",
+      " -1.33086169e-05 -1.44190619e-05 -2.22311673e-05 -1.62183435e-05\n",
+      " -2.27451768e-05 -3.12756663e-05 -3.69454808e-05 -3.84794713e-05\n",
+      " -3.51979665e-05 -3.08609391e-05 -2.29004575e-05 -2.70143309e-05\n",
+      "  3.20468435e-05  3.46549249e-05  2.98449645e-05  1.77772344e-05\n",
+      " -1.73744319e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-2.50618664e-05 -1.62856507e-05 -1.86573348e-05 -1.61177206e-05\n",
+      " -1.68953633e-05 -1.96296013e-05 -1.04530459e-05 -7.78141412e-06\n",
+      " -4.06557756e-06  0.00000000e+00  4.91386571e-06  9.18451383e-06\n",
+      "  1.40872302e-05  1.68544005e-05  1.53429532e-05  2.08585998e-05\n",
+      "  3.40067244e-05  2.90078794e-05  3.83846010e-05  3.92505573e-05\n",
+      " -2.99346968e-05 -2.69136163e-05 -2.44705891e-05 -1.98900075e-05\n",
+      "  2.69690958e-05  2.63816777e-05  3.84414727e-05  3.77248701e-05\n",
+      "  2.98135420e-05 -7.49764792e-06 -9.32657829e-06 -1.06724129e-05\n",
+      " -1.16637448e-05 -1.28210940e-05 -1.93045657e-05 -1.45063390e-05\n",
+      " -2.04855872e-05 -2.78314606e-05 -3.27156285e-05 -3.38630597e-05\n",
+      " -3.10314211e-05 -2.76568507e-05 -1.99642066e-05 -2.39086513e-05\n",
+      "  2.81983198e-05  3.06291402e-05  2.62676625e-05  1.59265026e-05\n",
+      " -1.53894825e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 37%|███▋      | 15/41 [00:28<00:48,  1.87s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000004\n",
+      "INFO:shap:phi = [ 2.79463581e-05  1.80495365e-05  2.10132499e-05  1.78586098e-05\n",
+      "  1.86133562e-05  2.19277459e-05  2.11966039e-05  2.83361995e-05\n",
+      "  4.45489297e-05 -5.26998072e-05 -4.66951024e-05 -3.88013380e-05\n",
+      " -3.72218950e-05 -3.03166853e-05 -1.78043941e-05 -1.55241004e-05\n",
+      " -1.64138748e-05 -8.56581429e-06 -5.34817475e-06  0.00000000e+00\n",
+      "  0.00000000e+00  1.06577768e-05  1.66543965e-05  2.24816774e-05\n",
+      " -2.42174898e-05 -1.86433577e-05 -2.24797244e-05 -1.68815714e-05\n",
+      " -9.42584722e-06 -7.87648945e-06 -1.05811450e-05 -1.21928921e-05\n",
+      " -1.31296347e-05  4.76661941e-05  5.49345762e-05  3.07766296e-05\n",
+      "  3.50792744e-05  3.95551854e-05  3.75653155e-05  4.00089637e-05\n",
+      "  3.67234400e-05  3.46346705e-05 -2.25722788e-05 -2.68800014e-05\n",
+      " -2.98363654e-05 -3.36553062e-05 -2.99692579e-05 -1.75691560e-05\n",
+      "  2.05681804e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000004\n",
+      "INFO:shap:phi = [ 2.41254464e-05  1.56303518e-05  1.87967760e-05  1.55908368e-05\n",
+      "  1.67527618e-05  1.90993041e-05  1.83827112e-05  2.48079031e-05\n",
+      "  3.86387303e-05 -4.66599511e-05 -4.14053461e-05 -3.42567859e-05\n",
+      " -3.27964640e-05 -2.70216083e-05 -1.57703563e-05 -1.40392649e-05\n",
+      " -1.44768578e-05 -7.39585902e-06  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  9.33499132e-06  1.41085298e-05  1.92294584e-05\n",
+      " -2.14007583e-05 -1.65977151e-05 -1.99294540e-05 -1.54652679e-05\n",
+      " -8.37714529e-06 -7.27445551e-06 -9.01655514e-06 -1.06651567e-05\n",
+      " -1.17414585e-05  4.21432739e-05  4.73609132e-05  2.75371623e-05\n",
+      "  3.17186122e-05  3.52912215e-05  3.29984831e-05  3.51193675e-05\n",
+      "  3.24244031e-05  3.12305613e-05 -1.97403961e-05 -2.37241161e-05\n",
+      " -2.62235326e-05 -2.97701333e-05 -2.64684876e-05 -1.56279396e-05\n",
+      "  1.79897603e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 39%|███▉      | 16/41 [00:30<00:46,  1.86s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.000000000000014\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000004\n",
+      "INFO:shap:phi = [ 7.79139876e-06  4.81655671e-06  6.02371859e-06  5.04571545e-06\n",
+      "  0.00000000e+00  0.00000000e+00  9.60067953e-06  1.46138947e-05\n",
+      "  2.60177680e-05  2.89814388e-05  3.39406167e-05  3.69462429e-05\n",
+      "  4.39770429e-05 -4.46764445e-05 -2.89680504e-05 -2.80984755e-05\n",
+      " -3.28751278e-05 -2.10663518e-05 -2.02157854e-05 -1.35159809e-05\n",
+      " -8.52074605e-06  0.00000000e+00  0.00000000e+00  6.38647247e-06\n",
+      " -2.40386772e-05 -1.91115655e-05 -2.27187262e-05 -1.68664479e-05\n",
+      " -9.86021112e-06 -7.96696350e-06 -9.71403952e-06 -1.17824634e-05\n",
+      " -1.24788617e-05 -1.38212040e-05 -2.18727782e-05 -1.59548459e-05\n",
+      " -2.24423039e-05  3.92935810e-05  3.68662557e-05  4.02625651e-05\n",
+      "  3.68105984e-05  3.39498449e-05  2.48492674e-05  2.85548232e-05\n",
+      "  3.15472143e-05  3.43391676e-05 -2.92892415e-05 -1.73458871e-05\n",
+      "  2.05919689e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.000000000000014\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000004\n",
+      "INFO:shap:phi = [ 6.79524741e-06  4.69750770e-06  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  8.49511492e-06  1.28933565e-05\n",
+      "  2.27041844e-05  2.57678854e-05  2.99480209e-05  3.25224786e-05\n",
+      "  3.94703436e-05 -3.93366513e-05 -2.54184625e-05 -2.47661789e-05\n",
+      " -2.88430920e-05 -1.81176005e-05 -1.79919464e-05 -1.15737348e-05\n",
+      " -7.49051247e-06  0.00000000e+00  0.00000000e+00  5.82460756e-06\n",
+      " -2.06992711e-05 -1.67216842e-05 -1.92910166e-05 -1.49783484e-05\n",
+      " -8.20157053e-06 -6.47370724e-06 -8.26587194e-06 -9.93636062e-06\n",
+      " -1.06434657e-05 -1.21283208e-05 -1.88154554e-05 -1.38636919e-05\n",
+      " -2.02273996e-05  3.52170328e-05  3.25487217e-05  3.56273755e-05\n",
+      "  3.28787705e-05  3.07122715e-05  2.18062285e-05  2.53450232e-05\n",
+      "  2.81852913e-05  3.04070052e-05 -2.56763817e-05 -1.50890867e-05\n",
+      "  1.85212792e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 41%|████▏     | 17/41 [00:32<00:44,  1.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-3.38490088e-05 -2.15809779e-05 -2.52210059e-05 -2.18839414e-05\n",
+      " -2.26162279e-05 -2.64011504e-05 -1.50015775e-05 -1.23133955e-05\n",
+      " -8.99950505e-06  0.00000000e+00  0.00000000e+00  6.23984236e-06\n",
+      "  1.16287862e-05  1.52654653e-05  1.48564412e-05  2.05538493e-05\n",
+      "  3.43833500e-05  2.97997759e-05  3.94276688e-05  4.20279437e-05\n",
+      "  4.66550767e-05 -3.40060502e-05 -3.23834722e-05 -2.68437420e-05\n",
+      "  3.04600374e-05  2.95648577e-05  4.37560906e-05  4.17912635e-05\n",
+      "  3.36087101e-05  3.97570152e-05 -1.09226471e-05 -1.23242699e-05\n",
+      " -1.33270873e-05 -1.45427855e-05 -2.22975798e-05 -1.63127061e-05\n",
+      " -2.26637216e-05 -3.14516625e-05 -3.70821668e-05 -3.87161909e-05\n",
+      " -3.53300743e-05 -3.10514858e-05 -2.31991372e-05 -2.70864647e-05\n",
+      " -3.03820425e-05  3.46009836e-05  2.97063136e-05  1.79034999e-05\n",
+      " -2.39134280e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-2.96934008e-05 -1.91907700e-05 -2.22191296e-05 -1.91705548e-05\n",
+      " -2.00802476e-05 -2.32983741e-05 -1.30065122e-05 -1.08557560e-05\n",
+      " -7.85361781e-06  0.00000000e+00  0.00000000e+00  5.48473636e-06\n",
+      "  1.02278721e-05  1.34762258e-05  1.30538894e-05  1.81269302e-05\n",
+      "  3.02574241e-05  2.61851021e-05  3.50311631e-05  3.65721036e-05\n",
+      "  4.14277633e-05 -3.03215630e-05 -2.80930695e-05 -2.34948027e-05\n",
+      "  2.69834410e-05  2.62152307e-05  3.83798183e-05  3.78596928e-05\n",
+      "  2.99180422e-05  3.59343731e-05 -9.36128000e-06 -1.07056975e-05\n",
+      " -1.16773696e-05 -1.29278101e-05 -1.93595434e-05 -1.45870121e-05\n",
+      " -2.04119059e-05 -2.79837145e-05 -3.28308598e-05 -3.40652691e-05\n",
+      " -3.11428866e-05 -2.78215140e-05 -2.02235079e-05 -2.39692901e-05\n",
+      " -2.67301032e-05  3.05774176e-05  2.61407724e-05  1.60357708e-05\n",
+      " -2.11791137e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 44%|████▍     | 18/41 [00:34<00:42,  1.86s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.80083387e-05  1.79604855e-05  2.13161084e-05  1.82826061e-05\n",
+      "  1.86674907e-05  2.22148425e-05  2.12791185e-05  2.85372880e-05\n",
+      "  4.44395962e-05 -5.27932029e-05 -4.65744523e-05 -3.88493941e-05\n",
+      " -3.70087316e-05 -3.03017219e-05 -1.76047689e-05 -1.59316745e-05\n",
+      " -1.64757066e-05 -8.75555234e-06 -5.41012564e-06  0.00000000e+00\n",
+      "  0.00000000e+00  1.02371160e-05  1.64942280e-05  2.26935463e-05\n",
+      " -2.44784392e-05 -1.86056979e-05 -2.21986107e-05 -1.66998228e-05\n",
+      " -9.97207910e-06 -8.19128269e-06 -1.06743098e-05 -1.19501765e-05\n",
+      " -1.28051131e-05  4.75760892e-05  5.49495000e-05  3.09081747e-05\n",
+      "  3.50478097e-05  3.94508868e-05  3.72322351e-05  4.00297086e-05\n",
+      "  3.64287417e-05  3.43581912e-05 -2.24316117e-05 -2.66744828e-05\n",
+      " -2.93028551e-05 -3.39207257e-05 -2.97113224e-05 -1.77855771e-05\n",
+      "  2.04905017e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.45703565e-05  1.59734387e-05  1.87839622e-05  1.60186803e-05\n",
+      "  1.65785027e-05  1.96094106e-05  1.84554179e-05  2.51673065e-05\n",
+      "  3.87902424e-05 -4.64019094e-05 -4.11770136e-05 -3.41566608e-05\n",
+      " -3.25535873e-05 -2.67561438e-05 -1.54674576e-05 -1.40519366e-05\n",
+      " -1.44984816e-05 -7.69378527e-06 -4.80589203e-06  0.00000000e+00\n",
+      "  0.00000000e+00  9.13059050e-06  1.43075510e-05  1.98672257e-05\n",
+      " -2.16854518e-05 -1.64978868e-05 -1.94670056e-05 -1.51330402e-05\n",
+      " -8.87721904e-06 -7.40217070e-06 -9.14807467e-06 -1.03786772e-05\n",
+      " -1.12177361e-05  4.23011987e-05  4.77224160e-05  2.76427506e-05\n",
+      "  3.15638368e-05  3.51056908e-05  3.29682126e-05  3.52255424e-05\n",
+      "  3.21127855e-05  3.07893021e-05 -1.95538750e-05 -2.36035794e-05\n",
+      " -2.57802468e-05 -2.99785222e-05 -2.61476513e-05 -1.59340262e-05\n",
+      "  1.81501048e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 46%|████▋     | 19/41 [00:36<00:41,  1.89s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 48.99999999999999\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.31413251e-05 -8.26844698e-06 -9.65216306e-06 -8.29733381e-06\n",
+      " -8.58084957e-06 -1.01555042e-05  0.00000000e+00  0.00000000e+00\n",
+      "  8.98929194e-06  1.26851885e-05  1.78218162e-05  2.18009396e-05\n",
+      "  2.84525668e-05  3.04764326e-05  2.55253642e-05  3.27421954e-05\n",
+      "  5.11783575e-05 -3.46036314e-05 -3.55470771e-05 -2.78809762e-05\n",
+      " -2.31732978e-05 -1.89674898e-05 -1.57777539e-05 -1.04470182e-05\n",
+      "  3.04869270e-05  2.95471299e-05 -2.26841934e-05 -1.71103847e-05\n",
+      " -9.71679187e-06 -8.38686987e-06 -1.08168586e-05 -1.21126004e-05\n",
+      " -1.31654741e-05 -1.46400733e-05 -2.20322147e-05 -1.62703568e-05\n",
+      " -2.27221639e-05 -3.10327591e-05 -3.69295378e-05 -3.82188189e-05\n",
+      " -3.50870308e-05  3.45288799e-05  2.47448108e-05  2.87589596e-05\n",
+      "  3.18716577e-05  3.45072669e-05  2.96811676e-05  1.76474326e-05\n",
+      "  0.00000000e+00]\n",
+      "INFO:shap:np.sum(w_aug) = 48.99999999999999\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.15289108e-05 -7.35750315e-06 -8.50004391e-06 -7.26453109e-06\n",
+      " -7.62064776e-06 -8.96113311e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.84896493e-06  1.11531944e-05  1.57586144e-05  1.91711781e-05\n",
+      "  2.50369636e-05  2.69132208e-05  2.24364240e-05  2.88862922e-05\n",
+      "  4.50469678e-05 -3.04074977e-05 -3.15858254e-05 -2.42648376e-05\n",
+      " -2.05794516e-05 -1.69182951e-05 -1.36869633e-05 -9.14084489e-06\n",
+      "  2.70142276e-05  2.62066794e-05 -1.99026810e-05 -1.54992216e-05\n",
+      " -8.65456258e-06 -7.57464597e-06 -9.26843243e-06 -1.05226527e-05\n",
+      " -1.15390624e-05 -1.30133110e-05 -1.91307714e-05 -1.45529437e-05\n",
+      " -2.04586638e-05 -2.76184579e-05 -3.27005465e-05 -3.36369451e-05\n",
+      " -3.09375950e-05  3.09508483e-05  2.15742323e-05  2.54527096e-05\n",
+      "  2.80488313e-05  3.05007325e-05  2.61315955e-05  1.58203196e-05\n",
+      "  0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 49%|████▉     | 20/41 [00:38<00:42,  2.01s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.82394555e-05 -1.13825216e-05 -1.33670789e-05 -1.14946273e-05\n",
+      " -1.22082219e-05 -1.42397485e-05 -5.93809919e-06  0.00000000e+00\n",
+      "  0.00000000e+00  8.21597867e-06  1.35986260e-05  1.83706474e-05\n",
+      "  2.42818134e-05  2.65307025e-05  2.30397668e-05  2.95342409e-05\n",
+      "  4.70678655e-05  3.93079564e-05 -3.92080127e-05 -3.11104142e-05\n",
+      " -2.65260334e-05 -2.26100965e-05 -1.98653184e-05 -1.44162982e-05\n",
+      "  3.05636638e-05  2.97357795e-05  4.37516557e-05 -1.69483683e-05\n",
+      " -9.85291802e-06 -8.14834072e-06 -1.07895819e-05 -1.22142406e-05\n",
+      " -1.32234576e-05 -1.44098421e-05 -2.20358866e-05 -1.61169668e-05\n",
+      " -2.27278914e-05 -3.11484530e-05 -3.68614633e-05 -3.81697290e-05\n",
+      " -3.47463883e-05 -3.06927721e-05  2.49067754e-05  2.85769234e-05\n",
+      "  3.18457184e-05  3.45059233e-05  2.98069990e-05  1.78522016e-05\n",
+      " -4.83382988e-06]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.60057188e-05 -1.01304631e-05 -1.17798687e-05 -1.00709419e-05\n",
+      " -1.08436999e-05 -1.25681402e-05 -5.15204346e-06  0.00000000e+00\n",
+      "  0.00000000e+00  7.22103389e-06  1.20267255e-05  1.61543437e-05\n",
+      "  2.13665554e-05  2.34324347e-05  2.02516091e-05  2.60584428e-05\n",
+      "  4.14337385e-05  3.45528685e-05 -3.48456951e-05 -2.70786344e-05\n",
+      " -2.35638637e-05 -2.01719279e-05 -1.72392961e-05 -1.26217753e-05\n",
+      "  2.70830968e-05  2.63744959e-05  3.83905542e-05 -1.53607406e-05\n",
+      " -8.77700161e-06 -7.36978705e-06 -9.24927771e-06 -1.06141518e-05\n",
+      " -1.15930295e-05 -1.28161038e-05 -1.91388886e-05 -1.44194558e-05\n",
+      " -2.04699729e-05 -2.77269951e-05 -3.26472238e-05 -3.35992515e-05\n",
+      " -3.06437428e-05 -2.75117817e-05  2.17165884e-05  2.52986873e-05\n",
+      "  2.80283941e-05  3.05014306e-05  2.62406770e-05  1.59966656e-05\n",
+      " -4.27919867e-06]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 51%|█████     | 21/41 [00:40<00:38,  1.94s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.80659703e-05  1.79936272e-05  2.08014554e-05  1.80763588e-05\n",
+      "  1.86913311e-05  2.18539648e-05  2.12268833e-05  2.82118434e-05\n",
+      "  4.44510237e-05 -5.26770993e-05 -4.67102995e-05 -3.89333200e-05\n",
+      " -3.73321996e-05 -3.00529963e-05 -1.79822301e-05 -1.59516142e-05\n",
+      " -1.64160291e-05 -8.76653549e-06 -5.53510572e-06  0.00000000e+00\n",
+      "  4.65655365e-06  1.03170892e-05  1.65449300e-05  2.23238042e-05\n",
+      " -2.44371491e-05 -1.89033066e-05 -2.26220478e-05 -1.68509245e-05\n",
+      " -9.84357252e-06 -8.18520275e-06 -1.07327907e-05 -1.21118804e-05\n",
+      " -1.31309434e-05  4.75857302e-05  5.46140959e-05  3.06470811e-05\n",
+      "  3.50040790e-05  3.95358460e-05  3.72280968e-05  4.01164741e-05\n",
+      "  3.66242212e-05  3.43582651e-05 -2.25889139e-05 -2.66529871e-05\n",
+      " -2.97324110e-05 -3.39957496e-05 -2.99012022e-05 -1.79113204e-05\n",
+      "  2.05242728e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 2.44205803e-05  1.58113188e-05  1.80584157e-05  1.56018482e-05\n",
+      "  1.62272236e-05  1.94618338e-05  1.82599664e-05  2.47580703e-05\n",
+      "  3.84908337e-05 -4.61530796e-05 -4.14328217e-05 -3.43323136e-05\n",
+      " -3.28587416e-05 -2.65015717e-05 -1.57957093e-05 -1.44351741e-05\n",
+      " -1.46136172e-05 -7.88730742e-06  0.00000000e+00  0.00000000e+00\n",
+      "  4.29941188e-06  9.12500431e-06  1.42923488e-05  1.92110086e-05\n",
+      " -2.17020697e-05 -1.68495936e-05 -2.01066770e-05 -1.52866461e-05\n",
+      " -8.79487172e-06 -7.49878109e-06 -9.46514873e-06 -1.03714183e-05\n",
+      " -1.15225734e-05  4.23237309e-05  4.73237395e-05  2.72378059e-05\n",
+      "  3.15322463e-05  3.52270242e-05  3.27377100e-05  3.53062382e-05\n",
+      "  3.24073788e-05  3.07956891e-05 -1.98305210e-05 -2.39930598e-05\n",
+      " -2.61931051e-05 -3.01969366e-05 -2.64918661e-05 -1.58989420e-05\n",
+      "  1.77696132e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 54%|█████▎    | 22/41 [00:42<00:40,  2.14s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 7.48597607e-06  4.91482200e-06  5.73459835e-06  4.57909315e-06\n",
+      "  0.00000000e+00  5.98035655e-06  9.29539026e-06  1.49795756e-05\n",
+      "  2.64510104e-05  2.82415183e-05  3.35445888e-05  3.69634153e-05\n",
+      "  4.44172447e-05 -4.50094525e-05 -2.88277253e-05 -2.78482827e-05\n",
+      " -3.32918157e-05 -2.12880559e-05 -1.99343303e-05 -1.38588116e-05\n",
+      " -9.42185499e-06  0.00000000e+00  0.00000000e+00  5.88841847e-06\n",
+      " -2.40062451e-05 -1.91134512e-05 -2.22944217e-05 -1.69705078e-05\n",
+      " -1.00967318e-05 -8.05978676e-06 -1.03101918e-05 -1.17391985e-05\n",
+      " -1.34879697e-05 -1.41654597e-05 -2.20513161e-05 -1.57620076e-05\n",
+      " -2.23181045e-05  3.94302480e-05  3.75586806e-05  4.01747834e-05\n",
+      "  3.62050413e-05  3.43711117e-05  2.47868294e-05  2.80954696e-05\n",
+      "  3.14978153e-05  3.45150147e-05 -2.94983081e-05 -1.80979357e-05\n",
+      "  2.03466161e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 6.67879302e-06  4.49658204e-06  5.14572290e-06  0.00000000e+00\n",
+      "  0.00000000e+00  5.19477996e-06  8.28047289e-06  1.32112771e-05\n",
+      "  2.31502286e-05  2.50421301e-05  2.97157603e-05  3.24905575e-05\n",
+      "  3.91580775e-05 -3.94316032e-05 -2.52288166e-05 -2.46647486e-05\n",
+      " -2.92989784e-05 -1.88184750e-05 -1.75271236e-05 -1.19074896e-05\n",
+      " -8.51898664e-06  0.00000000e+00  0.00000000e+00  5.10967101e-06\n",
+      " -2.12187839e-05 -1.67124739e-05 -1.95006684e-05 -1.52202068e-05\n",
+      " -8.90618862e-06 -7.13914901e-06 -8.70775354e-06 -1.02235396e-05\n",
+      " -1.18454667e-05 -1.25406141e-05 -1.90822341e-05 -1.38286867e-05\n",
+      " -2.02507743e-05  3.51085511e-05  3.34390830e-05  3.52982207e-05\n",
+      "  3.21574965e-05  3.07286433e-05  2.17748497e-05  2.51677432e-05\n",
+      "  2.83640213e-05  3.04816063e-05 -2.58004509e-05 -1.61511528e-05\n",
+      "  1.81480315e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 56%|█████▌    | 23/41 [00:44<00:37,  2.07s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.29038708e-05 -8.38434680e-06 -9.54540388e-06 -8.19493472e-06\n",
+      " -8.62693034e-06 -9.97607178e-06 -2.84041255e-06  0.00000000e+00\n",
+      "  8.93420000e-06  1.24891891e-05  1.77175454e-05  2.19859606e-05\n",
+      "  2.83918586e-05  3.04862600e-05  2.57479152e-05  3.29064632e-05\n",
+      "  5.12464110e-05 -3.44763160e-05 -3.53530068e-05 -2.78557886e-05\n",
+      " -2.29580246e-05 -1.90195302e-05 -1.57908292e-05 -1.02243509e-05\n",
+      "  3.03244577e-05  2.96349862e-05 -2.27100404e-05 -1.68937882e-05\n",
+      " -9.86524628e-06 -8.22783028e-06 -1.08311489e-05 -1.22361797e-05\n",
+      " -1.33027796e-05 -1.42865587e-05 -2.21447997e-05 -1.60587766e-05\n",
+      " -2.27999135e-05 -3.10735527e-05 -3.67655595e-05 -3.83432850e-05\n",
+      " -3.49176341e-05  3.48452417e-05  2.48568108e-05  2.89325785e-05\n",
+      "  3.20649207e-05  3.46673032e-05  2.97233972e-05  1.76788003e-05\n",
+      "  0.00000000e+00]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.13215667e-05 -7.45587508e-06 -8.40743784e-06 -7.17674019e-06\n",
+      " -7.66198208e-06 -8.80290602e-06 -2.46336812e-06  0.00000000e+00\n",
+      "  7.80030922e-06  1.09794454e-05  1.56695006e-05  1.93335916e-05\n",
+      "  2.49829596e-05  2.69219786e-05  2.26312502e-05  2.90325037e-05\n",
+      "  4.51058985e-05 -3.03006954e-05 -3.14160757e-05 -2.42452550e-05\n",
+      " -2.03901619e-05 -1.69654320e-05 -1.36973344e-05 -8.94458038e-06\n",
+      "  2.68701058e-05  2.62846030e-05 -1.99219043e-05 -1.53095982e-05\n",
+      " -8.78363211e-06 -7.43821782e-06 -9.28585798e-06 -1.06307497e-05\n",
+      " -1.16623068e-05 -1.27048252e-05 -1.92328854e-05 -1.43658850e-05\n",
+      " -2.05300035e-05 -2.76574672e-05 -3.25565302e-05 -3.37486726e-05\n",
+      " -3.07873625e-05  3.12279867e-05  2.16716418e-05  2.56058399e-05\n",
+      "  2.82179332e-05  3.06415754e-05  2.61673274e-05  1.58458763e-05\n",
+      "  0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 59%|█████▊    | 24/41 [00:46<00:33,  1.97s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.82012728e-05 -1.13909411e-05 -1.36184848e-05 -1.14740035e-05\n",
+      " -1.19341474e-05 -1.42197048e-05 -5.78577764e-06  0.00000000e+00\n",
+      "  0.00000000e+00  8.21684484e-06  1.34144415e-05  1.77044244e-05\n",
+      "  2.43292748e-05  2.61395390e-05  2.23433160e-05  3.01276736e-05\n",
+      "  4.72442953e-05  3.96447583e-05 -3.94262036e-05 -3.12457990e-05\n",
+      " -2.65623623e-05 -2.25877563e-05 -1.97397092e-05 -1.47617426e-05\n",
+      "  3.04390690e-05  2.95354655e-05  4.32341258e-05 -1.67832036e-05\n",
+      " -1.02296426e-05 -8.45343572e-06 -1.10590335e-05 -1.17633180e-05\n",
+      " -1.32141686e-05 -1.44479953e-05 -2.22393988e-05 -1.66518473e-05\n",
+      " -2.25264886e-05 -3.12453023e-05 -3.68464264e-05 -3.83887688e-05\n",
+      " -3.52347246e-05 -3.12609661e-05  2.48540519e-05  2.86049571e-05\n",
+      "  3.17675613e-05  3.43696415e-05  2.94475177e-05  1.78428495e-05\n",
+      "  0.00000000e+00]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-1.59737479e-05 -1.01351182e-05 -1.20007949e-05 -1.00518290e-05\n",
+      " -1.06026003e-05 -1.25512351e-05 -5.01946521e-06  0.00000000e+00\n",
+      "  0.00000000e+00  7.22165886e-06  1.18662560e-05  1.55685507e-05\n",
+      "  2.14077129e-05  2.30828056e-05  1.96411664e-05  2.65749311e-05\n",
+      "  4.15893260e-05  3.48481819e-05 -3.50403782e-05 -2.72010515e-05\n",
+      " -2.35969963e-05 -2.01521097e-05 -1.71269219e-05 -1.29238333e-05\n",
+      "  2.69721630e-05  2.61969009e-05  3.79347462e-05 -1.52162873e-05\n",
+      " -9.10538191e-06 -7.63756368e-06 -9.48787827e-06 -1.02181318e-05\n",
+      " -1.15859873e-05 -1.28493494e-05 -1.93186558e-05 -1.48925780e-05\n",
+      " -2.02945985e-05 -2.78120931e-05 -3.26337381e-05 -3.37934213e-05\n",
+      " -3.10724297e-05 -2.80137570e-05  2.16687881e-05  2.53245356e-05\n",
+      "  2.79579267e-05  3.03814819e-05  2.59233607e-05  1.59871111e-05\n",
+      "  0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 61%|██████    | 25/41 [00:48<00:31,  1.95s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  6.75487063e-06  1.22162116e-05\n",
+      "  2.20245202e-05  2.48789078e-05  3.00067306e-05  3.30731959e-05\n",
+      "  4.02916128e-05  4.14298701e-05 -3.09817424e-05 -3.08759882e-05\n",
+      " -3.74110688e-05 -2.42622271e-05 -2.35649929e-05 -1.73874732e-05\n",
+      " -1.21449390e-05 -7.71299250e-06  0.00000000e+00  0.00000000e+00\n",
+      " -2.39365940e-05 -1.87188112e-05 -2.22666833e-05 -1.66816717e-05\n",
+      " -9.48329928e-06 -8.11651873e-06 -1.03997206e-05 -1.18764653e-05\n",
+      " -1.29355674e-05 -1.40623890e-05 -2.15151275e-05 -1.56367469e-05\n",
+      " -2.23926381e-05 -3.04637071e-05  3.73162267e-05  3.99747586e-05\n",
+      "  3.69533018e-05  3.43491827e-05  2.48850064e-05  2.84640154e-05\n",
+      "  3.18676496e-05  3.46411320e-05  2.97193320e-05 -1.78437423e-05\n",
+      "  2.02934914e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  5.86569692e-06  1.07743909e-05\n",
+      "  1.92317313e-05  2.18707942e-05  2.65323571e-05  2.90845119e-05\n",
+      "  3.54505422e-05  3.65880722e-05 -2.72345787e-05 -2.72359227e-05\n",
+      " -3.29240053e-05 -2.13228694e-05 -2.09424108e-05 -1.51340471e-05\n",
+      " -1.07866519e-05 -6.87965150e-06  0.00000000e+00  0.00000000e+00\n",
+      " -2.12137739e-05 -1.65990977e-05 -1.95346026e-05 -1.51179663e-05\n",
+      " -8.44264654e-06 -7.33609685e-06 -8.90559198e-06 -1.03160964e-05\n",
+      " -1.13377078e-05 -1.25072400e-05 -1.86804167e-05 -1.39897523e-05\n",
+      " -2.01670726e-05 -2.71142113e-05  3.30482176e-05  3.51841784e-05\n",
+      "  3.25812406e-05  3.07878890e-05  2.16975743e-05  2.51964496e-05\n",
+      "  2.80459701e-05  3.06211968e-05  2.61569223e-05 -1.59850954e-05\n",
+      "  1.79862179e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 63%|██████▎   | 26/41 [00:50<00:28,  1.90s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-2.29639658e-05 -1.48791000e-05 -1.68425634e-05 -1.51331323e-05\n",
+      " -1.53213094e-05 -1.80583761e-05 -8.73198989e-06 -5.25465371e-06\n",
+      "  0.00000000e+00  0.00000000e+00  9.89468525e-06  1.42642205e-05\n",
+      "  2.00803745e-05  2.28637111e-05  1.99846042e-05  2.67149227e-05\n",
+      "  4.28901187e-05  3.61879517e-05  4.67923498e-05 -3.43162733e-05\n",
+      " -2.98485204e-05 -2.60194559e-05 -2.39685412e-05 -1.85872550e-05\n",
+      "  3.03122916e-05  2.97228381e-05  4.37542629e-05  4.12624211e-05\n",
+      " -9.70854147e-06 -8.54378673e-06 -1.08158216e-05 -1.21403387e-05\n",
+      " -1.32804554e-05 -1.43982635e-05 -2.20509852e-05 -1.59507904e-05\n",
+      " -2.27948491e-05 -3.10723754e-05 -3.67778675e-05 -3.82765027e-05\n",
+      " -3.46193224e-05 -3.06423017e-05 -2.26438257e-05  2.87469304e-05\n",
+      "  3.17546751e-05  3.43860925e-05  2.99294625e-05  1.77722059e-05\n",
+      "  2.07126653e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-2.01453081e-05 -1.32332894e-05 -1.48406315e-05 -1.32560442e-05\n",
+      " -1.36076891e-05 -1.59380271e-05 -7.57115839e-06 -4.63400093e-06\n",
+      "  0.00000000e+00  0.00000000e+00  8.74665366e-06  1.25409068e-05\n",
+      "  1.76627715e-05  2.01857093e-05  1.75617482e-05  2.35642840e-05\n",
+      "  3.77465471e-05  3.17997908e-05  4.15772333e-05 -2.98586462e-05\n",
+      " -2.65084877e-05 -2.32085079e-05 -2.07940599e-05 -1.62692517e-05\n",
+      "  2.68560654e-05  2.63551382e-05  3.83832222e-05  3.73899406e-05\n",
+      " -8.64442366e-06 -7.71452396e-06 -9.27023476e-06 -1.05465070e-05\n",
+      " -1.16381862e-05 -1.28010357e-05 -1.91457477e-05 -1.42702779e-05\n",
+      " -2.05229369e-05 -2.76511851e-05 -3.25649222e-05 -3.36833196e-05\n",
+      " -3.05203596e-05 -2.74598526e-05 -1.97404044e-05  2.54389423e-05\n",
+      "  2.79420665e-05  3.03873314e-05  2.63410782e-05  1.59214711e-05\n",
+      "  1.83465072e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 66%|██████▌   | 27/41 [00:51<00:25,  1.83s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-3.89397879e-05 -2.51054397e-05 -2.90739739e-05 -2.52389094e-05\n",
+      " -2.58687076e-05 -3.03453940e-05 -1.82012094e-05 -1.56247858e-05\n",
+      " -1.38118491e-05 -8.03625164e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.83291938e-06  1.16017694e-05  1.20330805e-05  1.74838706e-05\n",
+      "  3.01137138e-05  2.65649849e-05  3.59387125e-05  3.82354669e-05\n",
+      "  4.33384169e-05  5.13016301e-05 -3.64823278e-05 -3.10683437e-05\n",
+      "  3.04360182e-05  3.02595684e-05  4.40089936e-05  4.16402713e-05\n",
+      "  3.35164602e-05  4.00659782e-05  5.11480576e-05 -1.24743270e-05\n",
+      " -1.35671813e-05 -1.46313648e-05 -2.21865948e-05 -1.62257592e-05\n",
+      " -2.27581170e-05 -3.14437603e-05 -3.70637053e-05 -3.86095265e-05\n",
+      " -3.55088502e-05 -3.10174594e-05 -2.30552851e-05 -2.71725010e-05\n",
+      " -3.01238969e-05 -3.47538126e-05  3.00030771e-05  1.79488266e-05\n",
+      " -2.99984129e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-3.41578149e-05 -2.23245378e-05 -2.56170256e-05 -2.21104604e-05\n",
+      " -2.29721197e-05 -2.67828084e-05 -1.57818004e-05 -1.37752619e-05\n",
+      " -1.20548770e-05 -7.06130727e-06  0.00000000e+00  0.00000000e+00\n",
+      "  6.88923718e-06  1.02435277e-05  1.05743497e-05  1.54216483e-05\n",
+      "  2.65013340e-05  2.33451976e-05  3.19306997e-05  3.32715815e-05\n",
+      "  3.84859298e-05  4.57468735e-05 -3.16510625e-05 -2.71952132e-05\n",
+      "  2.69631214e-05  2.68308766e-05  3.86066146e-05  3.77310490e-05\n",
+      "  2.98383285e-05  3.62099636e-05  4.38378597e-05 -1.08390926e-05\n",
+      " -1.18900714e-05 -1.30070874e-05 -1.92625624e-05 -1.45109781e-05\n",
+      " -2.04964793e-05 -2.79775773e-05 -3.28172520e-05 -3.39719535e-05\n",
+      " -3.13007017e-05 -2.77926128e-05 -2.00955587e-05 -2.40479703e-05\n",
+      " -2.65048116e-05 -3.07134949e-05  2.64035783e-05  1.60772349e-05\n",
+      " -2.65705105e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 68%|██████▊   | 28/41 [00:53<00:23,  1.81s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-3.92282427e-05 -2.51073822e-05 -2.90261157e-05 -2.52367148e-05\n",
+      " -2.60188489e-05 -3.02926411e-05 -1.81774589e-05 -1.54131064e-05\n",
+      " -1.37941770e-05 -8.26482951e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.75154445e-06  1.15813855e-05  1.20586697e-05  1.75088604e-05\n",
+      "  3.01106685e-05  2.65589561e-05  3.56869118e-05  3.82897202e-05\n",
+      "  4.33080145e-05  5.11556321e-05 -3.67177569e-05 -3.08873103e-05\n",
+      "  3.05685936e-05  2.97858186e-05  4.39171632e-05  4.15553301e-05\n",
+      "  3.34557277e-05  3.99700905e-05  5.12838959e-05 -1.20429816e-05\n",
+      " -1.31750368e-05 -1.45191887e-05 -2.21790192e-05 -1.61710754e-05\n",
+      " -2.28450471e-05 -3.14057323e-05 -3.70529210e-05 -3.84794594e-05\n",
+      " -3.54469473e-05 -3.08165839e-05 -2.29900489e-05 -2.67367821e-05\n",
+      " -3.04741821e-05 -3.45674315e-05  2.98034714e-05  1.78625904e-05\n",
+      " -3.00617416e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-3.44128998e-05 -2.23252065e-05 -2.55735219e-05 -2.21084739e-05\n",
+      " -2.31039965e-05 -2.67359194e-05 -1.57608893e-05 -1.35902963e-05\n",
+      " -1.20385806e-05 -7.26338068e-06  0.00000000e+00  0.00000000e+00\n",
+      "  6.81811949e-06  1.02257545e-05  1.05983890e-05  1.54432304e-05\n",
+      "  2.65000777e-05  2.33396660e-05  3.17105022e-05  3.33201063e-05\n",
+      "  3.84584547e-05  4.56152339e-05 -3.18587904e-05 -2.70334178e-05\n",
+      "  2.70814682e-05  2.64129465e-05  3.85262107e-05  3.76541997e-05\n",
+      "  2.97879918e-05  3.61254171e-05  4.39557148e-05 -1.04577316e-05\n",
+      " -1.15436680e-05 -1.29091710e-05 -1.92553454e-05 -1.44627769e-05\n",
+      " -2.05751488e-05 -2.79450443e-05 -3.28077457e-05 -3.38579495e-05\n",
+      " -3.12461930e-05 -2.76159385e-05 -2.00372932e-05 -2.36643442e-05\n",
+      " -2.68140072e-05 -3.05483968e-05  2.62266202e-05  1.60001860e-05\n",
+      " -2.66281601e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 71%|███████   | 29/41 [00:55<00:21,  1.81s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.28542084e-05 -8.45355809e-06 -9.58068911e-06 -8.34426206e-06\n",
+      " -8.57284032e-06 -1.00246024e-05  0.00000000e+00  0.00000000e+00\n",
+      "  8.80057125e-06  1.22783970e-05  1.76232808e-05  2.19346091e-05\n",
+      "  2.81893846e-05  3.02375431e-05  2.56185800e-05  3.25746585e-05\n",
+      "  5.10589222e-05 -3.44554220e-05 -3.54378031e-05 -2.77847272e-05\n",
+      " -2.33008251e-05 -1.88873491e-05 -1.59844223e-05 -1.02794919e-05\n",
+      "  3.00863890e-05  2.92410135e-05 -2.31926888e-05 -1.70060811e-05\n",
+      " -9.95995615e-06 -8.12837164e-06 -1.07345064e-05 -1.22077516e-05\n",
+      " -1.32918553e-05 -1.42839071e-05 -2.20739128e-05 -1.61269887e-05\n",
+      " -2.25119672e-05 -3.11797419e-05 -3.69181597e-05 -3.82069330e-05\n",
+      " -3.48358369e-05  3.47167772e-05  2.46689508e-05  2.83700541e-05\n",
+      "  3.17372701e-05  3.44805000e-05  2.95950527e-05  1.78227380e-05\n",
+      "  2.06850427e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.12816045e-05 -7.51642176e-06 -8.44023825e-06 -7.30884508e-06\n",
+      " -7.61699167e-06 -8.84520122e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.68278768e-06  1.07935597e-05  1.55863137e-05  1.92849616e-05\n",
+      "  2.48063918e-05  2.67012040e-05  2.25150130e-05  2.87408240e-05\n",
+      "  4.49402542e-05 -3.02811413e-05 -3.14914665e-05 -2.41815668e-05\n",
+      " -2.06929841e-05 -1.68500065e-05 -1.38652837e-05 -8.99496215e-06\n",
+      "  2.66621005e-05  2.59425415e-05 -2.03448161e-05 -1.54062905e-05\n",
+      " -8.86626870e-06 -7.34980121e-06 -9.19956233e-06 -1.06070827e-05\n",
+      " -1.16508802e-05 -1.27017961e-05 -1.91712857e-05 -1.44253659e-05\n",
+      " -2.02721078e-05 -2.77503772e-05 -3.26901269e-05 -3.36300667e-05\n",
+      " -3.07195174e-05  3.11108881e-05  2.15096395e-05  2.51103670e-05\n",
+      "  2.79291905e-05  3.04743126e-05  2.60568025e-05  1.59734862e-05\n",
+      "  1.83245535e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 73%|███████▎  | 30/41 [00:56<00:19,  1.76s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.84861917e-05 -1.13588938e-05 -1.34231455e-05 -1.16005426e-05\n",
+      " -1.23323692e-05 -1.41096008e-05 -6.26881334e-06  0.00000000e+00\n",
+      "  0.00000000e+00  8.40196665e-06  1.36332545e-05  1.79913071e-05\n",
+      "  2.42939857e-05  2.63247047e-05  2.26466555e-05  2.97377358e-05\n",
+      "  4.68483948e-05  3.89540848e-05 -3.94517742e-05 -3.10762562e-05\n",
+      " -2.62378378e-05 -2.29099153e-05 -1.98873796e-05 -1.43527046e-05\n",
+      "  3.04044470e-05  2.97157181e-05  4.35128589e-05 -1.70644438e-05\n",
+      " -9.77101275e-06 -8.65122823e-06 -1.07443662e-05 -1.19284026e-05\n",
+      " -1.29965883e-05 -1.46875276e-05 -2.20147486e-05 -1.63353191e-05\n",
+      " -2.29811920e-05 -3.12856918e-05 -3.70081570e-05 -3.83082365e-05\n",
+      " -3.50140423e-05 -3.10062071e-05  2.45072125e-05  2.87119684e-05\n",
+      "  3.15680619e-05  3.45139820e-05  2.95542946e-05  1.79391370e-05\n",
+      "  0.00000000e+00]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.62230021e-05 -1.01088160e-05 -1.18299263e-05 -1.01650232e-05\n",
+      " -1.09546496e-05 -1.24555124e-05 -5.44384295e-06  0.00000000e+00\n",
+      "  0.00000000e+00  7.38509691e-06  1.20591335e-05  1.58227161e-05\n",
+      "  2.13761181e-05  2.32519419e-05  1.99070911e-05  2.62332119e-05\n",
+      "  4.12388235e-05  3.42405672e-05 -3.50611035e-05 -2.70491527e-05\n",
+      " -2.33110843e-05 -2.04374265e-05 -1.72567816e-05 -1.25655799e-05\n",
+      "  2.69418488e-05  2.63564951e-05  3.81810936e-05 -1.54633858e-05\n",
+      " -8.70542389e-06 -7.81076300e-06 -9.20862560e-06 -1.03617295e-05\n",
+      " -1.13926578e-05 -1.30609585e-05 -1.91236379e-05 -1.46162955e-05\n",
+      " -2.06944746e-05 -2.78473777e-05 -3.27780021e-05 -3.37218365e-05\n",
+      " -3.08755554e-05 -2.77891282e-05  2.13607034e-05  2.54155992e-05\n",
+      "  2.77812127e-05  3.05088885e-05  2.60161068e-05  1.60747752e-05\n",
+      "  0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 76%|███████▌  | 31/41 [00:58<00:17,  1.78s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.83375697e-05  1.79675760e-05  2.05922408e-05  1.81827264e-05\n",
+      "  1.86855619e-05  2.21962456e-05  2.13947128e-05  2.81607058e-05\n",
+      "  4.45278253e-05 -5.25676578e-05 -4.67135063e-05 -3.88930702e-05\n",
+      " -3.72370845e-05 -3.00671254e-05 -1.76532648e-05 -1.59513349e-05\n",
+      " -1.62646008e-05 -8.72935077e-06 -5.22261332e-06  0.00000000e+00\n",
+      "  0.00000000e+00  1.03933469e-05  1.66828588e-05  2.22673339e-05\n",
+      " -2.44445007e-05 -1.89018195e-05 -2.26402871e-05 -1.64999993e-05\n",
+      " -1.00575535e-05 -7.93918642e-06 -1.05904653e-05 -1.20577521e-05\n",
+      " -1.28665268e-05  4.79282897e-05  5.47894310e-05  3.07137934e-05\n",
+      "  3.51016767e-05  3.93620470e-05  3.73697491e-05  4.02975476e-05\n",
+      "  3.67687370e-05  3.41260136e-05 -2.21653121e-05 -2.62687334e-05\n",
+      " -2.93613241e-05 -3.37671059e-05 -3.00330923e-05 -1.77763204e-05\n",
+      "  2.03187651e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.49863713e-05  1.61248968e-05  1.78304040e-05  1.59448603e-05\n",
+      "  1.63117165e-05  1.95942089e-05  1.81344503e-05  2.47033307e-05\n",
+      "  3.89925475e-05 -4.64381445e-05 -4.13389087e-05 -3.44139361e-05\n",
+      " -3.30068359e-05 -2.65091042e-05 -1.57013479e-05 -1.44175441e-05\n",
+      " -1.44967807e-05 -7.75687420e-06  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  8.91442710e-06  1.44871348e-05  1.94461544e-05\n",
+      " -2.16569767e-05 -1.71219245e-05 -1.99728251e-05 -1.48051300e-05\n",
+      " -8.90214815e-06 -7.24943365e-06 -9.23982270e-06 -1.05155780e-05\n",
+      " -1.14557702e-05  4.27426041e-05  4.74333464e-05  2.74918769e-05\n",
+      "  3.15742055e-05  3.48955381e-05  3.30663612e-05  3.50632077e-05\n",
+      "  3.22394831e-05  3.00796066e-05 -1.92860824e-05 -2.31801138e-05\n",
+      " -2.57009774e-05 -2.98791990e-05 -2.66083090e-05 -1.59183209e-05\n",
+      "  1.79818495e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 78%|███████▊  | 32/41 [01:00<00:16,  1.84s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-4.45967404e-05 -2.83946798e-05 -3.28383381e-05 -2.86832093e-05\n",
+      " -2.97701673e-05 -3.47368486e-05 -2.15221681e-05 -1.92749494e-05\n",
+      " -1.83378546e-05 -1.22105049e-05 -6.68496643e-06  0.00000000e+00\n",
+      "  0.00000000e+00  7.83260191e-06  9.53942028e-06  1.47153265e-05\n",
+      "  2.60289103e-05  2.36910524e-05  3.23383546e-05  3.51398118e-05\n",
+      "  4.01249919e-05  4.80820895e-05  5.82599055e-05 -3.55416583e-05\n",
+      "  3.07766047e-05  3.00155087e-05  4.44847029e-05  4.20510549e-05\n",
+      "  3.39733089e-05  4.02690763e-05  5.17063679e-05  5.70710432e-05\n",
+      " -1.34392303e-05 -1.45413934e-05 -2.24399519e-05 -1.62543877e-05\n",
+      " -2.28313609e-05 -3.14403395e-05 -3.75153078e-05 -3.90758244e-05\n",
+      " -3.55458577e-05 -3.11729524e-05 -2.27760204e-05 -2.74267093e-05\n",
+      " -3.04475404e-05 -3.47652938e-05 -3.05807552e-05  1.79535602e-05\n",
+      " -1.39822902e-04]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [-3.91334428e-05 -2.52595897e-05 -2.89399660e-05 -2.51345757e-05\n",
+      " -2.64426416e-05 -3.06669399e-05 -1.86693193e-05 -1.70014022e-05\n",
+      " -1.60081658e-05 -1.07340867e-05 -5.91127755e-06  0.00000000e+00\n",
+      "  0.00000000e+00  6.91606229e-06  8.38644380e-06  1.29819241e-05\n",
+      "  2.29131484e-05  2.08242451e-05  2.87405690e-05  3.05873516e-05\n",
+      "  3.56402108e-05  4.28850639e-05  5.05545224e-05 -3.11191623e-05\n",
+      "  2.72725310e-05  2.66235892e-05  3.90335647e-05  3.81099257e-05\n",
+      "  3.02521511e-05  3.64040499e-05  4.43293732e-05  4.95860196e-05\n",
+      " -1.17794290e-05 -1.29309679e-05 -1.94891954e-05 -1.45415017e-05\n",
+      " -2.05715563e-05 -2.79852962e-05 -3.32253228e-05 -3.43904117e-05\n",
+      " -3.13424003e-05 -2.79408144e-05 -1.98530060e-05 -2.42786291e-05\n",
+      " -2.67976222e-05 -3.07325168e-05 -2.69168054e-05  1.60867866e-05\n",
+      " -1.23880523e-04]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 80%|████████  | 33/41 [01:02<00:15,  1.88s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  7.72906821e-06\n",
+      "  1.75442819e-05  2.04812077e-05  2.53387888e-05  2.91636215e-05\n",
+      "  3.62262685e-05  3.78755669e-05  3.05876504e-05 -3.46514629e-05\n",
+      " -4.21485433e-05 -2.82243133e-05 -2.83479133e-05 -2.08405242e-05\n",
+      " -1.67258466e-05 -1.21080084e-05 -7.85326523e-06  0.00000000e+00\n",
+      " -2.44776759e-05 -1.88934760e-05 -2.28732463e-05 -1.69656171e-05\n",
+      " -1.02948792e-05 -8.23680037e-06 -1.09379901e-05 -1.24019619e-05\n",
+      " -1.31214731e-05 -1.48524646e-05 -2.19687763e-05 -1.65557740e-05\n",
+      " -2.32842266e-05 -3.13123979e-05 -3.67577006e-05  3.99706308e-05\n",
+      "  3.64843608e-05  3.43418247e-05  2.40986110e-05  2.82180373e-05\n",
+      "  3.14916135e-05  3.43010094e-05  2.90278083e-05  1.73354342e-05\n",
+      "  1.39593543e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 0.00000000e+00  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  0.00000000e+00  6.81814466e-06\n",
+      "  1.53132732e-05  1.79989660e-05  2.24050920e-05  2.56465708e-05\n",
+      "  3.18695057e-05  3.34429344e-05  2.68845969e-05 -3.05702046e-05\n",
+      " -3.71050098e-05 -2.48070717e-05 -2.51893331e-05 -1.81432419e-05\n",
+      " -1.48502324e-05 -1.07950801e-05 -6.81815041e-06  0.00000000e+00\n",
+      " -2.16933355e-05 -1.67584430e-05 -2.00718588e-05 -1.53728146e-05\n",
+      " -9.16474820e-06 -7.44451569e-06 -9.38445883e-06 -1.07810855e-05\n",
+      " -1.15037821e-05 -1.32034803e-05 -1.90789942e-05 -1.48063812e-05\n",
+      " -2.09573272e-05 -2.78671002e-05 -3.25540757e-05  3.51734735e-05\n",
+      "  3.21658603e-05  3.07779866e-05  2.10026004e-05  2.49765092e-05\n",
+      "  2.77111309e-05  3.03160468e-05  2.55511625e-05  1.55346189e-05\n",
+      "  1.23664274e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 83%|████████▎ | 34/41 [01:04<00:13,  1.97s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-4.46210485e-05 -2.89022544e-05 -3.28575414e-05 -2.87356411e-05\n",
+      " -2.97308052e-05 -3.46573870e-05 -2.14514967e-05 -1.92412511e-05\n",
+      " -1.83287523e-05 -1.21823693e-05 -6.70524938e-06  0.00000000e+00\n",
+      "  0.00000000e+00  7.67757987e-06  9.59078932e-06  1.46630525e-05\n",
+      "  2.64077515e-05  2.36463833e-05  3.23288272e-05  3.53929288e-05\n",
+      "  4.01322316e-05  4.79138047e-05  5.84391115e-05 -3.53173902e-05\n",
+      "  3.09475370e-05  3.02390417e-05  4.43170001e-05  4.22354729e-05\n",
+      "  3.39721548e-05  4.01413009e-05  5.15466762e-05  5.70253306e-05\n",
+      " -1.34601105e-05 -1.44702733e-05 -2.25130158e-05 -1.61418707e-05\n",
+      " -2.29311982e-05 -3.15546418e-05 -3.73162297e-05 -3.90241561e-05\n",
+      " -3.56867934e-05 -3.08432267e-05 -2.31589159e-05 -2.72254177e-05\n",
+      " -3.06262066e-05 -3.47912681e-05 -3.06398698e-05  1.76533522e-05\n",
+      " -1.39770166e-04]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-3.90342138e-05 -2.57050971e-05 -2.90186902e-05 -2.49804244e-05\n",
+      " -2.62058528e-05 -3.05092444e-05 -1.79172316e-05 -1.66890931e-05\n",
+      " -1.56692448e-05 -1.06847812e-05 -6.06336710e-06  0.00000000e+00\n",
+      "  0.00000000e+00  0.00000000e+00  8.39244402e-06  1.31809611e-05\n",
+      "  2.32882311e-05  2.05817756e-05  2.88225899e-05  3.08989561e-05\n",
+      "  3.59329284e-05  4.29067739e-05  5.10529548e-05 -3.10781225e-05\n",
+      "  2.74273729e-05  2.68159919e-05  3.95513597e-05  3.81347473e-05\n",
+      "  3.01438964e-05  3.66596395e-05  4.43720006e-05  4.95078096e-05\n",
+      " -1.16849942e-05 -1.26428401e-05 -1.94392192e-05 -1.40172359e-05\n",
+      " -2.03806604e-05 -2.79745263e-05 -3.26265880e-05 -3.40219661e-05\n",
+      " -3.12247910e-05 -2.75206921e-05 -2.00656386e-05 -2.42291338e-05\n",
+      " -2.66528052e-05 -3.05284631e-05 -2.70181778e-05  1.55914466e-05\n",
+      " -1.23227820e-04]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 85%|████████▌ | 35/41 [01:07<00:12,  2.08s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.29370075e-05 -8.19109082e-06 -9.49901001e-06 -8.29663588e-06\n",
+      " -8.64924072e-06 -9.95096945e-06  0.00000000e+00  0.00000000e+00\n",
+      "  8.87628547e-06  1.22912490e-05  1.76024550e-05  2.18893098e-05\n",
+      "  2.83917585e-05  3.03981631e-05  2.54300683e-05  3.25161260e-05\n",
+      "  5.10339393e-05 -3.47201820e-05 -3.52845980e-05 -2.76336407e-05\n",
+      " -2.32098501e-05 -1.89371406e-05 -1.58226444e-05 -1.01200209e-05\n",
+      "  3.03409092e-05  2.95375597e-05 -2.27617035e-05 -1.69929317e-05\n",
+      " -1.00858998e-05 -8.40344925e-06 -1.07446778e-05 -1.22828143e-05\n",
+      " -1.33855254e-05 -1.44149407e-05 -2.23524825e-05 -1.60716271e-05\n",
+      " -2.27529028e-05 -3.12444495e-05 -3.65978091e-05 -3.83394858e-05\n",
+      " -3.50088741e-05  3.47467793e-05  2.49850250e-05  2.88825953e-05\n",
+      "  3.19856699e-05  3.45960725e-05  2.96154908e-05  1.75995376e-05\n",
+      "  0.00000000e+00]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-1.13509979e-05 -7.28703853e-06 -8.36850030e-06 -7.26404791e-06\n",
+      " -7.67864445e-06 -8.77865837e-06  0.00000000e+00  0.00000000e+00\n",
+      "  7.74990045e-06  1.08071021e-05  1.55668777e-05  1.92501657e-05\n",
+      "  2.49837062e-05  2.68411984e-05  2.23542382e-05  2.86897628e-05\n",
+      "  4.49190971e-05 -3.05135178e-05 -3.13554435e-05 -2.40493007e-05\n",
+      " -2.06094085e-05 -1.68908363e-05 -1.37242322e-05 -8.85559853e-06\n",
+      "  2.68890242e-05  2.62005389e-05 -1.99690341e-05 -1.53956448e-05\n",
+      " -8.97258319e-06 -7.59165043e-06 -9.20810697e-06 -1.06699411e-05\n",
+      " -1.17340233e-05 -1.28175303e-05 -1.94136327e-05 -1.43762917e-05\n",
+      " -2.04854605e-05 -2.78061552e-05 -3.24103090e-05 -3.37458017e-05\n",
+      " -3.08677468e-05  3.11362075e-05  2.17849878e-05  2.55627142e-05\n",
+      "  2.81498911e-05  3.05782544e-05  2.60739174e-05  1.57775703e-05\n",
+      "  0.00000000e+00]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 88%|████████▊ | 36/41 [01:09<00:10,  2.12s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.77305615e-05  1.14043506e-05  1.31299690e-05  1.17054713e-05\n",
+      "  1.20076341e-05  1.39457675e-05  1.52651524e-05  2.13635575e-05\n",
+      "  3.57245755e-05  3.67957561e-05  4.14879297e-05 -4.66176230e-05\n",
+      " -4.57943171e-05 -3.76072887e-05 -2.33344222e-05 -2.22282536e-05\n",
+      " -2.49515280e-05 -1.50556424e-05 -1.29669354e-05 -6.97479460e-06\n",
+      "  0.00000000e+00  0.00000000e+00  8.50414008e-06  1.41165615e-05\n",
+      " -2.42533995e-05 -1.89064193e-05 -2.24807521e-05 -1.70035154e-05\n",
+      " -9.91543039e-06 -8.26663275e-06 -1.06169275e-05 -1.21186606e-05\n",
+      " -1.30747132e-05 -1.42201968e-05 -2.18450579e-05  3.05852651e-05\n",
+      "  3.51744944e-05  3.96659342e-05  3.72470006e-05  4.01159776e-05\n",
+      "  3.67686015e-05  3.45227306e-05  2.46569965e-05  2.85252756e-05\n",
+      " -2.97582365e-05 -3.38837986e-05 -2.99174910e-05 -1.77976405e-05\n",
+      "  2.06735848e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.55522814e-05  1.01405640e-05  1.15647531e-05  1.02548834e-05\n",
+      "  1.06626241e-05  1.23055809e-05  1.32383686e-05  1.88361808e-05\n",
+      "  3.11841773e-05  3.23403655e-05  3.66776268e-05 -4.09840072e-05\n",
+      " -4.02873965e-05 -3.32048477e-05 -2.05074627e-05 -1.96074661e-05\n",
+      " -2.19605083e-05 -1.32301119e-05 -1.15214477e-05 -6.06862168e-06\n",
+      "  0.00000000e+00  0.00000000e+00  7.37480086e-06  1.23528850e-05\n",
+      " -2.14848972e-05 -1.67634044e-05 -1.97191653e-05 -1.54031775e-05\n",
+      " -8.82565819e-06 -7.46955490e-06 -9.09598464e-06 -1.05277492e-05\n",
+      " -1.14561960e-05 -1.26414569e-05 -1.89654344e-05  2.73553019e-05\n",
+      "  3.16747835e-05  3.52958871e-05  3.29792974e-05  3.52994245e-05\n",
+      "  3.24136755e-05  3.09324191e-05  2.14922189e-05  2.52437200e-05\n",
+      " -2.61836150e-05 -2.99427710e-05 -2.63267490e-05 -1.59449611e-05\n",
+      "  1.83107862e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 90%|█████████ | 37/41 [01:11<00:08,  2.03s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.30743329e-05  1.47197146e-05  1.69409944e-05  1.48139777e-05\n",
+      "  1.52653560e-05  1.77801043e-05  1.80050109e-05  2.47468646e-05\n",
+      "  4.00960913e-05  4.04629005e-05 -5.08073319e-05 -4.26267592e-05\n",
+      " -4.16274692e-05 -3.37235224e-05 -2.05419183e-05 -1.89833910e-05\n",
+      " -2.05232269e-05 -1.19120494e-05 -9.21264966e-06  0.00000000e+00\n",
+      "  0.00000000e+00  6.61497329e-06  1.24243039e-05  1.81923208e-05\n",
+      " -2.46278671e-05 -1.90974585e-05 -2.25967312e-05 -1.69701379e-05\n",
+      " -1.00849397e-05 -8.26328084e-06 -1.08234781e-05 -1.21259245e-05\n",
+      " -1.33381393e-05 -1.43761185e-05  5.45873347e-05  3.05695879e-05\n",
+      "  3.51023488e-05  3.96251236e-05  3.70708127e-05  4.00188879e-05\n",
+      "  3.66078101e-05  3.41695486e-05  2.46745900e-05 -2.66542156e-05\n",
+      " -2.97566170e-05 -3.41370201e-05 -3.00851169e-05 -1.78555464e-05\n",
+      "  2.06034129e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [ 2.02447881e-05  1.30903016e-05  1.49303417e-05  1.29785360e-05\n",
+      "  1.35585754e-05  1.56946121e-05  1.56151129e-05  2.18267757e-05\n",
+      "  3.50011058e-05  3.55647526e-05 -4.49265527e-05 -3.74860943e-05\n",
+      " -3.66200381e-05 -2.97801927e-05 -1.80551082e-05 -1.67443646e-05\n",
+      " -1.80655386e-05 -1.04685485e-05 -8.18395459e-06  0.00000000e+00\n",
+      "  0.00000000e+00  5.90142645e-06  1.07793412e-05  1.59273555e-05\n",
+      " -2.18165041e-05 -1.69350741e-05 -1.98227683e-05 -1.53717725e-05\n",
+      " -8.97322389e-06 -7.46607957e-06 -9.27948046e-06 -1.05354018e-05\n",
+      " -1.16873712e-05 -1.27795967e-05  4.74000916e-05  2.73490437e-05\n",
+      "  3.16153935e-05  3.52619731e-05  3.28297660e-05  3.52185590e-05\n",
+      "  3.22749766e-05  3.06305139e-05  2.15100032e-05 -2.35939626e-05\n",
+      " -2.61868399e-05 -3.01721906e-05 -2.64765353e-05 -1.59997876e-05\n",
+      "  1.82528276e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 93%|█████████▎| 38/41 [01:12<00:05,  1.93s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.27411394e-05  8.08412339e-06  9.18197641e-06  8.22783884e-06\n",
+      "  8.47736049e-06  9.87180396e-06  1.24115655e-05  1.82623435e-05\n",
+      "  3.12858474e-05  3.26047062e-05  3.76335651e-05  4.09949126e-05\n",
+      " -4.96890913e-05 -4.11525043e-05 -2.58418530e-05 -2.47658854e-05\n",
+      " -2.87647417e-05 -1.84344425e-05 -1.65561653e-05 -1.01530203e-05\n",
+      " -5.67659468e-06  0.00000000e+00  0.00000000e+00  1.04521474e-05\n",
+      " -2.42789168e-05 -1.88318839e-05 -2.26539837e-05 -1.70330315e-05\n",
+      " -9.87979368e-06 -8.14478352e-06 -1.06427656e-05 -1.21873290e-05\n",
+      " -1.26720051e-05 -1.39905954e-05 -2.16459632e-05 -1.58974462e-05\n",
+      "  3.53184581e-05  3.95668742e-05  3.72391189e-05  4.01162829e-05\n",
+      "  3.67997015e-05  3.45898169e-05  2.46374934e-05  2.82831874e-05\n",
+      "  3.17682017e-05 -3.39563153e-05 -2.98771895e-05 -1.79199900e-05\n",
+      "  2.03147364e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 1.11772632e-05  7.18958756e-06  8.09078060e-06  7.20455734e-06\n",
+      "  7.52840035e-06  8.71010961e-06  1.07661953e-05  1.60999543e-05\n",
+      "  2.73152567e-05  2.86635680e-05  3.32687586e-05  3.60334164e-05\n",
+      " -4.37186460e-05 -3.63404136e-05 -2.27124678e-05 -2.18534229e-05\n",
+      " -2.53137921e-05 -1.61999142e-05 -1.47147945e-05 -8.83547389e-06\n",
+      " -5.04191188e-06  0.00000000e+00  0.00000000e+00  9.14458162e-06\n",
+      " -2.15160561e-05 -1.67026289e-05 -1.98759061e-05 -1.54258151e-05\n",
+      " -8.79444676e-06 -7.36224758e-06 -9.12251884e-06 -1.05903432e-05\n",
+      " -1.11121348e-05 -1.24455835e-05 -1.88001989e-05 -1.42240553e-05\n",
+      "  3.17914801e-05  3.52165546e-05  3.29750572e-05  3.53090260e-05\n",
+      "  3.24516885e-05  3.09872544e-05  2.14827801e-05  2.50268722e-05\n",
+      "  2.79504280e-05 -3.00063556e-05 -2.63005428e-05 -1.60614686e-05\n",
+      "  1.79950164e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 95%|█████████▌| 39/41 [01:14<00:03,  1.92s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 7.84889342e-06  0.00000000e+00  0.00000000e+00  4.86097214e-06\n",
+      "  5.52124568e-06  5.92714196e-06  9.30467717e-06  1.52085816e-05\n",
+      "  2.66113748e-05  2.84280665e-05  3.34235141e-05  3.68702228e-05\n",
+      "  4.41979943e-05 -4.49691829e-05 -2.79722542e-05 -2.71548217e-05\n",
+      " -3.30231429e-05 -2.13930828e-05 -2.05611212e-05 -1.40701082e-05\n",
+      " -8.63978652e-06  0.00000000e+00  0.00000000e+00  6.19988217e-06\n",
+      " -2.42235955e-05 -1.86405348e-05 -2.27321551e-05 -1.67216690e-05\n",
+      " -9.83086608e-06 -7.88453246e-06 -1.00000068e-05 -1.21359808e-05\n",
+      " -1.29021348e-05 -1.44358483e-05 -2.14350751e-05 -1.57427596e-05\n",
+      " -2.22053894e-05  3.95675243e-05  3.75078772e-05  4.00410542e-05\n",
+      "  3.63788772e-05  3.44787364e-05  2.43037227e-05  2.85707686e-05\n",
+      "  3.15543537e-05  3.42192061e-05 -2.94641583e-05 -1.78577347e-05\n",
+      "  2.09769070e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.0\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0\n",
+      "INFO:shap:phi = [ 6.90584584e-06  0.00000000e+00  0.00000000e+00  0.00000000e+00\n",
+      "  4.77511835e-06  5.75205451e-06  8.28147990e-06  1.34812648e-05\n",
+      "  2.32511927e-05  2.48700062e-05  2.98771079e-05  3.27125446e-05\n",
+      "  3.90777381e-05 -3.97745277e-05 -2.43441352e-05 -2.40370944e-05\n",
+      " -2.90535699e-05 -1.87984707e-05 -1.81483393e-05 -1.22341272e-05\n",
+      " -7.43740708e-06  0.00000000e+00  0.00000000e+00  5.57979097e-06\n",
+      " -2.15037875e-05 -1.64552619e-05 -1.98012909e-05 -1.51620970e-05\n",
+      " -8.63261818e-06 -7.12149628e-06 -8.27107617e-06 -1.07886684e-05\n",
+      " -1.10974870e-05 -1.26256889e-05 -1.85169926e-05 -1.38765103e-05\n",
+      " -1.98049146e-05  3.52722083e-05  3.31954046e-05  3.54265624e-05\n",
+      "  3.21935969e-05  3.09801450e-05  2.14769833e-05  2.53240892e-05\n",
+      "  2.76086113e-05  3.03493202e-05 -2.58298346e-05 -1.59110417e-05\n",
+      "  1.86533070e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      " 98%|█████████▊| 40/41 [01:16<00:01,  1.85s/it]"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:shap:num_full_subsets = 1\n",
+      "INFO:shap:remaining_weight_vector = [0.15162364 0.10327987 0.07918123 0.06478465 0.05524272 0.04847831\n",
+      " 0.04345312 0.03959062 0.03654519 0.03409718 0.0321005  0.03045432\n",
+      " 0.02908698 0.02794632 0.0269936  0.02619967 0.02554233 0.0250046\n",
+      " 0.02457349 0.02423915 0.02399431 0.02383382 0.02375437]\n",
+      "INFO:shap:num_paired_subset_sizes = 24\n",
+      "INFO:shap:weight_left = 0.7710518569800939\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-7.67038662e-06 -4.94104093e-06 -6.18704314e-06  0.00000000e+00\n",
+      " -5.13042935e-06 -6.22232022e-06  0.00000000e+00  0.00000000e+00\n",
+      "  1.35369210e-05  1.61442015e-05  2.17014329e-05  2.54518598e-05\n",
+      "  3.20766736e-05  3.41648174e-05  2.80008862e-05  3.58671422e-05\n",
+      " -4.58778584e-05 -3.12458500e-05 -3.16282803e-05 -2.42302516e-05\n",
+      " -1.92719122e-05 -1.54465404e-05 -1.18541060e-05 -6.00657951e-06\n",
+      "  3.01088905e-05 -1.96144699e-05 -2.24571379e-05 -1.67221955e-05\n",
+      " -9.84581505e-06 -8.09376263e-06 -1.05067447e-05 -1.23180245e-05\n",
+      " -1.29850092e-05 -1.45068491e-05 -2.17848602e-05 -1.59256711e-05\n",
+      " -2.27197963e-05 -3.10110622e-05 -3.67439974e-05 -3.82760872e-05\n",
+      "  3.69100068e-05  3.46729146e-05  2.43281404e-05  2.86499783e-05\n",
+      "  3.22924295e-05  3.44536150e-05  2.96050054e-05  1.76242633e-05\n",
+      "  2.01202657e-05]\n",
+      "INFO:shap:np.sum(w_aug) = 49.00000000000001\n",
+      "INFO:shap:np.sum(self.kernelWeights) = 1.0000000000000002\n",
+      "INFO:shap:phi = [-6.73062260e-06 -4.39557003e-06 -5.45070908e-06  0.00000000e+00\n",
+      " -4.55716933e-06 -5.49156866e-06  0.00000000e+00  0.00000000e+00\n",
+      "  1.18185407e-05  1.41900975e-05  1.91890718e-05  2.23819691e-05\n",
+      "  2.82189242e-05  3.01700726e-05  2.46139254e-05  3.16383772e-05\n",
+      " -4.03831894e-05 -2.74596747e-05 -2.81049289e-05 -2.10852614e-05\n",
+      " -1.71208260e-05 -1.37750400e-05 -1.02877725e-05 -5.25707368e-06\n",
+      "  2.66808136e-05 -1.73872801e-05 -1.97017575e-05 -1.51589723e-05\n",
+      " -8.76647153e-06 -7.31891730e-06 -8.99997707e-06 -1.07044324e-05\n",
+      " -1.13807048e-05 -1.28991033e-05 -1.89150997e-05 -1.42480374e-05\n",
+      " -2.04597500e-05 -2.76000316e-05 -3.25393152e-05 -3.36849809e-05\n",
+      "  3.25412254e-05  3.10749372e-05  2.12060530e-05  2.53579100e-05\n",
+      "  2.84179658e-05  3.04527885e-05  2.60582830e-05  1.57914086e-05\n",
+      "  1.78301677e-05]\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 41/41 [01:18<00:00,  1.91s/it]\n"
+     ]
+    }
+   ],
    "source": [
     "# Calculate SHAP values for the test set\n",
     "shap_values = explainer.shap_values(X_test)"
@@ -1331,12 +5673,67 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 21,
    "id": "d9d3d533",
    "metadata": {
     "id": "2e318a5b"
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No data for colormapping provided via 'c'. Parameters 'vmin', 'vmax' will be ignored\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxEAAAO8CAYAAAA25TlWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdeVxU9f748dewiGyCEipu4G7uCmq3FDU0S8IriUtetdBAVCorteXrFezaTe3mVRPX3LDccENwSbsBpuaWpmIKboiySgiBgjLM+f3hj8lxBmQQWfT9fDzm8XA+5zPnvM+Z43De57MclaIoCkIIIYQQQghRSiaVHYAQQgghhBCiepEkQgghhBBCCGEUSSKEEEIIIYQQRpEkQgghhBBCCGEUSSKEEEIIIYQQRpEkQgghhBBCCGEUSSKEEEIIIYQQRpEkQgghhBBCCGEUSSKEEEIIIYQQRpEkQgghnnFvv/02Li4uFbKttLQ0fHx8cHBwQKVSMX/+/ArZrni0NWvWoFKpSEhIqOxQHptKpSI4OLiyw6hygoODUalUZf788ePHefHFF7G2tkalUvHbb7899jpF9SVJhBCiSjh79iw+Pj44OztTs2ZNGjZsSP/+/fnmm28qO7Rqq0+fPqhUKu2rTp06dOvWjVWrVqHRaMplG//+97/ZsWNHqet/8MEH/PDDD3z66aesW7eOV199tVziKMnt27f517/+RceOHbGyssLOzo5evXoRGhqKoihlXu/u3bsr7EL1zp07BAcHEx0dXar60dHROt+9hYUF9erVo0+fPvz73//m5s2bTzbgZ1hWVhb+/v44OjpibW1N3759OXnyZGWH9dgKCgoYOnQomZmZ/Pe//2XdunU4OztXdliiEqmUx/kFFUKIcnD48GH69u1LkyZNeOutt6hfvz7Xr1/nyJEjXL58mUuXLlV2iNVSnz59uHz5Ml9++SUAN2/eJDQ0lN9++42PP/6Y2bNnA/dbIqKjo8t0B9rGxgYfHx/WrFlTqvr169enX79+fPfdd0ZvqyzS0tLw8PDg/PnzjBgxgt69e5Ofn8/WrVs5cOAAw4cP5/vvv8fU1NTodQcGBhISEvJYiUhpZWRk4OjoSFBQUKkSl+joaPr27ct7771Ht27dKCws5ObNmxw+fJiIiAjs7OzYvHkzL7/8svYzhYWFFBQUYGFhUe3vLOfn52NmZoaZmVmFblej0dCrVy9Onz7N1KlTee6551i8eDHXr1/n119/pWXLlhUaz8PUajVqtZqaNWsa/dkLFy7w/PPPs2LFCt555x1teXBwMDNnzqyQ/weiaqnY/11CCGHAF198gZ2dHcePH8fe3l5nWXp6euUEVYkURSE/Px9LS8vHXpednR2jRo3Svh8/fjytW7dm0aJF/Otf/8Lc3Pyxt2GM9PR0ve/4ceTn51OjRg1MTAw3rL/11lucP3+e7du3M2jQIG35e++9x9SpU/nPf/5Dly5d+Pjjj8stpqqkV69e+Pj46JSdPn2aV155hSFDhvD777/j5OQEgKmpaZmSqaqoLBfJ5WHLli0cPnyYsLAw7XEfNmwYrVq1IigoiPXr11dKXEUeJ7Eq+i0uz/+/onqT7kxCiEp3+fJl2rVrZ/CPU926dbX/TkhIQKVSGbzr/XAf6KJ+uvHx8YwaNQo7OzscHR355z//iaIoXL9+nb///e/UqlWL+vXr8/XXX+usr6g7yObNm5k5cyYNGzbE1tYWHx8fsrOzuXv3LpMnT6Zu3brY2Njg6+vL3bt3ddaxevVqXn75ZerWrYuFhQVt27ZlyZIlerG7uLjw+uuv88MPP+Dm5oalpSXLli2jd+/edOrUyeAxa926NQMGDCjhqBpmZWXFCy+8wO3bt0vs0nL79m0++ugjGjdujIWFBa1bt+Y///mPzt1GlUrF7du3Wbt2rbbbzNtvv21wfUX97RVFISQkRFu/yJUrVxg6dCh16tTRxrhr1y6ddRR9Jxs3bmT69Ok0bNgQKysr/vzzT4PbPHLkCD/88ANvv/22TgJR5Msvv6Rly5bMmTOHvLw8nW083G3o4XPv7bffJiQkRHscHtyforr/+c9/+O9//4uzszOWlpb07t2b2NhYnfX26dOHPn366MX24DiVhIQEHB0dAZg5c6Z2W2XtStWpUyfmz59PVlYWixYt0pYbGhNRdG5GR0drz80OHTpoj8+2bdvo0KEDNWvWxNXVlVOnTult78KFC/j4+FCnTh1q1qyJm5sbO3fu1KlTtO1Dhw7x4YcfarsCeXt7652nJ06cYMCAATz33HNYWlrStGlTxo4dq1PH0PE5deoUr732GrVq1cLGxgYPDw+OHDlS5jgM2bJlC/Xq1eONN97Qljk6OjJs2DDCw8P1fiNKo+i37MKFCwwbNoxatWrh4ODA+++/T35+fpnW9SCVSkVgYCA7duygffv2WFhY0K5dO/bu3aut8/bbb9O7d28Ahg4dikqlMnjePui7777D1dUVS0tL6tSpw4gRI7h+/bp2+erVq1GpVKxatUrnc//+979RqVTs3r3bqH0TFU9aIoQQlc7Z2ZlffvmF2NhY2rdvX67rHj58OM8//zyzZ89m165dzJo1izp16rBs2TJefvll5syZw/fff8+UKVPo1q0b7u7uOp//8ssvsbS05JNPPuHSpUt88803mJubY2Jiwq1btwgODubIkSOsWbOGpk2bMmPGDO1nlyxZQrt27Rg0aBBmZmZEREQwceJENBoNkyZN0tlOXFwcb775JuPHj8fPz4/WrVtjY2ODn5+f3nE5fvw48fHxTJ8+vUzH5MqVK5iamhZ7R1FRFAYNGkRUVBTjxo2jc+fO/PDDD0ydOpWkpCT++9//ArBu3Treeecdunfvjr+/PwDNmzc3uE53d3fWrVvH6NGj6d+/P2PGjNEuS0tL48UXX+TOnTu89957ODg4sHbtWgYNGsSWLVvw9vbWWde//vUvatSowZQpU7h79y41atQwuM2IiAgAnW09yMzMjJEjRzJz5kwOHTpEv379ij9oDxk/fjzJycns37+fdevWGawTGhpKTk4OkyZNIj8/nwULFvDyyy9z9uxZ6tWrV+ptOTo6smTJEiZMmIC3t7f2ArVjx46lXsfDfHx8GDduHPv27eOLL74ose6lS5cYOXIk48ePZ9SoUfznP//By8uLpUuX8tlnnzFx4kTg/v+VYcOGERcXp20ZOnfuHC+99BINGzbkk08+wdrams2bNzN48GC2bt2q992+++671K5dm6CgIBISEpg/fz6BgYFs2rQJuH83/JVXXsHR0ZFPPvkEe3t7EhIS2LZtW4n7cO7cOXr16kWtWrWYNm0a5ubmLFu2jD59+hATE0OPHj2MiqM4p06domvXrnotY927d2f58uXEx8fToUOHEtdRnGHDhuHi4sKXX37JkSNHWLhwIbdu3SI0NLRM63vQwYMH2bZtGxMnTsTW1paFCxcyZMgQEhMTcXBwYPz48TRs2JB///vf2i5yJZ3DX3zxBf/85z8ZNmwY77zzDjdv3uSbb77B3d2dU6dOYW9vj6+vL9u2bePDDz+kf//+NG7cmLNnzzJz5kzGjRvHwIEDH3u/xBOmCCFEJdu3b59iamqqmJqaKn/729+UadOmKT/88INy7949nXpXr15VAGX16tV66wCUoKAg7fugoCAFUPz9/bVlarVaadSokaJSqZTZs2dry2/duqVYWloqb731lrYsKipKAZT27dvrxPHmm28qKpVKee2113S2/7e//U1xdnbWKbtz545enAMGDFCaNWumU+bs7KwAyt69e3XKs7KylJo1ayoff/yxTvl7772nWFtbK7m5uXrrf1Dv3r2VNm3aKDdv3lRu3rypnD9/XnnvvfcUQPHy8tLWe+utt3Ri37FjhwIos2bN0lmfj4+PolKplEuXLmnLrK2tdY7bowDKpEmTdMomT56sAMrPP/+sLcvJyVGaNm2quLi4KIWFhYqi/PWdNGvWzOCxfdjgwYMVQLl161axdbZt26YAysKFC3W2ERUVpVPP0Lk3adIkxdCf0aK6lpaWyo0bN7TlR48eVQDlgw8+0Jb17t1b6d27t946Hv5Obt68qXeOl6RoP8LCwoqt06lTJ6V27dra96tXr1YA5erVq9qyonPz8OHD2rIffvhBu3/Xrl3Tli9btkzv2Hl4eCgdOnRQ8vPztWUajUZ58cUXlZYtW+ptu1+/fopGo9GWf/DBB4qpqamSlZWlKIqibN++XQGU48ePl7j/Dx+rwYMHKzVq1FAuX76sLUtOTlZsbW0Vd3d3o+MojrW1tTJ27Fi98l27dhn8P14aRb9lgwYN0imfOHGiAiinT582el0PApQaNWro/L8+ffq0AijffPONtqy4c+rhdSYkJCimpqbKF198oVPv7NmzipmZmU55SkqKUqdOHaV///7K3bt3lS5duihNmjRRsrOzS71PovJIdyYhRKXr378/v/zyC4MGDeL06dPMnTuXAQMG0LBhQ71uD8Z6cACgqakpbm5uKIrCuHHjtOX29va0bt2aK1eu6H1+zJgxOuMGevTogaIoet0nevTowfXr11Gr1dqyB8c0ZGdnk5GRQe/evbly5QrZ2dk6n2/atKle9yQ7Ozv+/ve/s2HDBm03osLCQjZt2sTgwYOxtrZ+5P5fuHABR0dHHB0def755/nmm2/w9PTU60LwoN27d2Nqasp7772nU/7RRx+hKAp79ux55HaNsXv3brp3707Pnj21ZTY2Nvj7+5OQkMDvv/+uU/+tt94q1XiRnJwcAGxtbYutU7SsuC5Rj2Pw4ME0bNhQ+7579+706NGjynTTsLGx0R6jkrRt25a//e1v2vdFd+1ffvllmjRpolde9P8oMzOTn376iWHDhpGTk0NGRgYZGRn88ccfDBgwgIsXL5KUlKSzLX9/f53uNr169aKwsJBr164Bf/XHj4yMpKCgoFT7WVhYyL59+xg8eDDNmjXTljs5OTFy5EgOHjyo9/0/Ko7i5OXlYWFhoVdeNEajqNtcWTzcevnuu+8ClMv51K9fP51WxI4dO1KrVi2Dv4mPsm3bNjQaDcOGDdN+5xkZGdSvX5+WLVsSFRWlrVu/fn1CQkLYv38/vXr14rfffmPVqlXUqlXrsfdJPHmSRAghqoRu3bqxbds2bt26xbFjx/j000/JycnBx8dH7yLSGA9e5MD9C/OaNWvy3HPP6ZXfunWrVJ8HaNy4sV65RqPRSQ6KushYW1tjb2+Po6Mjn332GYDBJMKQMWPGkJiYyM8//wzAjz/+SFpaGqNHjy52nx/k4uLC/v37+fHHHzl48CCpqalERkbq7f+Drl27RoMGDfQuvp9//nnt8vJ07do1WrdurVde3PaKO1YPK4q/pAvl0iQaZWVoJp5WrVpVmecw5Obmlmq/jfk/AGj/H126dAlFUfjnP/+pTWSLXkFBQYD+xAkPb6t27do66+zduzdDhgxh5syZPPfcc/z9739n9erVJY41uHnzJnfu3Cn2HNNoNDp99UsTR3EsLS0NxlI0duFxJkt4+Hxq3rw5JiYm5XI+Pby/cH+fH7W/hly8eBFFUWjZsqXe937+/Hm973zEiBF4enpy7Ngx/Pz88PDwKPN+iIolYyKEEFVKjRo16NatG926daNVq1b4+voSFhZGUFBQsdNOFhYWFrs+Q7PNFDcDjfLAoOFH1X3UOi5fvoyHhwdt2rRh3rx5NG7cmBo1arB7927++9//6j2nobiLiwEDBlCvXj2+++473N3d+e6777TTpJaGtbW1UX39q4PSXog9//zz7NixgzNnzuiNdSly5swZ4P7ddqBM59jjKBpsXlHbK1JQUEB8fHypxiCV9f9A0Tk+ZcqUYicBaNGihVHrVKlUbNmyhSNHjhAREcEPP/zA2LFj+frrrzly5Ag2NjaP3J/SMOY34kFOTk6kpKTolReVNWjQ4PGD+//Kcxresu6vIRqNBpVKxZ49ewyu9+Hv6I8//uDEiRMA/P7772g0mmJnWxNViyQRQogqy83NDfjrD3DR3cCsrCydeuV9Z7w8REREcPfuXXbu3Klzl+/BpvzSMDU1ZeTIkaxZs4Y5c+awY8cO/Pz8nuhUnM7Ozvz444/k5OTo3Km+cOGCdnmR8riQcXZ2Ji4uTq/c0PaM8frrr/Pll18SGhpqMIkoLCxk/fr11K5dm5deegkw7hx71L5fvHhRryw+Pl7n6eC1a9c22GXk4e2V93MbtmzZQl5eXplm+Cqtoq5D5ubm5Z7IvvDCC7zwwgt88cUXrF+/nn/84x9s3LhRp/tiEUdHR6ysrIo9x0xMTPRaVcqqc+fO/Pzzz3oXwkePHsXKyopWrVqVed0XL17UaYW7dOkSGo2mwp42X1rNmzdHURSaNm1aqv2dNGkSOTk5fPnll3z66afMnz+fDz/8sAIiFY9LUj0hRKWLiooyeMerqK9vUTeEWrVq8dxzz3HgwAGdeosXL37yQRqp6CL/wf3Kzs5m9erVRq9r9OjR3Lp1i/Hjx5Obm6vz3IcnYeDAgRQWFupM/wnw3//+F5VKxWuvvaYts7a21rvgLsv2jh07xi+//KItu337NsuXL8fFxUXbSmCsF198kX79+rF69WoiIyP1lv/f//0f8fHxTJs2Tdu64ezsjKmpaanOsaIxKcXt/44dO3T6/B87doyjR4/qHL/mzZtz4cIFnelDT58+zaFDh3TWZWVlVeK2jHH69GkmT55M7dq19frZl6e6devSp08fli1bZvDufFmemn3r1i2934rOnTsDFNulydTUlFdeeYXw8HCdrj9paWmsX7+enj17llsffB8fH9LS0nRmi8rIyCAsLAwvLy+D4yVKq2hK4SLffPMNgM75VBW88cYbmJqaGnwAnaIo/PHHH9r3W7ZsYdOmTcyePZtPPvmEESNGMH36dOLj4ys6bFEG0hIhhKh07777Lnfu3MHb25s2bdpw7949Dh8+zKZNm3BxccHX11db95133mH27Nm88847uLm5ceDAgSr5B+eVV16hRo0aeHl5aS/+V6xYQd26dQ1eUJWkS5cutG/fnrCwMJ5//nm6du36hKK+z8vLi759+/J///d/JCQk0KlTJ/bt20d4eDiTJ0/WGYDp6urKjz/+yLx582jQoAFNmzbVmy7zUT755BM2bNjAa6+9xnvvvUedOnVYu3YtV69eZevWrY/VtSE0NBQPDw/+/ve/M3LkSHr16sXdu3fZtm0b0dHRDB8+nKlTp2rr29nZMXToUL755htUKhXNmzcnMjLS4EMPXV1dgfsPrhswYACmpqaMGDFCu7xFixb07NmTCRMmcPfuXebPn4+DgwPTpk3T1hk7dizz5s1jwIABjBs3jvT0dJYuXUq7du10BvtaWlrStm1bNm3aRKtWrahTpw7t27d/ZHekn3/+mfz8fAoLC/njjz84dOgQO3fuxM7Oju3bt1O/fv0yH9vSCAkJoWfPnnTo0AE/Pz+aNWtGWloav/zyCzdu3OD06dNGrW/t2rUsXrwYb29vmjdvTk5ODitWrKBWrVolTgk6a9Ys9u/fT8+ePZk4cSJmZmYsW7aMu3fvMnfu3MfdTS0fHx9eeOEFfH19+f3337VPrC4sLGTmzJk6dd9++23teV6a1oSrV68yaNAgXn31VX755Re+++47Ro4cWeyzZCpL8+bNmTVrFp9++ikJCQkMHjwYW1tbrl69yvbt2/H392fKlCmkp6czYcIE+vbtS2BgIACLFi0iKiqKt99+m4MHD0q3pqqugmeDEkIIPXv27FHGjh2rtGnTRrGxsVFq1KihtGjRQnn33XeVtLQ0nbp37txRxo0bp9jZ2Sm2trbKsGHDlPT09GKneL1586bO59966y3F2tpaL4bevXsr7dq1074vbjrDoikgH55i0tD2du7cqXTs2FGpWbOm4uLiosyZM0dZtWqVwWk0PT09SzxGc+fOVQDl3//+d4n1Stqn4jw8naii3J9i9YMPPlAaNGigmJubKy1btlS++uornWkvFUVRLly4oLi7uyuWlpYK8MjpXjEwxauiKMrly5cVHx8fxd7eXqlZs6bSvXt3JTIyUqdOaaYtNSQnJ0cJDg5W2rVrp1haWiq2trbKSy+9pKxZs0ZvfxTl/nSqQ4YMUaysrJTatWsr48ePV2JjY/WmeFWr1cq7776rODo6KiqVSjvNZdEUr1999ZXy9ddfK40bN1YsLCyUXr16GZyO87vvvlOaNWum1KhRQ+ncubPyww8/GPxODh8+rLi6uio1atR45HSvRceq6GVubq44Ojoq7u7uyhdffKGkp6frfaa4KV4NnZuGvscH9/tBly9fVsaMGaPUr19fMTc3Vxo2bKi8/vrrypYtW/S2/fD/q4en3D158qTy5ptvKk2aNFEsLCyUunXrKq+//rpy4sQJvfgePj4nT55UBgwYoNjY2ChWVlZK3759daauNSaOkmRmZirjxo1THBwcFCsrK6V3794Gp6QdMmSIYmlpWeIUxIry12/L77//rvj4+Ci2trZK7dq1lcDAQCUvL++R8Rha14OK+z/p7OxscNrrR03xWmTr1q1Kz549FWtra8Xa2lpp06aNMmnSJCUuLk5RFEV54403FFtbWyUhIUHnc+Hh4QqgzJkzx6h9ExVPpShlGDUjhBCiQi1YsIAPPviAhIQEgzOpiKojISGBpk2b8tVXXzFlypTKDkdUUfXq1WPMmDF89dVXJdYLDg5m5syZ3Lx5s8RZ1YSoaNJOJIQQVZyiKKxcuZLevXtLAiHEU+DcuXPk5eXx8ccfV3YoQpSZJBFCCFFF3b59mw0bNjB+/HjOnj3LBx98UNkhCSHKQdGYl/JqWcjOziY1NbXEl3hygoODi51e+MFlCQkJ2mmKjVHWzz1pMrBaCCGqqJs3bzJy5Ejs7e357LPPGDRoUGWHJISogt5//33Wrl1bYh3pvV75nJyc+OWXXx5rqt+qRJIIIYSoolxcXOQPfzUk35soT8HBwQQHB5dYZ9q0aU986mfx+CwsLHjhhRcqO4xyI0mEEEIIIUQ11rZt2zI/T0VUnKJJF8LCwvDx8QHg3r17TJkyhe+++w6NRsPw4cPp3bs3//jHP/Sm/83PzycwMJDvv/+emjVr8o9//IPZs2djZlY5l/MyJkIIIYQQQojHpFar9V4ajabEz3zyyScsW7aMjz/+mE2bNqHRaPjkk08M1v2///s/TExM2Lx5MwEBAXz99dd8++23T2JXSkVaIoQQQgghhHgMt2/fxtzc3OCyoqfbPywzM5MlS5Ywffp07UxdAwYMoF+/fly/fl2vfo8ePVi4cCEA/fv3Jyoqii1bthAQEFBOe2EcSSKEEEKIClZQUMDq1asB8PX1LfbiQwjxhKneKH1dZVuxiywtLTlw4IBe+fLly1m/fr3Bz5w9e5b8/Hy9STP+/ve/87///U+v/iuvvKLzvm3btvz000+lifyJkCRCCCGEEEKIx2BiYoKbm5teeWRkZLGfSUlJAcDR0VGnvG7dugbr29vb67yvUaMG+fn5RkZafmRMhBBCCCGEEBXMyckJuD+d94PS09MrIxyjSRIhhBBCCCGeUSojXuWrffv21KxZk/DwcJ3yHTt2lPu2ngTpziSEEEIIIUQFc3BwYMKECXzxxRfUrFmTzp07ExYWRnx8PHC/i1RVVrWjE0IIIYQQ4ik1e/Zs/P39+fLLLxk6dCgFBQXaKV7t7OwqObqSqRR5rKYQQghRoWR2JiGqCNWQ0tdVtj65OB4wevRoDh48yNWrVytke2Ul3ZmEEEIIIcQzqvzHOhgjJiaGQ4cO4erqikajITIyku+//5558+ZValylIUmEEEIIIYQQlcDGxobIyEjmzJlDXl4eTZs2Zd68eUyePLmyQ3skSSKEEEIIIYSoBK6urhw+fLiywygTSSKEEEIIIcQzqnK7M1VnMjuTEEIIIYQQwiiSRAghhBBCCCGMIkmEEEIIIYQQwigyJkIIIYQQQjyjZExEWUlLhBBCCCGEEMIokkQIIYQQQgghjCJJhBBCCCGEEMIokkQIIYQQQgghjCJJhBBCCCGEEMIoMjuTEEIIIYR4RsnsTGUlLRFCCCGEEEIIo0gSIYQQQgghhDCKJBFCCCGEEEIIo0gSIYQQQghRFeTkwZXUyo7iGaMy4iUeJEmEEEIIIURlm70N6o+F5hOh7Xvw+/XKjkiIEkkSIYQQQghRmY7Gw6ffwZ2799+fvwFvzK3cmIR4BEkihBBCCCEqU1SsfllcEvyeWPGxPHOkO1NZSRIhhBBCCFGZmtY1XB6yt2LjEMIIkkQIIUQlyr6rcCpN4a5aqexQhBCVZXB3w+XHLlZsHEIYQZ5YLYQQlWTxKQ1TYzTcUcNzlrBuoAmvNpV7O0I8c5JvGS63sqjYOJ5J0k2prOSvlRBCVIKfEjVM+t/9BAIgIw/e2qPhXqG0SAjxzNl40HB53/YVG4cQRpAkQgghKphGURgRodErT78D8ZmVEJAQonLdyjVcPuylio1DCCNIEiGEEBXst3S4madfbmUGLnYVH48QopK1bWy4/N9bKzYOIYwgYyKEEKKCpd023GWpT2OwqSH9c4V45nR0Nlz+y4WKjeOZJL+5ZVWlWyKCg4Nxc3MrVd3k5GTc3NxYtmzZE47qPmNi8/f3x8vL6wlHVDJjj09cXBwTJkygb9++FXpchXgWOFga/qOVXEyPBiHEU+6b3YbLZYiUqMKkJULoUavVTJs2DbVaTUBAALa2trRs2bKyw6pw0dHRxMXFMX78+FJ/Zv369dja2pZ70hgbG8uePXs4f/48Fy9eJC8vj6CgoBK3k5aWxrfffsvhw4fJzMykVq1atG7dmsmTJ9OsWbNyjU8Yp00dw1cGSTkVHIgQomq4dtNwedYdKCwEU9OKjUeIUqjSScT06dP59NNPKzuMZ05SUhJJSUlMnjyZ4cOHV3Y4lSY6OprIyEijkogNGzbg5ORU7knEoUOHCAsLw8XFhZYtW3LmzJkS61+4cIFJkyZhZWXFoEGDqF+/Pn/++Se///47t24VM5WgqBDZdxXe/VF/UDVA5l3IylewrynN60I8U+ytDZffyoW0bGhQp2LjeabI721ZPXYSUVhYSEFBATVr1iyPeHSYmZlhZlal85yn0h9//AGAnV35jvBUFIW8vDysrKzKdb3Vmb+/PwDLly8vsZ6Pjw9jxozB0tKSH3/8scQk4u7du3z66afUq1eP5cuXY2NjU64xi8fzRriGnxINLytU4H+JCkNayR81IZ4pKcXc3LG3AjNphRBVk1FX6BEREcycOZOQkBDOnj1LREQEqampTJ8+HS8vLxRFYevWrezYsYOrV69iYmJC27Zt8fPz0xs/EBkZyebNm0lMTEStVuPg4ECHDh346KOPqF27NnB/3EFkZCQnTpzQ+exvv/3GwoULiYuLw9raGg8PD4YMGVJsvEuXLtXbvr+/PykpKURERGjLjhw5Qnh4OL///jsZGRmYm5vTrl07xo4di6urqzGHqlROnjzJt99+y7lz51Cr1bi4uDB06FAGDx6sUy82NpYtW7Zw5swZ0tLSMDU1pUWLFowePZq+ffvqrbe0x8cQf39/Tp48CcDMmTOZOXMmADt37qRBgwbk5eWxcuVK9u/fT3p6OrVq1aJHjx5MmDABJycn7XpOnDhBQEAAQUFB5OXlERYWxo0bN3j77be1d/b37dvHpk2buHjxIoWFhdp96tevn15cJ06cYN26dcTGxpKXl4ejoyOurq6899572NvbAxAWFkZ0dDRXrlzh1q1b2NnZ0b17dyZMmECDBg101nfw4EFCQ0O5fPky+fn52Nvb07ZtWwIDA3F2dtY5Dg+eOyV1ISqql5KSovOZomP3OBwcHEpdd//+/Vy/fp158+ZhY2PDvXv3AKhRo8ZjxSAe36VbCj8lltzJuZGtJBBCPHOSi5nbOesOuE2FE3Ohrn2FhiTEo5TpNv+CBQtQq9V4e3tjbW2Ns/P9WQVmzJjBDz/8gIeHB15eXhQUFLBnzx4mTZrE3Llz6d27NwC7du0iODiYLl26EBAQgIWFBWlpaRw6dIjMzExtEmFIbGwsEydOxMrKijFjxmBra8u+ffsICgoqy67oiIiIIDs7m4EDB1KvXj3S09MJDw9n4sSJLF26lC5dujz2NoocOHCAqVOn4uDgwKhRo7CysmLfvn3MmjWLpKQkJk2apK0bHR1NQkIC/fr1w8nJiezsbCIjI5k6dSqzZs3i1Vdf1dZ93OMzduxYOnXqxOrVq/H29tbuc+3atVGr1QQGBnL69Gk8PDwYNWoUiYmJbN26laNHjxIaGkq9evV01rdhwways7MZPHgwDg4O2uWLFy9m1apVvPjiiwQEBGBiYkJUVBSffPIJ06ZNY9iwYdp1bN26ldmzZ1O3bl2GDBmCk5MTqamp/Pzzz6SlpWmTiO+++4727dszfPhw7OzsuHz5Mjt27OD48eNs3LhRW+/XX3/lww8/pHnz5vj6+mJjY0NGRgbHjh3j+vXrODs7M3bsWBRF4dSpU3z++efaWDp27Fjssfv888+ZN28e9vb2jB07Vlte0vn8JBw6dAgAW1tb/Pz8+O2331AUhVatWvHuu+/yt7/9rULjEX9RPSI/sDaDHk6SRAjxzLlzt/hl1zNgxY/wfz4VF48QpaEYYefOnYqrq6vi7e2t5OXl6Sz76aefFFdXV2Xr1q065QUFBcqoUaMULy8vRaPRKIqiKFOmTFHc3d2VgoKCErcXFBSkuLq66pT5+voqPXr0UBISErRl9+7dU0aPHq24uroqS5cu1Yv3+PHjeuv28/NTXn/9dZ2yO3fu6NXLyMhQXn75ZeXdd999ZGzFeXhbarVa8fT0VHr37q2kp6fr7Ievr6/SrVs35dq1ayXGlZeXp3h7eys+Pj465cYcn+IcP35ccXV1VXbu3KlTvm3bNsXV1VWZP3++TvnPP/+suLq6KtOnT9dbR9++fZU//vhDp/758+cVV1dXZdGiRXrb/vDDDxV3d3clNzdXURRFSU1NVV544QXFx8dH+fPPP/XqFxYWav9t6DgdPXpUcXV1VdasWaMt+/rrrxVXV1e9uB5mzHdc5PXXX1f8/PxKXd/Pz8+o+oqiKPv37zf4/RR58803FVdXV6Vfv37K5MmTlX379ilhYWHKwIEDlW7duilHjhwxantP0h9//KHk5+dr3+fk5Oh8z3fv3lUyMjJ0PpOcnFzi+5SUFO1vTVXbRkGhRuGrgmJfNb4ueOxtVMR+yDYefxv37t1TwsPDlWXLlin37t2rtvsh2yinbTw3RlHwLv41aXn12I8nuI0nRcOoUr+ErjJN8erj46M3BmL37t1YW1vTp08fsrKytK/c3Fx69epFcnIyiYn3OwLb2NiQn5/PwYMHUZTSz1+WmZnJmTNn6N27t7b1A8Dc3JyRI0eWZVd0WFpaav99584dsrKyMDU1pX379pw7d+6x11/k/PnzpKamMmjQIBwdHbXl5ubmjBkzBo1GQ0xMjMG48vPzycrKIj8/n27dunH16lVyc+/PC/mkj09UVBQmJib4+vrqlPfs2ZNWrVpx4MABNBrdAaOenp7UqaM7IGzPnj2oVCo8PT11zpWsrCzc3d25ffs2Z8+eBeDHH3+koKAAPz8/bG1t9WIyMfnrFC46ThqNhtzcXLKysmjVqhU2NjbExsZq6xWNEfjpp59Qq9WPcUSMU3ROPfhSq9Wo1Wq98jt37jzWdgBcXFyYN28e/fv3x8fHhyVLlqBSqVi8eHF57dJjq1OnDhYWFtr3NjY2Ot9zjRo19LpyPdhtztD7+vXro3rgln9V2oaZiYrXmlKsQgUKCpUqvx+yjfLZRmpq6lOxH7KNcthGy0d0eX3jheqxH09wG6LqKVN3piZNmuiVJSQkcPv2bV555ZViP5eZmYmzszO+vr6cPHmSKVOmYGdnR9euXXnppZfo378/1tbFzFDA/VmD4P7F0cPKY8rKGzduEBISwpEjR8jJ0Z1rUfWofghGSE5OBgzH3Lx5c+CvfYX7x23JkiXExMSQmanfbzI3NxcbG5snfnySk5NxdHSkVq1aBuOOj48nKytLJ2kwdK5cvXoVRVHw8Sm+abZocPf169cBaN269SPjO378OCtWrODcuXPcvavbNPzg9zls2DBiYmKYPXs233zzDZ06deLFF19kwIABT7Tr0dy5c4mMjDS47OFxIK+//jrBwcFl2k7RD7enp6fOedukSRM6derEqVOnyMvL00lORcUJfc2U1qsKyczXX1ao3H+adTf52ynEs6VdY/glTr/cqTbMGAYvd6j4mIR4hDIlEYZmYlIUhdq1azNr1qxiP1d0gdykSRPCwsI4duwYx48f5+TJk8yaNYtly5axYsUKGjVqVJaw9JR04V9YWKjz/s6dO/j5+ZGXl8ebb75JixYtsLa2RqVSsWbNGo4fP14uMRlLURQCAwO5evUqI0aMoG3bttjY2GBiYkJERAR79+7Vu/tflRQ3a5dKpWLhwoU6LQkPKjpXSuvcuXMEBgbSqFEjAgMDadCgARYWFqhUKj777DOdY2Rvb09oaCinTp3i6NGjnDp1innz5rFs2TIWLFhQ4riHxzFmzBhee+01nbL58+cDMHnyZJ3yB1uojFWvXj0uX75scDC2g4MDiqKQm5srSUQlec5KRdRwU9zWFVJg4L9uY/0cXQjxtLtXTKv49o+hR6uKjUWIUiq3+VMbN25MYmIiHTp0KNUUnjVq1KBnz5707NkTuD9bzuTJk/n+++/5+OOPDX6maIabhIQEvWVXrlzRKyu6Y/7nn3/qLUtOTtaZPvbYsWPcvHmTGTNmMGjQIJ26S5YseeT+GKNhw4aA4ZiLyorqXLx4kfj4ePz8/PSeV7Bjxw6d98YeH2M1bNiQX375hZycHL2uRVeuXMHa2lo7eLkkjRs35vDhw9SvX5+mTUvo28FfLRnx8fE6XbQetnfvXgoLC1m4cKH22AHk5eXptSoBmJqa4ubmpp1F6eLFi4waNYqVK1eyYMECoGytTyV9plmzZnotQkXHsUePHkZvqzjt2rXj8OHDpKWl6S1LT0/H1NTUYGuSqDgdHVU41ITUh3qtmaqgvrUMrBbimZNZzOPqCyquy60QxirTmAhDPD090Wg0LFq0yODyou4pAFlZWXrL27RpA0B2dnax2yiaBjYmJoZr165pywsKCli/fr1e/aIL0GPHjumU7927l5s3dZ8Oafr/nwb58BiNI0eO6PSnLw9t2rShfv36REREkJGRoS1Xq9WsW7cOlUqlncmq6E79w3FdunSJ6OhonTJjj4+x+vTpg0ajYc2aNTrlhw4dIi4uDnd392JbFh40cOBAAEJCQvRahED3XPHw8MDc3JwVK1Zox348qOi4FPf9rVq1Sq+lxtD55+LiQs2aNXUSzqI79SWdkw+ztLQ0mLRWpAEDBmBqakp4eLjOmI/4+HjOnj2Lm5ubTl9VUfEy8xTSDQx7MZH8QYhnU01zw+UHfq/YOIQwQrm1RPTr1w8vLy82b97MhQsX6NWrF/b29qSnp3PmzBlu3LhBeHg4AJMmTcLW1pYuXbpQr149cnJyiIiIQKVSaS8wi/PBBx8wfvx4xo0bx9ChQ7VTmBq6GHVxcaF79+5s27ZNO8VlfHw80dHRNG7cWOcCq3Pnzjg4ODB//nxSUlKoW7cu8fHx7N69mxYtWnDp0qXyOlSYmpoybdo0pk6dyltvvYW3tzdWVlbs37+fs2fP4uvrq02AmjZtSrNmzQgNDSU/Px9nZ2cSExPZtm0bLVq04Pz582U+Psby8vIiMjKStWvXkpycTNeuXbl+/TpbtmzBwcFBZ1rakrRr1w5/f3+WL1/OyJEj6devH46OjmRkZHD+/HkOHTrEkSNHgPtdcz766CPmzJnDiBEj8PT0xMnJifT0dGJiYpgxYwatW7emT58+rF+/nvfffx9vb2/Mzc05evQoly5d0msdmTVrFunp6fTo0QMnJyfu3r3L/v37uX37Np6entp6HTp0YPPmzcyePZuePXtiZmZG+/btdVo6HtahQwfCw8NZsmQJTZs2RaVS4e7u/thdh1JSUti1axfwV6vSgQMHtK0NRccF7p/3Y8aMYfXq1fj7+/PKK6/w559/smnTJmrWrKnXdUpUvEtZYKgTYi15lIcQz6b+nWDLL/rlZ67pl4lyJndvyqpcHwcdFBSEm5sb27dvZ82aNRQUFODg4ECbNm10LjB9fHzYv38/27ZtIzs7Gzs7O1q3bs20adP0Hgr3sI4dOxISEsKiRYtYu3YtNjY22oepjRgxQq/+559/zldffcXevXvZvXs3Xbp0YenSpXz55ZekpKRo69na2rJo0SIWLlzIpk2bKCwspE2bNixYsIDw8PByTSIA3N3dWbx4MStXrmTdunUUFBTg4uLC9OnTdR42Z2pqyoIFC5g/fz6RkZHk5eXRvHlzgoODiY+P10sijD0+xjAzM2PRokXah81FRUVha2uLh4cHEydOpH79+qVel7+/P23btmXjxo1s2LCBvLw86tSpQ/PmzZkyZYpOXR8fHxo1akRoaCgbN26koKAAR0dHunXrpn3uROfOnZk7dy7ffvstS5cuxcLCgu7du7N8+XL8/Px01jdw4EAiIiLYtWsXt27dwtrammbNmjFnzhw8PDy09QYMGEBcXBz79u3jf//7HxqNhqCgoBKTiIkTJ5KdnU1YWBg5OTkoisLOnTsfO4lISkpi6dKlOmVRUVFERUVp9//BmSwmTZqEk5MTYWFhLFy4EAsLC9zc3AgICDB6vIkofx2eAzMVqB+anM7QYGshxDPAspiWiFYyy4KoulSKMXOsCiGEKBdNlqm5/tBwHWtzyH2/XO/tiCqqoKCA1atXA+Dr64u5eTEXkeLZMHc7fLxOv/zwv+FvbSo+nmeIohpT6roqJfQJRlL9lNuYCCGEEKXXpa5+WaeyT8olhKjOMvUnAAFgTVTFxiGEESSJEEKISjClmylmD/wCm5nAbHfTygtICFF56tkbLv/2R7iWXqGhPGsUVKV+CV3Sbi6EEJWgVyMVR0aa8u3Z+0Os3+lggmt9+SMlxDOpuI7lGgUupYKzgaZLISqZJBFCCFFJXOurcK0vrQ9CPPPOFjMLk60ldG9ZsbEIUUqSRAghhBBCVKb2TfTLLMxh44f3EwnxBEkLcFnJmAghhBBCiMrk/wp0a/HXe3tr+HkWDHStvJiEeARpiRBCCCGEqEy2lnBkNkTFQtZtGNAZbKQFQlRtkkQIIYQQQlQ2ExPw6FjZUTyDpDtTWUl3JiGEEEIIIYRRJIkQQgghhBBCGEWSCCGEEEIIIYRRZEyEEEIIIYR4JsmTqMtOWiKEEEIIIYQQRpEkQgghhBBCCGEU6c4khBBCCCGeUdKdqaykJUIIIYQQQghhFGmJEEKIKiIpR2HBSQ3X/gTPZipGt1WhUsldMiGEEFWPJBFCCFEFZOUr9Pi+kKTc++83xynEZar4opdp5QYmhCgfl1LA3BSc61Z2JEKUC+nOJIQQVcCmOEWbQBT5z3EFtUapnICEEOUjMwd6T4eWk8AlAAbPhry7lR2V+P8UI15ClyQRQghRBdwp0C+7p4FfkuRPlxDVWvAmOPD7X+/Dj8H7KysvHiHKiSQRQghRBThaGk4WjqZWcCBCiPL183n9shU/wv7fKjwUIcqTJBFCCFEF7L5qOIno6FjBgQghyldLJ8Pli/ZUbByiGCojXuJBkkQIIUQVcDlLv8xMBf2d5Q+XENWaUkyXxHwDfRiFqEYkiRBCiCqgnpV+mVqBPHXFxyKEKEdnEw2Xd3Su2DiEKGeSRAghRBXQr5gWh7A4TQVHIoQoV51dDJefuVahYQjDFFSlfgldkkQIIUQV4NPa8B+oPVcrOBAhRPl6oZXhcnVhxcYhRDmr0klEcHAwbm5upaqbnJyMm5sby5Yte8JR3WdMbP7+/nh5eT3hiEpm7PGJi4tjwoQJ9O3bt0KPqxDPqucsVQbvc91RyxSvQlRrMecMl/v3r9g4hChn8sRqoUetVjNt2jTUajUBAQHY2trSsmXLyg6rwkVHRxMXF8f48eNL/Zn169dja2tb7kljbGwse/bs4fz581y8eJG8vDyCgoIMbic5OZlBgwYZXE+zZs3YvHlzucYmysf+BMXgw4ys5FdaiOpLo4GoWP1yqxowvGfFxyNEOarSf56mT5/Op59+WtlhPHOSkpJISkpi8uTJDB8+vLLDqTTR0dFERkYalURs2LABJyenck8iDh06RFhYGC4uLrRs2ZIzZ8488jN9+/alb9++OmW2trblGpcoP6m3DZcfT6nYOIQQ5Sj8GGTf0S+va1/hoYjiyFiHsnrsJKKwsJCCggJq1qxZHvHoMDMzw8ysSuc5T6U//vgDADs7u3Jdr6Io5OXlYWVlYBqaZ5S/vz8Ay5cvL7Gej48PY8aMwdLSkh9//LFUSUSLFi0YOHBgucQpnqx8tcKMQ4YHUF/5E+4UKFiZyx86IaqdX68YLrcp/2smISqaUVfoERERzJw5k5CQEM6ePUtERASpqalMnz4dLy8vFEVh69at7Nixg6tXr2JiYkLbtm3x8/PTGz8QGRnJ5s2bSUxMRK1W4+DgQIcOHfjoo4+oXbs2cH/cQWRkJCdOnND57G+//cbChQuJi4vD2toaDw8PhgwZUmy8S5cu1du+v78/KSkpREREaMuOHDlCeHg4v//+OxkZGZibm9OuXTvGjh2Lq6urMYeqVE6ePMm3337LuXPnUKvVuLi4MHToUAYPHqxTLzY2li1btnDmzBnS0tIwNTWlRYsWjB49Wu9OM5T++Bji7+/PyZMnAZg5cyYzZ84EYOfOnTRo0IC8vDxWrlzJ/v37SU9Pp1atWvTo0YMJEybg5PTXA3VOnDhBQEAAQUFB5OXlERYWxo0bN3j77be1d/b37dvHpk2buHjxIoWFhdp96tevn15cJ06cYN26dcTGxpKXl4ejoyOurq6899572NvbAxAWFkZ0dDRXrlzh1q1b2NnZ0b17dyZMmECDBg101nfw4EFCQ0O5fPky+fn52Nvb07ZtWwIDA3F2dtY5Dg+eO8V1IXqwXkpKis5nio7d43BwcCjT5+7evYuiKE8kyRfl578nNCQX0xJhWwNJIISoroqbmSkzt0LDEOJJKNNt/gULFqBWq/H29sba2hpn5/tzHc+YMYMffvgBDw8PvLy8KCgoYM+ePUyaNIm5c+fSu3dvAHbt2kVwcDBdunQhICAACwsL0tLSOHToEJmZmdokwpDY2FgmTpyIlZUVY8aMwdbWln379hEUFFSWXdERERFBdnY2AwcOpF69eqSnpxMeHs7EiRNZunQpXbp0eextFDlw4ABTp07FwcGBUaNGYWVlxb59+5g1axZJSUlMmjRJWzc6OpqEhAT69euHk5MT2dnZREZGMnXqVGbNmsWrr76qrfu4x2fs2LF06tSJ1atX4+3trd3n2rVro1arCQwM5PTp03h4eDBq1CgSExPZunUrR48eJTQ0lHr16umsb8OGDWRnZzN48GAcHBy0yxcvXsyqVat48cUXCQgIwMTEhKioKD755BOmTZvGsGHDtOvYunUrs2fPpm7dugwZMgQnJydSU1P5+eefSUtL0yYR3333He3bt2f48OHY2dlx+fJlduzYwfHjx9m4caO23q+//sqHH35I8+bN8fX1xcbGhoyMDI4dO8b169dxdnZm7NixKIrCqVOn+Pzzz7WxdOzYsdhj9/nnnzNv3jzs7e0ZO3astryk8/lJ+v777/n2229RFIV69erh5eXF2LFjqVGjRqXEI4q37Ezxg6e71K3AQIQQ5cuhmC6k+XcrNg5RLJm69TEoRti5c6fi6uqqeHt7K3l5eTrLfvrpJ8XV1VXZunWrTnlBQYEyatQoxcvLS9FoNIqiKMqUKVMUd3d3paCgoMTtBQUFKa6urjplvr6+So8ePZSEhARt2b1795TRo0crrq6uytKlS/XiPX78uN66/fz8lNdff12n7M6dO3r1MjIylJdffll59913HxlbcR7ellqtVjw9PZXevXsr6enpOvvh6+urdOvWTbl27VqJceXl5Sne3t6Kj4+PTrkxx6c4x48fV1xdXZWdO3fqlG/btk1xdXVV5s+fr1P+888/K66ursr06dP11tG3b1/ljz/+0Kl//vx5xdXVVVm0aJHetj/88EPF3d1dyc3NVRRFUVJTU5UXXnhB8fHxUf7880+9+oWFhdp/GzpOR48eVVxdXZU1a9Zoy77++mvF1dVVL66HGfMdF3n99dcVPz+/Utf38/Mzqr6iKMr+/fsNfj9FUlJSlICAAGXDhg1KdHS0sn37dmXSpEmKq6urMmHCBEWtVhu1vSfpjz/+UPLz87Xvc3JydL7nu3fvKhkZGTqfSU5OLvF9SkqK9remOmxDXahR+Kqg2Ney3wqrxX7INozbxr1795Tw8HBl2bJlyr1796rtfsg2St7GXdcPFQVv/ZfF0Gq1H1VhG0/KXfxL/RK6yjTFq4+Pj173iN27d2NtbU2fPn3IysrSvnJzc+nVqxfJyckkJt5/aqONjQ35+fkcPHgQpbjHwRuQmZnJmTNn6N27t7b1A8Dc3JyRI0eWZVd0WFpaav99584dsrKyMDU1pX379pw7V8wUbWVw/vx5UlNTGTRoEI6Ojtpyc3NzxowZg0ajISYmxmBc+fn5ZGVlkZ+fT7du3bh69Sq5ufebRZ/08YmKisLExARfX1+d8p49e9KqVSsOHDiARqPbr9vT05M6derolO3ZsweVSoWnp6fOuZKVlYW7uzu3b9/m7NmzAPz4448UFBTg5+dncFCwiclfp3DRcdJoNOTm5pKVlUWrVq2wsbEhNvav2TFsbGwA+Omnn1CrK+5xwEXn1IMvtVqNWq3WK79zx8BAvFKqX78+S5YsYcSIEfTu3ZvBgwezaNEivL29OXbsGPv27SvHvXo8derUwcLCQvvexsZG53uuUaOGXleuB7vNGXpfv359VKq/7ixV9W2YmqjoXp9i1bdSqsV+yDaM30ZqaupTsR+yjWK2kXeXGqeLeaDcXTWkZFaP/agi2xBVT5m6MzVp0kSvLCEhgdu3b/PKK68U+7nMzEycnZ3x9fXl5MmTTJkyBTs7O7p27cpLL71E//79sba2LvbzSUlJALi4uOgta9asmfE78pAbN24QEhLCkSNHyMnJ0Vn24H+Ox5WcnAwYjrl58+bAX/sK94/bkiVLiImJITMzU+8zubm52NjYPPHjk5ycjKOjI7Vq1TIYd3x8PFlZWTpJg6Fz5erVqyiKgo+PT7HbKhrcff36dQBat279yPiOHz/OihUrOHfuHHfv6jYVP/h9Dhs2jJiYGGbPns0333xDp06dePHFFxkwYMAT7Xo0d+5cIiMjDS57eBzI66+/TnBwcLluf+zYsWzfvp2DBw/y2muvleu6xeNZ/oopfTcVcstAD4cpBxQGPXszLAtR/ZmYgLkZqO8ZXm4uE8eI6q1MZ7ChQZqKolC7dm1mzZpV7OeKLpCbNGlCWFgYx44d4/jx45w8eZJZs2axbNkyVqxYQaNGjcoSlp6SLvwLC3WfFHnnzh38/PzIy8vjzTffpEWLFlhbW6NSqVizZg3Hjx8vl5iMpSgKgYGBXL16lREjRtC2bVtsbGwwMTEhIiKCvXv36t39r0qKG9CrUqlYuHChTkvCg4rOldI6d+4cgYGBNGrUiMDAQBo0aICFhQUqlYrPPvtM5xjZ29sTGhrKqVOnOHr0KKdOnWLevHksW7aMBQsWlDju4XGMGTNG7+J9/vz5AEyePFmn/MEWqvJSr149TE1NycrKKvd1i8fTqa6K2LdNaPathrsPPcT24i24V6hQw1T67QpRrViYw4QBMC9Cf5mJCp7TvyEnKoP8tpZVuaXBjRs3JjExkQ4dOpRqCs8aNWrQs2dPeva8/7CVgwcPMnnyZL7//ns+/vhjg58pmuEmISFBb9mVK/rTqBXdMf/zzz/1liUnJ+tMH3vs2DFu3rzJjBkz9B7UtWTJkkfujzEaNmwIGI65qKyozsWLF4mPj8fPz0/veQU7duzQeW/s8TFWw4YN+eWXX8jJydHrWnTlyhWsra21g5dL0rhxYw4fPkz9+vVp2rRpiXWLWjLi4+N1umg9bO/evRQWFrJw4ULtsQPIy8vTa1UCMDU1xc3NTTuL0sWLFxk1ahQrV65kwYIFQNlan0r6TLNmzfRahIqOY48ePYzelrGSkpIoLCzU614mqoYGtia41tNwOFm33AQkgRCiuvrqLdh9Ei4kPbquENVMmcZEGOLp6YlGo2HRokUGlxd1TwEM3glt06YNANnZ2cVuo2ga2JiYGK5d+6ufYUFBAevXr9erX3QBeuzYMZ3yvXv3cvPmTZ0yU1NTAL0xGkeOHNHpT18e2rRpQ/369YmIiCAjI0NbrlarWbduHSqVSjuTVdGd+ofjunTpEtHR0Tplxh4fY/Xp0weNRsOaNWt0yg8dOkRcXBzu7u7Ftiw8qOjZBSEhIXotQqB7rnh4eGBubs6KFSu0Yz8eVHRcivv+Vq1apddSY+j8c3FxoWbNmjoJZ9EYi5LOyYdZWloaTForkqH902g0LF68GAB3d/cKjkiU1vk/9MsspceDENWXiQmYGvi7aGZa8bEIUc7K7c9Tv3798PLyYvPmzVy4cIFevXphb29Peno6Z86c4caNG4SHhwMwadIkbG1t6dKlC/Xq1SMnJ4eIiAhUKtUjH471wQcfMH78eMaNG8fQoUO1U5gauhh1cXGhe/fubNu2DUVRaNWqFfHx8URHR9O4cWOdQbWdO3fGwcGB+fPnk5KSQt26dYmPj2f37t20aNGCS5culdehwtTUlGnTpjF16lTeeustvL29sbKyYv/+/Zw9exZfX19tAtS0aVOaNWtGaGgo+fn5ODs7k5iYyLZt22jRogXnz58v8/ExlpeXF5GRkaxdu5bk5GS6du3K9evX2bJlCw4ODjrT0pakXbt2+Pv7s3z5ckaOHEm/fv1wdHQkIyOD8+fPc+jQIY4cOQLc74Lz0UcfMWfOHEaMGIGnpydOTk6kp6cTExPDjBkzaN26NX369GH9+vW8//77eHt7Y25uztGjR7l06ZJe68isWbNIT0+nR48eODk5cffuXfbv38/t27fx9PTU1uvQoQObN29m9uzZ9OzZEzMzM9q3b6/T0vGwDh06EB4ezpIlS2jatCkqlQp3d3edwfFlkZKSwq5du4C/WpUOHDhAWloagPa4AHzxxRfcvn2bjh07Uq9ePbKysvjpp584f/48vXv3xsPD47FiEU/GXbVicExEl3r6ZUKIakRt4O/vPTUciYMXHj3eTzxZMsVr2ZXrPa6goCDc3NzYvn07a9asoaCgAAcHB9q0aaNzgenj48P+/fvZtm0b2dnZ2NnZ0bp1a6ZNm6b3ULiHdezYkZCQEBYtWsTatWuxsbHRPkxtxIgRevU///xzvvrqK/bu3cvu3bvp0qULS5cu5csvvyQlJUVbz9bWlkWLFrFw4UI2bdpEYWEhbdq0YcGCBYSHh5drEgH37wYvXryYlStXsm7dOgoKCnBxcWH69Ok6D5szNTVlwYIFzJ8/n8jISPLy8mjevDnBwcHEx8frJRHGHh9jmJmZsWjRIu3D5qKiorC1tcXDw4OJEydSv34JU8w8xN/fn7Zt27Jx40Y2bNhAXl4ederUoXnz5kyZMkWnro+PD40aNSI0NJSNGzdSUFCAo6Mj3bp10z53onPnzsydO5dvv/2WpUuXYmFhQffu3Vm+fDl+fn466xs4cCARERHs2rWLW7duYW1tTbNmzZgzZ47OBfaAAQOIi4tj3759/O9//0Oj0RAUFFRiEjFx4kSys7MJCwsjJycHRVHYuXPnYycRSUlJLF26VKcsKiqKqKgo7f4XJREvvfQSu3fvZvv27WRnZ1OjRg2aNWvGxx9/zJAhQ0rVWiQqXlYx08ZfyZInVgtRrXV2gbhk/fINByWJENWaSjFmjlUhhBBPxJ93FZ4LKaTAwDwJy/qb4N9Jkr+nSUFBAatXrwbA19cXc3PzSo5IPDEDZsK+0/rl/xwKn79Z8fEIHXdVE0pd10Ip3zGy1Z38VRJCiCqgloWKN4qZyjUuU+71CFFtnbqqX2ZqAu/00y8XohqRJEIIIaqIRjaGy/s5S1cmIaotQ11ILcyhkYN+uRDViCQRQghRRaTn6ScLKqC/iyQRQlRbHfUfusqdu7D3VMXHIkQ5kiRCCCGqiOb2+mUKkFvMA2+FENVAYDGzTl5Ordg4hChnkkQIIUQVMaSl/k9y9/pgX1NaIoSotgZ1hzYPzeqnUkH/TpUTj9ChoCr1S+iSJEIIIaqI9o4qlr9igsP/nxG4W334zlMeSiVEtbfjE+ja7P6/HWvBtxOhTaPKjUmIxyTPQhVCiCrEr6MJb7dT8ec9cLCUO19CPBVaN4Rf/wMZf4KdFZjL5Zeo/uQsFkKIKsbcVKVtjRBCPEWeq1XZEQg9crOmrKQ7kxBCCCGEEMIokkQIIYQQQgghjCLdmYQQQgghxDNJZl0qO2mJEEIIIYQQQhhFkgghhBBCCCGEUSSJEEIIIYQQQhhFxkQIIYQQQohnlIyJKCtpiRBCCCGEEEIYRZIIIYQQQgghhFGkO5MQQlQDOy5qWHhS4Z5GYVx7E3w7yD0gIao8RYGFu2DDz2BvDdO84eUOlR2VeIBM8Vp2kkQIIUQVt/eqBu9wjfb9oaT7/5ZEQogq7t9bYfr6v97/7ywcnQ1dm1deTEKUE/kLJIQQVdyqs4pe2X9/1RioKYSoMm7lwpdbdcvUhbA2ulLCEaK8SRIhhBBVnLmpfllsBhxN0U8uhBBVgEYDXT+C23f1l9WQTiDi6SBJhBBCVHETO+v/VCtAyClpjRCiSvrfGUi4qV9uagLjPCo+HiGeAEkihBCiinupoYrn6+iXH0+VlgghqqTgTYbLnWpDm0YVG4sQT4gkEUIIUcUVahRc7PTLL2dBzj1JJISoUs5eg8Nxhpel3oKs2xUbjxBPiCQRQghRhRVqFF7dqmHPVf1lBRr400CXayFEJbr5Z/HL1Br47UrFxSIeSUFV6pfQJUmEEEJUYbuvKvx4zXBrw98aQENb+cMmRJXyUhuwsyp++XcHKi4WIZ6gKp1EBAcH4+bmVqq6ycnJuLm5sWzZsicc1X3GxObv74+Xl9cTjqhkxh6fuLg4JkyYQN++fSv0uAoh/qJRFIIOGR48/VpT2OxlYNomIUTlsjCH50sY93A5reJiEeIJknnGhB61Ws20adNQq9UEBARga2tLy5YtKzusChcdHU1cXBzjx48v9WfWr1+Pra1tuSeNsbGx7Nmzh/Pnz3Px4kXy8vIICgoyuJ3g4GAiIyOLXVfjxo3Zvn17ucYnnoy9VxVOpeuXq4ANr5tiZyGtEEJUOWlZcOJy8cs95InVVYv8jpZVlU4ipk+fzqefflrZYTxzkpKSSEpKYvLkyQwfPryyw6k00dHRREZGGpVEbNiwAScnp3JPIg4dOkRYWBguLi60bNmSM2fOFFv3jTfeoHv37nrlx48fJyIigl69epVrbOLJ+SnRcDcmBYjLVOjuJH/8hKhyzt+4/1C54vRtX3GxCPEEPXYSUVhYSEFBATVr1iyPeHSYmZlhZlal85yn0h9//AGAnZ2B6WAeg6Io5OXlYWVVQl/RZ4y/vz8Ay5cvL7Gej48PY8aMwdLSkh9//LHEJKJjx4507NhRr3z37t0A/P3vf3+MiEVFOphU/MxL95OICgxGCFE6nZuCdU24nW94+ZooeOn5io1JiCfAqCv0iIgIZs6cSUhICGfPniUiIoLU1FSmT5+Ol5cXiqKwdetWduzYwdWrVzExMaFt27b4+fnpjR+IjIxk8+bNJCYmolarcXBwoEOHDnz00UfUrl0b+KtbxokTJ3Q++9tvv7Fw4ULi4uKwtrbGw8ODIUOGFBvv0qVL9bbv7+9PSkoKERER2rIjR44QHh7O77//TkZGBubm5rRr146xY8fi6upqzKEqlZMnT/Ltt99y7tw51Go1Li4uDB06lMGDB+vUi42NZcuWLZw5c4a0tDRMTU1p0aIFo0ePpm/fvnrrLe3xMcTf35+TJ08CMHPmTGbOnAnAzp07adCgAXl5eaxcuZL9+/eTnp5OrVq16NGjBxMmTMDJ6a8rmhMnThAQEEBQUBB5eXmEhYVx48YN3n77be2d/X379rFp0yYuXrxIYWGhdp/69eunF9eJEydYt24dsbGx5OXl4ejoiKurK++99x729vYAhIWFER0dzZUrV7h16xZ2dnZ0796dCRMm0KBBA531HTx4kNDQUC5fvkx+fj729va0bduWwMBAnJ2ddY7Dg+dOcV2IHqyXkpKi85miY/c4HBwcHuvzKSkpHDt2jA4dOtC8efPHWpeoOBcyi192PBVGt6u4WIQQpWRvDcsCYNR8w8t/KWb6VyGqmTLd5l+wYAFqtRpvb2+sra1xdnYGYMaMGfzwww94eHjg5eVFQUEBe/bsYdKkScydO5fevXsDsGvXLoKDg+nSpQsBAQFYWFiQlpbGoUOHyMzM1CYRhsTGxjJx4kSsrKwYM2YMtra27Nu3j6CgoLLsio6IiAiys7MZOHAg9erVIz09nfDwcCZOnMjSpUvp0qXLY2+jyIEDB5g6dSoODg6MGjUKKysr9u3bx6xZs0hKSmLSpEnautHR0SQkJNCvXz+cnJzIzs4mMjKSqVOnMmvWLF599VVt3cc9PmPHjqVTp06sXr0ab29v7T7Xrl0btVpNYGAgp0+fxsPDg1GjRpGYmMjWrVs5evQooaGh1KtXT2d9GzZsIDs7m8GDB+Pg4KBdvnjxYlatWsWLL75IQEAAJiYmREVF8cknnzBt2jSGDRumXcfWrVuZPXs2devWZciQITg5OZGamsrPP/9MWlqaNon47rvvaN++PcOHD8fOzo7Lly+zY8cOjh8/zsaNG7X1fv31Vz788EOaN2+Or68vNjY2ZGRkcOzYMa5fv46zszNjx45FURROnTrF559/ro3F0B3+Ip9//jnz5s3D3t6esWPHastLOp8rys6dO9FoNNIKUc10coQDNwwv61xXujIJUWX9wx3GL4HbBuZgNpcJEaoSmbq17MqUROTn57N+/XqdLkxRUVHs2bOHzz77jDfeeENbPmLECHx9ffn6669xd3dHpVIRHR2NtbU1S5Ys0emuFBAQ8Mhtz5s3D41Gw8qVK7XJy9ChQxk3blxZdkXH9OnTsbS01CkbMmQIw4YNY/Xq1eWWRBQWFjJ37lwsLS1Zu3Ytjo6OAAwbNozx48ezdu1avLy8aNKkCQDjxo0jMDBQZx0jRoxg5MiRrFy5UieJeNzj88ILL2BmZsbq1avp2LEjAwcO1C7bvn07p0+fZvTo0bz//vva8h49ejB58mQWLVrEv/71L531paamsmXLFurU+etxuxcuXGDVqlX4+vrqJEsjRozgo48+IiQkBE9PT6ytrUlLS+M///kPLi4urFq1CltbW239CRMmoNH8NXPNxo0b9b4/d3d3Jk6cSHh4OG+99RYAMTExaDQaQkJCdOJ65513dI7D3r17OXXqlM4xKMnAgQNZsmQJderUKfVnKoJGoyEiIgIrKyteeeWVyg5HGOFDNxMO3NCfnUkFuMtDb4Wo2u4WGC6vYV6xcQjxhJRpilcfHx+9MRC7d+/G2tqaPn36kJWVpX3l5ubSq1cvkpOTSUxMBMDGxob8/HwOHjyIopT+aauZmZmcOXOG3r17ay+QAczNzRk5cmRZdkXHgxegd+7cISsrC1NTU9q3b8+5c+cee/1Fzp8/T2pqKoMGDdImEHB/P8aMGYNGoyEmJsZgXPn5+WRlZZGfn0+3bt24evUqubm5wJM/PlFRUZiYmODr66tT3rNnT1q1asWBAwd0LuoBPD09dS7UAfbs2YNKpcLT01PnXMnKysLd3Z3bt29z9uxZAH788UcKCgrw8/PTSSCKmJj8dQoXHSeNRkNubi5ZWVm0atUKGxsbYmNjtfVsbGwA+Omnn1Cr1Y9xRIxTdE49+FKr1ajVar3yO3fulNt2jx49SmpqKv37969y41EyMzO5e/evO3W5ubnk5ORo39+7d087RqdISkpKie9TU1N1fleq8zZebmz4R1oB3oxQV5v9kG0YXmf9+vWfiv2QbRSzDSsLDGrfpHrtRxXZhqh6ytQSUXSH/EEJCQncvn27xDudmZmZODs74+vry8mTJ5kyZQp2dnZ07dqVl156if79+2NtbV3s55OSkgBwcXHRW9asWTPjd+QhN27cICQkhCNHjuic7AAqVfk1dyUnJwOGYy7qr160r3D/uC1ZsoSYmBgyM/U7Sefm5mJjY/PEj09ycjKOjo7UqlXLYNzx8fFkZWXpJA2GzpWrV6+iKAo+Pj7Fbqvox+X69esAtG7d+pHxHT9+nBUrVnDu3DmdHy9A5/scNmwYMTExzJ49m2+++YZOnTrx4osvMmDAgCfa9Wju3LnFTr368DiQ119/neDg4HLZbnh4OIDeWJuq4OEEsyjBK1KjRg298SAPjr0x9P7hC7Pqvg0nGw1Jueg5kW7CLcWGotS6qu+HbEN/nampqU98G0/LsaqW28gvpiXi0796a1SL/agi23hSpDtT2ZUpiTA0E5OiKNSuXZtZs2YV+7miC+QmTZoQFhbGsWPHOH78OCdPnmTWrFksW7aMFStW0KhR+bTTl3ThX1ioO/3anTt38PPzIy8vjzfffJMWLVpgbW2NSqVizZo1HD9+vFxiMpaiKAQGBnL16lVGjBhB27ZtsbGxwcTEhIiICPbu3at3978qKW7WLpVKxcKFC3VaEh5k7ODfc+fOERgYSKNGjQgMDKRBgwZYWFigUqn47LPPdI6Rvb09oaGhnDp1iqNHj3Lq1CnmzZvHsmXLWLBgQYnjHh7HmDFjeO2113TK5s+fD8DkyZN1yh9soXocWVlZxMTE0Lx5czp0kLnJq5u8AoU/8opffrdQQeY4F6IKSr0FBQZauk1NoHl9/XIhqqFymz+1cePGJCYm0qFDh1J1mahRowY9e/akZ8+ewP3ZciZPnsz333/Pxx9/bPAzRTPcJCQk6C27cuWKXlnRHfM///xTb1lycrLOeIxjx45x8+ZNZsyYwaBBg3TqLlmy5JH7Y4yGDRsChmMuKiuqc/HiReLj4/Hz89N7XsGOHTt03ht7fIzVsGFDfvnlF3JycvS6Fl25cgVra2vt4OWSNG7cmMOHD1O/fn2aNm1aYt2iloz4+HidLloP27t3L4WFhSxcuFB77ADy8vL0WpUATE1NcXNz086idPHiRUaNGsXKlStZsGABULbWp5I+06xZM70WoaLj2KNHD6O3VRq7du2ioKBABlRXU3sTFPJLmG5+fwK0rPxx+0KIh209cr/f4cMKNXDiEnR79h7gKp4+ZRoTYYinpycajYZFixYZXP5g37esrCy95W3atAEgOzu72G0UTQMbExPDtWvXtOUFBQWsX79er37RBeixY8d0yvfu3cvNmzd1ykxN78+W8PAYjSNHjuj0py8Pbdq0oX79+kRERJCRkaEtV6vVrFu3DpVKpZ3JquhO/cNxXbp0iejoaJ0yY4+Psfr06YNGo2HNmjU65YcOHSIuLg53d/diWxYeVDToOCQkRK9FCHTPFQ8PD8zNzVmxYoV27MeDio5Lcd/fqlWr9FpqDJ1/Li4u1KxZUyfhLBpjUdI5+TBLS0uDSWtlCQ8Px9zcvEoN9BalZ/WI2zyW8hgdIaqmlFvFL7OsUXFxCPEEldufoH79+uHl5cXmzZu5cOECvXr1wt7envT0dM6cOcONGze0fbMnTZqEra0tXbp0oV69euTk5BAREYFKpXrkxc4HH3zA+PHjGTduHEOHDtVOYWroYtTFxYXu3buzbds2FEWhVatWxMfHEx0dTePGjXUG1Xbu3BkHBwfmz59PSkoKdevWJT4+nt27d9OiRQsuXbpUXocKU1NTpk2bxtSpU3nrrbfw9vbGysqK/fv3c/bsWXx9fbUJUNOmTWnWrBmhoaHk5+fj7OxMYmIi27Zto0WLFpw/f77Mx8dYXl5eREZGsnbtWpKTk+natSvXr19ny5YtODg46My0VJJ27drh7+/P8uXLGTlyJP369cPR0ZGMjAzOnz/PoUOHOHLkCAD16tXjo48+Ys6cOYwYMQJPT0+cnJxIT08nJiaGGTNm0Lp1a/r06cP69et5//338fb2xtzcnKNHj3Lp0iW91pFZs2aRnp5Ojx49cHJy4u7du+zfv5/bt2/j6emprdehQwc2b97M7Nmz6dmzJ2ZmZrRv316npeNhHTp0IDw8nCVLltC0aVNUKhXu7u56s0YZKyUlhV27dgF/tSodOHCAtLQ0AO1xeVBsbCxXrlyhf//+pWohElVPP2cVHR3hzE39ZTVMwae1dGUSokpKNPCftkhuMQ+hE6KaKdf7WEFBQbi5ubF9+3bWrFlDQUEBDg4OtGnTRucC08fHh/3797Nt2zays7Oxs7OjdevWTJs2Te+hcA/r2LEjISEhLFq0iLVr12JjY6N9mNqIESP06n/++ed89dVX7N27l927d9OlSxeWLl3Kl19+qTPy39bWlkWLFrFw4UI2bdpEYWEhbdq0YcGCBYSHh5drEgH3px5dvHgxK1euZN26dRQUFODi4sL06dN1BsCampqyYMEC5s+fT2RkJHl5eTRv3pzg4GDi4+P1kghjj48xzMzMWLRokfZhc1FRUdja2uLh4cHEiRP1BlaVxN/fn7Zt27Jx40Y2bNhAXl4ederUoXnz5kyZMkWnro+PD40aNSI0NJSNGzdSUFCAo6Mj3bp10z53onPnzsydO5dvv/2WpUuXYmFhQffu3Vm+fDl+fn466xs4cCARERHs2rWLW7duYW1tTbNmzZgzZw4eHh7aegMGDCAuLo59+/bxv//9D41GQ1BQUIlJxMSJE8nOziYsLIycnBwURWHnzp2PnUQkJSWxdOlSnbKoqCiioqK0+/9wElGUtEtXpurL1ERF1DBTmiwv5PZDYzTb1gHbGpJECFElldQdVl11xzEKYQyVYswcq0IIISrU4SSFlzbotyT+uyd8+oL0Z6quCgoKWL16NQC+vr6Ym8uzA54qB85B738aXnZsjoyJqEJyVB+Wuq6tMu8JRlL9lNuYCCGEEOXvVr7h+zw/JFRsHEIII7i3g1qGZycku/yeAyQen4Kq1C+hS5IIIYSowl5uouI5A73hYm7AwRvSkCxElfVKZ8PlrsZNYS5EVSVJhBBCVGGW5ipWDjD8U52YI0mEEFVW32KezZNTwsNfhKhGpEOtEEJUca84g4kKNA/lDDbSjV6IqsvQw+ZqmkOT8nmYqCgv0k2prKQlQgghqribeSq9BAIg5XbFxyKEKKVUA88YumcgsRCimpIkQgghqrhGttDCXr+8dyO5gyZEldW7rX5ZcV2chKiGJIkQQogqTqVS8Z2nKc617r+3MYeFL5vQxkGSCCGqrFe7wsfeUOP/9xxv3wSWjq/cmIQoRzImQgghqoEeTiqu+Jly8RY0tAEbedCcEFXf7NH3E4k/cqCF06PriwonU7eWnSQRQghRTZioVLSuU9lRCCGMUtvm/kuIp4x0ZxJCCCGEEEIYRVoihBBCCCHEM0m6M5WdtEQIIYQQQgghjCJJhBBCCCGEEMIo0p1JCCGEEEI8o6Q7U1lJS4QQQgghhBDCKJJECCGEEEIIIYwiSYQQQgghRGUrLITcvMqOQohSkyRCCCGEEKIyrdgPTuPA9h/QdwZcz6jsiJ4ZihEvoUuSCCGEEEKIynLqCoxfCjf/vP8+Ohbe/qZyYxKiFCSJEEIIIYSoLDM3gfLQfe6fzkL+vcqJR4hSkilehRDiKZR+W+HfRzWcSlf4WwMVn3Q3wb6mTGUoRJWSdxf2/aZf7mALFuYVHs6zSJ5YXXaSRAghxFNGoyj0Cyvk7P/vVn3ghsLh5EIOjJCffCGqlLRsyCvQL3+tC6jk4lZUbdKdSQghnjLRiYo2gSjy8w04lyFDA4WoUurYGC7v4FyxcQhRBpJECCHEUyYs3nCy8HC3ayFEJTt5xXC5Y62KjUOIMpC2bSGEeMrsvaqfLagAR6uKj0UIUYJf4gyXv9K5QsN4tkm3sbKSlgghhHiKJOcqXPtTv1wBvjmlqfB4hBAlaFDHcPmNPyo2DiHKoEonEcHBwbi5uZWqbnJyMm5ubixbtuwJR3WfMbH5+/vj5eX1hCMqmbHHJy4ujgkTJtC3b98KPa5CiMdzPaf4hyJFXpb+TEJUKV2aGi7fdKhi4xCiDKQ7k9CjVquZNm0aarWagIAAbG1tadmyZWWHVeGio6OJi4tj/Pjxpf7M+vXrsbW1LfekMTY2lj179nD+/HkuXrxIXl4eQUFBpdpORkYGQ4cOJScnh/fff5/Ro0eXa2yiaulSF+rUhMx8/WW//wEFhQrmptJ8L0SV0L4J1DCDe2rd8tNXKyeeZ5BM8Vp2VbolYvr06Rw6JNl4RUtKSiIpKYk333yT4cOHM3DgwGc2iVixYoVRn9mwYQMRERHlHsuhQ4cICwsjNzfX6O9i7ty5FBYWlntMomqqYaqiw3OGlxVoYPkZaY0QosrIzQe1gd/nGnKPV1R9j51EFBYWkp9v4JZXOTAzM8PCwuKJrFsU748/7vfFtLOzK9f1KorCnTt3ynWd1Z2/vz/+/v6PrOfj40NMTAybN29m5MiRpV5/TEwM0dHRvPPOO48TpqhmLmQWvyzmuiQRQlQZmw+BxsD/ya7NKj4WIYxkVKobERHBzJkzCQkJ4ezZs0RERJCamsr06dPx8vJCURS2bt3Kjh07uHr1KiYmJrRt2xY/Pz+98QORkZFs3ryZxMRE1Go1Dg4OdOjQgY8++ojatWsD98cdREZGcuLECZ3P/vbbbyxcuJC4uDisra3x8PBgyJAhxca7dOlSve37+/uTkpKic9f4yJEjhIeH8/vvv5ORkYG5uTnt2rVj7NixuLq6GnOoSuXkyZN8++23nDt3DrVajYuLC0OHDmXw4ME69WJjY9myZQtnzpwhLS0NU1NTWrRowejRo+nbt6/eekt7fAzx9/fn5MmTAMycOZOZM2cCsHPnTho0aEBeXh4rV65k//79pKenU6tWLXr06MGECRNwcnLSrufEiRMEBAQQFBREXl4eYWFh3Lhxg7ffflvbPWjfvn1s2rSJixcvUlhYqN2nfv366cV14sQJ1q1bR2xsLHl5eTg6OuLq6sp7772Hvb09AGFhYURHR3PlyhVu3bqFnZ0d3bt3Z8KECTRo0EBnfQcPHiQ0NJTLly+Tn5+Pvb09bdu2JTAwEGdnZ53j8OC5U1IXoqJ6KSkpOp8pOnaPw8HBwejP3L59m7lz5zJkyBDatm37WNsX1UthCXnCzTxQaxTMTKQJX4hKV9zYh9v3KjaOZ5h0Zyq7MrWXLViwALVajbe3N9bW1jg7338oyowZM/jhhx/w8PDAy8uLgoIC9uzZw6RJk5g7dy69e/cGYNeuXQQHB9OlSxcCAgKwsLAgLS2NQ4cOkZmZqU0iDImNjWXixIlYWVkxZswYbG1t2bdvH0FBQWXZFR0RERFkZ2czcOBA6tWrR3p6OuHh4UycOJGlS5fSpUuXx95GkQMHDjB16lQcHBwYNWoUVlZW7Nu3j1mzZpGUlMSkSZO0daOjo0lISKBfv344OTmRnZ1NZGQkU6dOZdasWbz66qvauo97fMaOHUunTp1YvXo13t7e2n2uXbs2arWawMBATp8+jYeHB6NGjSIxMZGtW7dy9OhRQkNDqVevns76NmzYQHZ2NoMHD8bBwUG7fPHixaxatYoXX3yRgIAATExMiIqK4pNPPmHatGkMGzZMu46tW7cye/Zs6taty5AhQ3ByciI1NZWff/6ZtLQ0bRLx3Xff0b59e4YPH46dnR2XL19mx44dHD9+nI0bN2rr/frrr3z44Yc0b94cX19fbGxsyMjI4NixY1y/fh1nZ2fGjh2LoiicOnWKzz//XBtLx44diz12n3/+OfPmzcPe3p6xY8dqy0s6n5+kRYsWUVhYyKRJk7hw4UKlxCAqh1kJfxOjrysEHdLwRS/TigtICKGvQA0xvxtelptXsbEIUQZlSiLy8/NZv349NWvW1JZFRUWxZ88ePvvsM9544w1t+YgRI/D19eXrr7/G3d0dlUpFdHQ01tbWLFmyBDOzv0IICAh45LbnzZuHRqNh5cqV2uRl6NChjBs3riy7omP69OlYWlrqlA0ZMoRhw4axevXqcksiCgsLmTt3LpaWlqxduxZHR0cAhg0bxvjx41m7di1eXl40adIEgHHjxhEYGKizjhEjRjBy5EhWrlypk0Q87vF54YUXMDMzY/Xq1XTs2JGBAwdql23fvp3Tp08zevRo3n//fW15jx49mDx5MosWLeJf//qXzvpSU1PZsmULder8NY3dhQsXWLVqFb6+vjrJ0ogRI/joo48ICQnB09MTa2tr0tLS+M9//oOLiwurVq3C1tZWW3/ChAloNH9NWblx40a978/d3Z2JEycSHh7OW2+9Bdzv4qPRaAgJCdGJ68EuPy+88AJ79+7l1KlTOsegJAMHDmTJkiXUqVOn1J95Us6ePcvWrVuZNWsWNjbFPBFVPLXsLCC1hJ6Dob8rfNGr4uIRQhhw4Pf7iYQhg7pVbCxClEGZxkT4+PjoJBAAu3fvxtramj59+pCVlaV95ebm0qtXL5KTk0lMTATAxsaG/Px8Dh48iGLEI1QzMzM5c+YMvXv31l4gA5ibmxvVT7w4D16A3rlzh6ysLExNTWnfvj3nzp177PUXOX/+PKmpqQwaNEibQMD9/RgzZgwajYaYmBiDceXn55OVlUV+fj7dunXj6tWr5ObmAk/++ERFRWFiYoKvr69Oec+ePWnVqhUHDhzQuagH8PT01LlQB9izZw8qlQpPT0+dcyUrKwt3d3du377N2bNnAfjxxx8pKCjAz89PJ4EoYmLy1ylcdJw0Gg25ublkZWXRqlUrbGxsiI2N1dYruqj+6aefUKuL+QF/AorOqQdfarUatVqtV/44Y0fUajWzZs2iR48evPLKK+W4B+UvMzOTu3fvat/n5uaSk5OjfX/v3j3tGJ0iKSkpJb5PTU3V+V15FrdRUncmAGvz6rEfT/s26tev/1Tsh2yjjNuwLmHM5/9/fkS12I8K2oaoesrUElF0h/xBCQkJ3L59u8SLlszMTJydnfH19eXkyZNMmTIFOzs7unbtyksvvUT//v2xtrYu9vNJSUkAuLi46C1r1uzxByHduHGDkJAQjhw5onOyA6hU5ddnLjk5GTAcc/PmzYG/9hXuH7clS5YQExNDZqb+iMnc3FxsbGye+PFJTk7G0dGRWrVqGYw7Pj6erKwsnaTB0Lly9epVFEXBx8en2G0V/bhcv34dgNatWz8yvuPHj7NixQrOnTun8+MF6Hyfw4YNIyYmhtmzZ/PNN9/QqVMnXnzxRQYMGPBEux7NnTuXyMhIg8seHgfy+uuvExwcXKbtrFmzhhs3bvD111+X6fMV6eEE8+FWkxo1auiNB3lw7I2h9w9fmD2L27j3iMm4priZPPY2iou7uh2rytxGamrqE9/G03Ksnspt9GhFsaLPgVuL6rEfFbQNUfWUKYl4uBUC7s+8U7t2bWbNmlXs54oukJs0aUJYWBjHjh3j+PHjnDx5klmzZrFs2TJWrFhBo0aNyhKWnpIu/B+e8vLOnTv4+fmRl5fHm2++SYsWLbC2tkalUrFmzRqOHz9eLjEZS1EUAgMDuXr1KiNGjKBt27bY2NhgYmJCREQEe/fu1bv7X5UYOlfg/nezcOFCnZaEBxWdK6V17tw5AgMDadSoEYGBgTRo0AALCwtUKhWfffaZzjGyt7cnNDSUU6dOcfToUU6dOsW8efNYtmwZCxYsKHHcw+MYM2YMr732mk7Z/PnzAZg8ebJO+YMtVMbIyMhg9erVeHp6oiiKNgm7efMmANnZ2Vy/fp3nnntOr+uXeHo0t4fEHMPLtg4y4Y1WVXp2byGeDSoVdGgCZxP1l2UW8x9YiCqk3CYibty4MYmJiXTo0AErK6tH1q9RowY9e/akZ8+ewP3ZciZPnsz333/Pxx9/bPAzRTPcJCQk6C27cuWKXlnRHfM///xTb1lycrLOeIxjx45x8+ZNZsyYwaBBg3TqLlmy5JH7Y4yGDRsChmMuKiuqc/HiReLj4/Hz89N76NmOHTt03ht7fIzVsGFDfvnlF3JycvS6Fl25cgVra2vt4OWSNG7cmMOHD1O/fn2aNi3maZ3/X1FLRnx8vE4XrYft3buXwsJCFi5cqD12AHl5eXqtSgCmpqa4ublpZ1G6ePEio0aNYuXKlSxYsAAoW+tTSZ9p1qyZXotQ0XHs0aOH0dsy5I8//uDu3bts27aNbdu26S1fs2YNa9asYfbs2QZnwRJPB+8WKqKKmcq1Z0OZiUSIKmP+WPAI1i+/drPCQxHCWOV2O8rT0xONRsOiRYsMLn+w71tWVpbe8jZt2gD375QWp2ga2JiYGK5du6YtLygoYP369Xr1iy5Ajx07plO+d+9e7Z3ZIqam92cqeXiMxpEjR3T605eHNm3aUL9+fSIiIsjIyNCWq9Vq1q1bh0ql0s5kVXSn/uG4Ll26RHR0tE6ZscfHWH369EGj0bBmzRqd8kOHDhEXF4e7u3uxLQsPKhp0HBISYvAhaA+eKx4eHpibm7NixQrt2I8HFR2X4r6/VatW6bXUGDr/XFxcqFmzpk7CWXSnvqRz8mGWlpYGk9aK0rBhQ2bPnq33KnoWhaenJ7Nnz35irS2iamii3+MQuD9rU11rSSKEqDJe7giWNfTL00v/d0c8HgVVqV9CV7m1RPTr1w8vLy82b97MhQsX6NWrF/b29qSnp3PmzBlu3LhBeHg4AJMmTcLW1pYuXbpQr149cnJyiIiIQKVSPXJWmw8++IDx48czbtw4hg4dqp3C1NDFqIuLC927d2fbtm0oikKrVq2Ij48nOjqaxo0b6wyq7dy5Mw4ODsyfP5+UlBTq1q1LfHw8u3fvpkWLFly6dKm8DhWmpqZMmzaNqVOn8tZbb+Ht7Y2VlRX79+/n7Nmz+Pr6ahOgpk2b0qxZM0JDQ8nPz8fZ2ZnExES2bdtGixYtOH/+fJmPj7G8vLyIjIxk7dq1JCcn07VrV65fv86WLVtwcHDQmWmpJO3atcPf35/ly5czcuRI+vXrh6OjIxkZGZw/f55Dhw5x5MgRAOrVq8dHH33EnDlzGDFiBJ6enjg5OZGenk5MTAwzZsygdevW9OnTh/Xr1/P+++/j7e2Nubk5R48e5dKlS3qtI7NmzSI9PZ0ePXrg5OTE3bt32b9/P7dv38bT01Nbr0OHDmzevJnZs2fTs2dPzMzMaN++vU5Lx8M6dOhAeHg4S5YsoWnTpqhUKtzd3R+761BKSgq7du0C/mpVOnDgAGlpaQDa42JjY1PsczYAWrRoIS0Qz4DaNVWAfktEI/25CYQQlel2Ptwt0C+3L358qBBVRbk+Vz0oKAg3Nze2b9/OmjVrKCgowMHBgTZt2uhcYPr4+LB//362bdtGdnY2dnZ2tG7dmmnTpuk9FO5hHTt2JCQkhEWLFrF27VpsbGy0D1MbMWKEXv3PP/+cr776ir1797J79266dOnC0qVL+fLLL3VG/tva2rJo0SIWLlzIpk2bKCwspE2bNixYsIDw8PByTSLg/tSjixcvZuXKlaxbt46CggJcXFyYPn26zsPmTE1NWbBgAfPnzycyMpK8vDyaN29OcHAw8fHxekmEscfHGGZmZixatEj7sLmoqChsbW3x8PBg4sSJegOrSuLv70/btm3ZuHEjGzZsIC8vjzp16tC8eXOmTJmiU9fHx4dGjRoRGhrKxo0bKSgowNHRkW7dummfO9G5c2fmzp3Lt99+y9KlS7GwsKB79+4sX74cPz8/nfUNHDiQiIgIdu3axa1bt7C2tqZZs2bMmTMHDw8Pbb0BAwYQFxfHvn37+N///odGoyEoKKjEJGLixIlkZ2cTFhZGTk4OiqKwc+fOx04ikpKSWLp0qU5ZVFQUUVFR2v2XQWiiiKEH4AJ4t5Q7aUJUKbGJhv/DvlDCoGshqgiVYswcq0IIIaq8r48XMiVG/6f9qp8pLnaSSFQFBQUFrF69GgBfX1/Mzc0rOSJRKTb+DG/+V7/8zH+hQ/HjAEX5SVf9s9R16yr/enSlZ4hM0SGEEE+Z9GIeM1LcWAkhRCXJN9CVCaBGuXYUEeKJkCRCCCGeMtbF3NTOKPszDIUQT0KbYqa033iwYuMQogwkiRBCiKdMR0f9LktWZmBjYBIYIUQlal4Pg5P+rIuu4ECEMJ4kEUII8ZTxbKbCrZ5u2bTuJliZy3gIIaoURztwa6FffjkNZMhqBVEZ8RIPkk53QgjxlDE3VREzwpR1vytcvKXQ31nFgKZyz0iIKiloGLz+b92yv7W+/0RrIaowSSKEEOIpZGWuYnwnuQgRosrzdIP3PCFkDxRqoGk9WB5Q2VEJ8UiSRAghhBBCVKYF4+ATb0jLho7OYCIthxVFOo2VnSQRQgghhBCVzanO/ZcQ1YSkukIIIYQQQgijSBIhhBBCCCGEMIp0ZxJCCCGEEM8kRaZuLTNpiRBCCCGEEEIYRZIIIYQQQgghhFGkO5MQQgghhHgmSXemspOWCCGEEEIIIYRRJIkQQgghhBBCGEW6MwkhhBBCiGeUdGcqK0kihBBCCCHKKus2LPsB4pLBowOMdAeVXJiKp58kEUIIIYQQZVGgBvfpcPba/ferf4Ljl2D+uMqNS4gKIGMihBCimjl4Q+GN8EI8Nhey8qymssMR4tm169e/EogiS36A7NuVE48QFUhaIoQQoho5labw8uZCCv5/7vBTokLOPZjsKveEhKhw6dn6ZffUkHcP7KwrPh5hNJnitezkr44QQlQjK89qtAlEkaWnpTVCiCrFRC5MxdNPkgghhKhGYjMUvbKcu5UQiBACfjxjuFwGVotngHRnEkKIaiTLQMJQqJ9XCCEqwqkr+mVNngNHu4qPRZSJ/HyWnbRECCFENdLQRv8OZ9od2J8gXZqEqHC5+fplrRpUfBxCVAJJIoQQohqZ2s1wN4ndV+V+mhAV6noGZOTol6fcqvhYhKgEVTqJCA4Oxs3NrVR1k5OTcXNzY9myZU84qvuMic3f3x8vL68nHFHJjD0+cXFxTJgwgb59+1bocRVClMysmF9te4uKjUOIZ96UNaAu1C8/dx2uplV4OEJUNBkTIfSo1WqmTZuGWq0mICAAW1tbWrZsWdlhVbjo6Gji4uIYP358qT+zfv16bG1tyzVpVBSFPXv28PPPP3P+/Hlu3ryJvb09rVq1Yty4cbRv316n/rVr19izZw9Hjhzhxo0b3Lt3j0aNGuHh4cHIkSOxtLQst9hExVEUhX/s0rDhguEWB2fbCg5IiGdd9Lnilx2+AE3rVVwsosxkiteyq9ItEdOnT+fQoUOVHcYzJykpiaSkJN58802GDx/OwIEDn9kkYsWKFUZ9ZsOGDURERJRrHPfu3WPGjBlcu3aNV155halTp+Lt7U1cXBy+vr7s3r1bp/7OnTtZv349jRo14p133uG9997D2dmZJUuWMHbsWPLzDfThFVXej9eUYhMIgA6O8odQiApV0jSunVwqLAwhKstjt0QUFhZSUFBAzZo1yyMeHWZmZpiZSWNJRfvjjz8AsLMr39klFEUhLy8PKyurcl1vdebv7w/A8uXLi61jamrKsmXLcHV11Sn39vZm2LBhzJ8/n1dffRUTk/v3BDw8PPD19cXGxkZb18fHh8aNG7Nq1SrCw8MZPnz4E9gb8SR9f77kMQ//2K3h6D9U2FlIMiFEhahpbri8vj20d67QUISoDEZdoUdERDBz5kxCQkI4e/YsERERpKamMn36dLy8vFAUha1bt7Jjxw6uXr2KiYkJbdu2xc/PT2/8QGRkJJs3byYxMRG1Wo2DgwMdOnTgo48+onbt2sD9cQeRkZGcOHFC57O//fYbCxcuJC4uDmtrazw8PBgyZEix8S5dulRv+/7+/qSkpOjcNT5y5Ajh4eH8/vvvZGRkYG5uTrt27Rg7dqzeBVx5OHnyJN9++y3nzp1DrVbj4uLC0KFDGTx4sE692NhYtmzZwpkzZ0hLS8PU1JQWLVowevRo+vbtq7fe0h4fQ/z9/Tl58iQAM2fOZObMmcD9u9sNGjQgLy+PlStXsn//ftLT06lVqxY9evRgwoQJODk5addz4sQJAgICCAoKIi8vj7CwMG7cuMHbb7+t7R60b98+Nm3axMWLFyksLNTuU79+/fTiOnHiBOvWrSM2Npa8vDwcHR1xdXXlvffew97eHoCwsDCio6O5cuUKt27dws7Oju7duzNhwgQaNNCdLePgwYOEhoZy+fJl8vPzsbe3p23btgQGBuLs7KxzHB48d4KCgortqlRULyUlReczRceurMzMzAyefw4ODnTt2pWoqCgyMzN57rnnAGjbtq3B9bzyyiusWrWKy5cvlzkWUXmir5ecRMRlwppYhfddJYkQokK0cIKEm/rlf+ZBgRrM5SZo9SC/mWVVpjN8wYIFqNVqvL29sba2xtn5fsY9Y8YMfvjhBzw8PPDy8qKgoIA9e/YwadIk5s6dS+/evQHYtWsXwcHBdOnShYCAACwsLEhLS+PQoUNkZmZqkwhDYmNjmThxIlZWVowZMwZbW1v27dtHUFBQWXZFR0REBNnZ2QwcOJB69eqRnp5OeHg4EydOZOnSpXTp0uWxt1HkwIEDTJ06FQcHB0aNGoWVlRX79u1j1qxZJCUlMWnSJG3d6OhoEhIS6NevH05OTmRnZxMZGcnUqVOZNWsWr776qrbu4x6fsWPH0qlTJ1avXo23t7d2n2vXro1arSYwMJDTp0/j4eHBqFGjSExMZOvWrRw9epTQ0FDq1dPtA7phwways7MZPHgwDg4O2uWLFy9m1apVvPjiiwQEBGBiYkJUVBSffPIJ06ZNY9iwYdp1bN26ldmzZ1O3bl2GDBmCk5MTqamp/Pzzz6SlpWmTiO+++4727dszfPhw7OzsuHz5Mjt27OD48eNs3LhRW+/XX3/lww8/pHnz5to79hkZGRw7dozr16/j7OzM2LFjURSFU6dO8fnnn2tj6dixY7HH7vPPP2fevHnY29szduxYbXlJ5/PjSk9Px9zcHFvbR3eIT0u7P9DPwcHhicUjnpzU24+ucy1bQxXvpSrE06N3O8MPm7tz9/7Ur7Vt9JcJ8RQpUxKRn5/P+vXrdbowRUVFsWfPHj777DPeeOMNbfmIESPw9fXl66+/xt3dHZVKRXR0NNbW1ixZskSnu1JAQMAjtz1v3jw0Gg0rV67UJi9Dhw5l3LhxZdkVHdOnT9cbdDpkyBCGDRvG6tWryy2JKCwsZO7cuVhaWrJ27VocHR0BGDZsGOPHj2ft2rV4eXnRpEkTAMaNG0dgYKDOOkaMGMHIkSNZuXKlThLxuMfnhRdewMzMjNWrV9OxY0cGDhyoXbZ9+3ZOnz7N6NGjef/997XlPXr0YPLkySxatIh//etfOutLTU1ly5Yt1KlTR1t24cIFVq1aha+vr06yNGLECD766CNCQkLw9PTE2tqatLQ0/vOf/+Di4sKqVat0LpYnTJiARvPX3PgbN27U+/7c3d2ZOHEi4eHhvPXWWwDExMSg0WgICQnRieudd97ROQ579+7l1KlTOsegJAMHDmTJkiXUqVOn1J95HAcPHuTcuXMMHDgQC4uSp+YpLCxk5cqVmJqaMmDAgCcemyh/VmZw18BEMA9ysZM7akJUmOb1DZc3cZAEQjwTynTLysfHR28MxO7du7G2tqZPnz5kZWVpX7m5ufTq1Yvk5GQSExMBsLGxIT8/n4MHD6IopZ/bPDMzkzNnztC7d2/tBTKAubk5I0eOLMuu6HjwAvTOnTtkZWVhampK+/btOXeuhFkYjHT+/HlSU1MZNGiQNoGA+/sxZswYNBoNMTExBuPKz88nKyuL/Px8unXrxtWrV8nNzQWe/PGJiorCxMQEX19fnfKePXvSqlUrDhw4oHNRD+Dp6alzoQ6wZ88eVCoVnp6eOudKVlYW7u7u3L59m7NnzwLw448/UlBQgJ+fn8G77UXjAOCv46TRaMjNzSUrK4tWrVphY2NDbGystl7RWIGffvoJtVr9GEfEOEXn1IMvtVqNWq3WK79z506J60pMTCQoKIi6devywQcfPHLbX3/9NWfOnCEgIAAXF5dy2qPHl5mZyd27fz2COTc3l5ycv+Zdv3fvnnaMTpGUlJQS36empur8rjwt27Azf0QGATxnmlvl90O28Zf69XUvQqvrfjyr28hTivn78cCfweqwH9VlG0+KgqrUL6GrTC0RRXfIH5SQkMDt27d55ZVXiv1cZmYmzs7O+Pr6cvLkSaZMmYKdnR1du3blpZdeon///lhbWxf7+aSkJACDF0HNmjUzfkcecuPGDUJCQjhy5IjOyQ6gUpXfyZOcnAwYjrl58+bAX/sK94/bkiVLiImJITMzU+8zubm52NjYPPHjk5ycjKOjI7Vq1TIYd3x8PFlZWTpJg6Fz5erVqyiKgo+PT7HbKvpxuX79OgCtW7d+ZHzHjx9nxYoVnDt3TufHC9D5PocNG0ZMTAyzZ8/mm2++oVOnTrz44osMGDDgiXY9mjt3LpGRkQaXPTwO5PXXXyc4ONhg3aSkJCZMmADAwoULHxnzkiVL2Lx5M97e3noJYGV7OMF8cDA4QI0aNfS6Xz049sbQ+4cvzJ6Wbbza3JSlpylWbQt4o73u/82quB+yjb+kpqY+8W08LceqKm7DsrhJQm78AYk3oYljtdiP6rINUfWUKYkwNBOToijUrl2bWbNmFfu5ogvkJk2aEBYWxrFjxzh+/DgnT55k1qxZLFu2jBUrVtCoUaOyhKWnpAv/wkLdu3p37tzBz8+PvLw83nzzTVq0aIG1tTUqlYo1a9Zw/PjxconJWIqiEBgYyNWrVxkxYgRt27bFxsYGExMTIiIi2Lt3r97d/6qkuFm7VCoVCxcu1GlJeFDRuVJa586dIzAwkEaNGhEYGEiDBg2wsLBApVLx2Wef6Rwje3t7QkNDOXXqFEePHuXUqVPMmzePZcuWsWDBghLHPTyOMWPG8Nprr+mUzZ8/H4DJkyfrlD/YQvWg5ORkAgICyMvLY/HixbRo0aLEbS5btoyVK1fi5eXFZ599VubYReUzU6mA4ltuuztBTTO5UyZEhSnpgXIlTf8qxFOi3KYOaNy4MYmJiXTo0KFUU3jWqFGDnj170rNnT+B+/+7Jkyfz/fff8/HHHxv8TNEMNwkJCXrLrly5oldWdMf8zz//1FuWnJysMx7j2LFj3Lx5kxkzZjBo0CCdukuWLHnk/hijYcOGgOGYi8qK6ly8eJH4+Hj8/Pz0Hnq2Y8cOnffGHh9jNWzYkF9++YWcnBy9rkVXrlzB2tpaO3i5JI0bN+bw4cPUr1+fpk2blli3qCUjPj5ep4vWw/bu3UthYSELFy7UHjuAvLw8vVYluD9tqpubm3YWpYsXLzJq1ChWrlzJggULgLK1PpX0mWbNmum1CBUdxx49ejxy3cnJyYwfP57c3FwWL15MmzZtSqxflJS//vrr/POf/yzX1jRR8WJulNz186yBSWKEEE/QtWL+0zWqA42eq9hYhKgE5TaNh6enJxqNhkWLFhlc/mDft6ysLL3lRRdE2dnZxW6jaBrYmJgYrl27pi0vKChg/fr1evWLLkCPHTumU753715u3tT9z29qagqgN0bjyJEjOv3py0ObNm2oX78+ERERZGRkaMvVajXr1q1DpVJpZ7IqulP/cFyXLl0iOjpap8zY42OsPn36oNFoWLNmjU75oUOHiIuLw93dvdiWhQcVDToOCQnRaxEC3XPFw8MDc3NzVqxYoR378aCi41Lc97dq1Sq9lhpD55+Liws1a9bUSTiLxliUdE4+zNLS0mDS+rhSUlIICAggJyeHRYsW8fzzz5dYf8WKFaxYsYKBAwcyY8aMUn0vomqr84hH8dypuOE9QggAx2KepWRtabhcVEmKES+hq9xaIvr164eXlxebN2/mwoUL9OrVC3t7e9LT0zlz5gw3btwgPDwcgEmTJmFra0uXLl2oV68eOTk5REREoFKpHjmrzQcffMD48eMZN24cQ4cO1U5hauhi1MXFhe7du7Nt2zYURaFVq1bEx8cTHR1N48aNdQbVdu7cGQcHB+bPn09KSgp169YlPj6e3bt306JFCy5dulRehwpTU1OmTZvG1KlTeeutt/D29sbKyor9+/dz9uxZfH19tQlQ06ZNadasGaGhoeTn5+Ps7ExiYiLbtm2jRYsWnD9/vszHx1heXl5ERkaydu1akpOT6dq1K9evX2fLli04ODjozLRUknbt2uHv78/y5csZOXIk/fr1w9HRkYyMDM6fP8+hQ4c4cuQIAPXq1eOjjz5izpw5jBgxAk9PT5ycnEhPTycmJoYZM2bQunVr+vTpw/r163n//ffx9vbG3Nyco0ePcunSJb3WkVmzZpGenk6PHj1wcnLi7t277N+/n9u3b+Pp6amt16FDBzZv3szs2bPp2bMnZmZmtG/fXqel42EdOnQgPDycJUuW0LRpU1QqFe7u7nqzRhnj9u3bBAQEkJyczPDhw7l27ZpOkgj3WzKK+pdu3ryZZcuWUb9+fbp3787evXt16tapU4cXXnihzPGIyvFJDxMOJmkoLOYvWb4kEUJUrHEeMHMTFDz09zUpw3B9IZ4y5foklKCgINzc3Ni+fTtr1qyhoKAABwcH2rRpo3OB6ePjw/79+9m2bRvZ2dnY2dnRunVrpk2bpvdQuId17NiRkJAQFi1axNq1a7GxsdE+TG3EiBF69T///HO++uor9u7dy+7du+nSpQtLly7lyy+/1Bn5b2try6JFi1i4cCGbNm2isLCQNm3asGDBAsLDw8s1iYD7U48uXryYlStXsm7dOgoKCnBxcWH69Ok6D5szNTVlwYIFzJ8/n8jISPLy8mjevDnBwcHEx8frJRHGHh9jmJmZsWjRIu3D5qKiorC1tcXDw4OJEyfqDawqib+/P23btmXjxo1s2LCBvLw86tSpQ/PmzZkyZYpOXR8fHxo1akRoaCgbN26koKAAR0dHunXrpn3uROfOnZk7dy7ffvstS5cuxcLCgu7du7N8+XL8/Px01jdw4EAiIiLYtWsXt27dwtrammbNmjFnzhw8PDy09QYMGEBcXBz79u3jf//7HxqNhqCgoBKTiIkTJ5KdnU1YWBg5OTkoisLOnTsfK4nIzs7WDprftGmTwTpLly7VJhG///47cH/QpqHB2V27dpUkohp6takJx0apWHxKw8pY/Uyi5ZObE0AIYUj92tCgjn63puJaKIR4yqgUY+ZYFUIIUam2xGkYGqE/mcI3L5sQ2FW6rVUXBQUFrF69GgBfX1/Mzc0rOSJRJjWG6rdEvNwB/jezcuIRRrum+nep6zorMkHJg+QvjhBCVCOt6xgu71i3YuMQQnC/JeJhyfpTsQvxNJIkQgghqhELU8OzbF26JY3KQlQ4JwP9CNOyKjwMISpDuY6JEEII8WQ1tr3/3NSHU4a7MrBaiIpnqNXBUOuEqLLkSdRlJy0RQghRjeQXqgxONXhPI38IhahwqVn6ZV2Ne1iqENWVJBFCCFGN1K6poudDE4SZqsCzmSQRQlSotCwoMNAE2KZBhYciRGWQJEIIIaqZ7z1N6e+sQgW41IINr5vQorYkEUJUqDt3DT+BrKUkEeLZIGMihBCimmlSS8W+oaYUahRMTSR5EKJSNK0HL7WBQxf+KnOsBa91qbyYRBnIb2hZSUuEEEJUU5JACFHJtk2Dt/veTyhed7v/fAibsj9cVIjqRFoihBBCCCHKoq49rH63sqMQolJIEiGEEEIIIZ5J8oSdspPuTEIIIYQQQgijSBIhhBBCCCGEMIokEUIIIYQQQgijyJgIIYQQQgjxTFJkitcyk5YIIYQQQgghhFEkiRBCCCGEEEIYRbozCSGEEEKIZ5J0Zyo7SSKEEEIIIcribgHM3Q77TkPz+vDZEGjVoLKjEqJCSBIhhBBCCFEW/ksgNPr+vw+eh92/QnwI2FtXalhCVAQZEyGEEEIIYaycPPguRrfs5p+w7UjlxCPKREFV6pfQJUmEEEIIIYSxbmSARtEvz82r+FiEqASSRAghhBBCGOuTdYbLm9ev2DiEqCSSRAghhBBCGENR7g+mfpiJCbzYpuLjEaISyMBqIYQQQghjmRi4D2tmAjY1Kz4WUWYGOqSJUpKWCCGEeIrl3FPYGq8hKlGDosifSyHKhUoFPQ20ONxTQ8qtio9HiEogSYQQQjylfk1VcFleiM9ODS9v1tBzQyG370kiIUS5eN3NcPmqnyo2DiEqiSQRQgjxlArYX0hm/l/vDyeD23eFHEuRREKIx3brtuHyL7bAn3cqNhbxGFRGvMSDqnQSERwcjJtbMZn+Q5KTk3Fzc2PZsmVPOKr7jInN398fLy+vJxxRyYw9PnFxcUyYMIG+fftW6HEVQpSPW/kKv6bpl1/IhH5hhaTdlkRCiMcSGmW4XF0IIXsqNhYhKoEMrBZ61Go106ZNQ61WExAQgK2tLS1btqzssCpcdHQ0cXFxjB8/vtSfWb9+Pba2tuWeNMbGxrJnzx7Onz/PxYsXycvLIygoqNjtZGVlsXbtWg4cOEBqaio2NjY0bdqUESNG0KdPn3KNTVRNXx3XFDtgMOcebL+oENBZ7qwJUSbX0uGygSy9SFQsfDqk4uIRohJU6ZaI6dOnc+jQocoO45mTlJREUlISb775JsOHD2fgwIHPbBKxYsUKoz6zYcMGIiIiyj2WQ4cOERYWRm5u7iO/i//H3n1HR1WtDRz+TUlPSEgIEGroSO8oQkSDIgkoSOdSBC6hiNeCcv0UaXKvgFelSpMiKr2HJogQinSQJr0lpBBCSEhCypTz/REyZDIz6SGU91kra2X27H32Pmfaec8uJyUlhUGDBrFq1SpefPFFPv30U/r06cPdu3f55JNPWLNmTaG3Tzx5Vl/MvqfB1f4xNUSIZ5GjffrkalvcnB5fW0SByB2r86/APREGgwGdToejY+EvaabVatFqpbPkcbt79y4A7u7uhbpdRVFITk7G2dm5ULf7NAsKCgJg/vz52ebr1q0b/fv3x8nJid9//53Tp0/bzLtnzx5CQ0MZNWoUvXv3NqW/8847BAQEsG7dOrp161Y4OyCeWBGJtp/TqOCdGvKDKES+lfGA6mXhcqT154e3f6zNEaI45OkMPTg4mAkTJjB79mzOnDlDcHAwUVFRjBkzhk6dOqEoCmvXrmXDhg1cv34dtVpNnTp1GDJkiMX8gc2bN7Nq1SpCQ0PR6/V4eXlRv359Ro0aRcmSJYH0eQebN2/m2LFjZmX/+usvZsyYwcWLF3FxccHf35+uXS27DTPaO3fuXIv6g4KCiIyMNLtqfOjQITZu3Mjff/9NTEwMdnZ21K1bl0GDBtG0adO8HKpcOXHiBD/++CPnzp1Dr9fj6+tL9+7d6dy5s1m+s2fPsmbNGk6fPs3t27fRaDRUr16dfv368eqrr1psN7fHx5qgoCBOnDgBwIQJE5gwYQIAmzZtoly5ciQnJ7Nw4UJ27txJdHQ0JUqUoGXLlgwfPhwfHx/Tdo4dO8awYcMYN24cycnJrF69mlu3bvHuu++ahgft2LGDlStXcvnyZQwGg2mf2rVrZ9GuY8eO8fPPP3P27FmSk5Px9vamadOm/Otf/8LDwwOA1atXs2fPHq5du8a9e/dwd3enRYsWDB8+nHLlypltb//+/SxdupSrV6+SkpKCh4cHderUYeTIkVSuXNnsOGR+72Q3hCgjX2RkpFmZjGNXEF5eXrnOm5SUPtnP29vbLN3V1RUnJ6ciCfjFk6ehNxy0cX7TpQY420kQIUSBfNEV3p1l/bkHqY+3LUIUg3xd5p8+fTp6vZ4uXbrg4uJC5cqVARg7diy//fYb/v7+dOrUCZ1Ox7Zt23jvvfeYOnUqr7zyCgBbtmxh/PjxNG7cmGHDhuHg4MDt27c5cOAAsbGxpiDCmrNnzzJixAicnZ3p378/bm5u7Nixg3HjxuVnV8wEBwcTHx9PQEAAZcqUITo6mo0bNzJixAjmzp1L48aNC1xHhr179/Lpp5/i5eVF3759cXZ2ZseOHUyaNInw8HDee+89U949e/Zw48YN2rVrh4+PD/Hx8WzevJlPP/2USZMm8eabb5ryFvT4DBo0iIYNG7J48WK6dOli2ueSJUui1+sZOXIkp06dwt/fn759+xIaGsratWs5fPgwS5cupUyZMmbbW758OfHx8XTu3BkvLy/T8z/88AOLFi2iVatWDBs2DLVaze7du/nss88YPXo0PXr0MG1j7dq1TJ48mdKlS9O1a1d8fHyIiopi37593L592xRE/PLLL9SrV4+ePXvi7u7O1atX2bBhA0ePHmXFihWmfMePH+fjjz+mWrVqDBw4EFdXV2JiYjhy5AhhYWFUrlyZQYMGoSgKJ0+eZOLEiaa2NGjQwOaxmzhxIt999x0eHh4MGjTIlJ7d+7koNG/eHI1Gw6xZs3B0dKRGjRokJCTw66+/kpCQYNY28exqXtZ6EOGkhdn+msffICGeNa7ZDFmy1UMhxLNEyYNNmzYpTZs2Vbp06aIkJyebPffHH38oTZs2VdauXWuWrtPplL59+yqdOnVSjEajoiiK8sknnyh+fn6KTqfLtr5x48YpTZs2NUsbOHCg0rJlS+XGjRumtLS0NKVfv35K06ZNlblz51q09+jRoxbbHjJkiNKxY0eztAcPHljki4mJUV577TXl/fffz7FttmStS6/XK4GBgcorr7yiREdHm+3HwIEDlebNmys3b97Mtl3JyclKly5dlG7dupml5+X42HL06FGladOmyqZNm8zS161bpzRt2lSZNm2aWfq+ffuUpk2bKmPGjLHYxquvvqrcvXvXLP/58+eVpk2bKrNmzbKo++OPP1b8/PyUxMRERVEUJSoqSnnxxReVbt26Kffv37fIbzAYTP9bO06HDx9WmjZtqixZssSU9u233ypNmza1aFdWeXmNM3Ts2FEZMmRIrvMPGTIkT/kVRVF27txp9fXJbNeuXUpAQIDStGlT098bb7yhnDx5Mk91FbW7d+8qKSkppscJCQlmr3NqaqoSExNjViYiIiLbx5GRkabvmue1Dr3BqHjO1Cl8Y/lXfYGuUOp4HPvxLNeRlpambNy4UZk3b56Slpb21O7H81yHru0XikIX638zNj81+/G01FFULvBtrv+EuXxNrO7WrZvFkIitW7fi4uJC27ZtiYuLM/0lJibSpk0bIiIiCA0NBdKHVaSkpLB///483UE1NjaW06dP88orr5h6PwDs7Ozo06dPfnbFjJPTo6sKDx48IC4uDo1GQ7169Th37lyBt5/h/PnzREVF8dZbb5kNObGzs6N///4YjUZCQkKstislJYW4uDhSUlJo3rw5169fJzExffBzUR+f3bt3o1arGThwoFl669atqVmzJnv37sVoNJo9FxgYiKenp1natm3bUKlUBAYGmr1X4uLi8PPzIykpiTNnzgDw+++/o9PpGDJkCG5ubhZtUqsfvYUzjpPRaCQxMZG4uDhq1qyJq6srZ8+eNeVzdXUF4I8//kCv1xfgiORNxnsq859er0ev11ukP3hQsDXG3dzcqF69OkFBQfzvf//j3//+N46OjowaNYpLly4V0h4VnKenJw4ODqbHrq6uZq+zvb29xVCuzMPmrD0uW7YsqkwTHp/HOo5EYXZ/iMySdE/PfjzrdURFRT0T+/G81qG9Go1NrV94avbjaalDPHnyNZypUqVKFmk3btwgKSmJN954w2a52NhYKleuzMCBAzlx4gSffPIJ7u7uNGnShJdffpnXX38dFxcXm+XDw8MB8PX1tXiuatWqed+RLG7dusXs2bM5dOgQCQkJZs+psluFIY8iIiIA622uVq0a8GhfIf24zZkzh5CQEGJjYy3KJCYm4urqWuTHJyIiAm9vb0qUKGG13ZcuXSIuLs4saLD2Xrl+/TqKomQ7uTdjcndYWBgAtWrVyrF9R48eZcGCBZw7d47UVPPxqJlfzx49ehASEsLkyZOZOXMmDRs2pFWrVrRv375Ihx5NnTqVzZs3W30u6zyQjh07Mn78+HzVc/DgQT744AOmTZtGq1atTOmvvvoq3bp1Y8qUKSxcuDBf2xZPB89spr3cToL7qQolHGROhBAFUq4khMVYf668p/V0IZ4h+QoirE3MVBSFkiVLMmnSJJvlMk6QK1WqxOrVqzly5AhHjx7lxIkTTJo0iXnz5rFgwQIqVKiQn2ZZyO7E32AwmD1+8OABQ4YMITk5md69e1O9enVcXFxQqVQsWbKEo0ePFkqb8kpRFEaOHMn169fp1asXderUwdXVFbVaTXBwMNu3b7e4+v8ksTWJV6VSMWPGDLOehMwy3iu5de7cOUaOHEmFChUYOXIk5cqVw8HBAZVKxeeff252jDw8PFi6dCknT57k8OHDnDx5ku+++4558+Yxffr0bOc9FET//v3p0KGDWdq0adMA+PDDD83Ss06KzouffvoJJycnswACoFSpUjRu3Jg///wTnU6HnZ1dvusQT7ZanipqloRL9yyfMwJX4hSalJEgQogC6fcKHL5s/bkbd6C0x2Ntjsgfue1m/hXa+qkVK1YkNDSU+vXr52oJT3t7e1q3bk3r1q2B9NVyPvzwQ3799Vf+/e9/Wy2TscLNjRs3LJ67du2aRVrGFfP79+9bPBcREWG2fOyRI0e4c+cOY8eO5a233jLLO2fOnBz3Jy/Kly8PWG9zRlpGnsuXL3Pp0iWGDBlicdOzDRs2mD3O6/HJq/Lly3Pw4EESEhIshhZdu3YNFxcX0+Tl7FSsWJE///yTsmXLUqVKlWzzZvRkXLp0yWyIVlbbt2/HYDAwY8YM07EDSE5OtuhVAtBoNDRr1sy0itLly5fp27cvCxcuZPr06UD+ep+yK1O1alWLHqGM49iyZcs812VLdHQ0RqMRRVEs2mMwGDAYDE904CkKx4zX1Ly51vrrfPM+NClj9SkhRG5cioDPfrH9fHT842uLEMWk0G42FxgYiNFoZNYs68udZQxPgfS76WZVu3ZtAOLjbX/wMpaBDQkJ4ebNm6Z0nU7HsmXLLPJnnIAeOXLELH379u3cuXPHLE2jSV+tJOscjUOHDpmNpy8MtWvXpmzZsgQHBxMT86grVK/X8/PPP6NSqUwrWWVcqc/aritXrrBnzx6ztLwen7xq27YtRqORJUuWmKUfOHCAixcv4ufnZ7NnIbOAgAAAZs+ebdEjBObvFX9/f+zs7FiwYIFp7kdmGcfF1uu3aNEiixNma+8/X19fHB0dzQLOjDkW2b0ns3JycrIatD5OVatWJTk5md9//90sPTw8nBMnTlC9enWzsari2dS+ipr/a2k9qC3rIr0QQhTI1PWQaGPiEYDP412VT4jiUGg9Ee3ataNTp06sWrWKCxcu0KZNGzw8PIiOjub06dPcunWLjRs3AvDee+/h5uZG48aNKVOmDAkJCQQHB6NSqUwnmLZ89NFHDB06lMGDB9O9e3fTEqbWTkZ9fX1p0aIF69atQ1EUatasyaVLl9izZw8VK1Y0m1TbqFEjvLy8mDZtGpGRkZQuXZpLly6xdetWqlevzpUrVwrrUKHRaBg9ejSffvopAwYMoEuXLjg7O7Nz507OnDnDwIEDTQFQlSpVqFq1KkuXLiUlJYXKlSsTGhrKunXrqF69OufPn8/38cmrTp06sXnzZn766SciIiJo0qQJYWFhrFmzBi8vL7NlabNTt25dgoKCmD9/Pn369KFdu3Z4e3sTExPD+fPnOXDgAIcOHQKgTJkyjBo1iilTptCrVy8CAwPx8fEhOjqakJAQxo4dS61atWjbti3Lli3jgw8+oEuXLtjZ2XH48GGuXLli0TsyadIkoqOjadmyJT4+PqSmprJz506SkpIIDAw05atfvz6rVq1i8uTJtG7dGq1WS7169cx6OrKqX78+GzduZM6cOVSpUgWVSoWfn5/Z5Pj8iIyMZMuWLcCjXqW9e/dy+/ZtANNxARg4cCAHDx7kyy+/5Pjx49SsWZPo6GjWrFlDWlparl8n8fT7bxsNMQ/0LDjzKO0NXxUvlZMgQogCuXnH9nMlXaBp3obkCvE0KtTbQY8bN45mzZqxfv16lixZgk6nw8vLi9q1a5uduHTr1o2dO3eybt064uPjcXd3p1atWowePdripnBZNWjQgNmzZzNr1ix++uknXF1dTTdT69Wrl0X+iRMn8s0337B9+3a2bt1K48aNmTt3Ll9//TWRkY/WcXZzc2PWrFnMmDGDlStXYjAYqF27NtOnT2fjxo2FGkQA+Pn58cMPP7Bw4UJ+/vlndDodvr6+jBkzxuxmcxqNhunTpzNt2jQ2b95McnIy1apVY/z48Vy6dMkiiMjr8ckLrVbLrFmzTDeb2717N25ubvj7+zNixAjKli2b620FBQVRp04dVqxYwfLly0lOTsbT05Nq1arxySefmOXt1q0bFSpUYOnSpaxYsQKdToe3tzfNmzc33XeiUaNGTJ06lR9//JG5c+fi4OBAixYtmD9/PkOGDDHbXkBAAMHBwWzZsoV79+7h4uJC1apVmTJlCv7+/qZ87du35+LFi+zYsYNdu3ZhNBoZN25ctkHEiBEjiI+PZ/Xq1SQkJKAoCps2bSpwEBEeHs7cuXPN0nbv3s3u3btN+58RRNStW5eFCxeyaNEi/vjjD9avX4+zszP16tVjwIABOX7GxLNl3hsa2ldR2B+u0KCUin/UkQBCiAILbAq/n7b+XPMaj7ctokAU5Dsxv1RKXtZYFUIIIUSB6XQ6Fi9eDKT3HspCB08ZgwHe+hq2nrB87rt34aO3LNPFE+m86vtc531B+agIW/L0KbQ5EUIIIYQQzwWNBl6ysfR4l8JbKEOIJ1mhDmcSQgghhHgu2Ns6hZLhMU8TGc6Uf9ITIYQQQgiRV7aCCFlCWzwnJIgQQgghhMir8l7W01N0j7cdQhQTCSKEEEIIIfLq9YbglmXlvdrl4YUKxdMekS9KHv6EOQkihBBCCCHyysMFNn8OjauAVgOv1YeN/wcqGWMvng8ysVoIIYQQIj/86sKJb4u7FUIUC+mJEEIIIYQQQuSJ9EQIIYQQQojnkizxmn/SEyGEEEIIIYTIEwkihBBCCCGEEHkiw5mEEEIIIcRzSYYz5Z/0RAghhBBCCCHyRIIIIYQQQgghRJ5IECGEEEIIIYTIE5kTIYQQQgghnktKcTfgKSY9EUIIIYQQQog8kSBCCCGEEEIIkScynEkIIYQQQjyXZInX/JOeCCGEeE7dT1F4kPbkjwhOTDKg0z357RTimRSXBClpxd0K8QSSngghhHjOJKUpDFqTwpozeuw0MKS5HdM6OaBRP1lX5OLiDMycH8PZv1NwclTxVoA777zlXtzNEuL5cCce+k6HHX+BiyN8+jaM61ncrRJPEOmJEEKI58z431NZdVqPUYFUPcw6qOPHo7ribpaFhT/HcvbvFACSUxRWrovj1NnkYm6VEM+JDxalBxAASSkwfiVsPlasTSoKCqpc/wlzEkQIIcRzZvtFQ67Sipu1gOHUGQkihHgstp/MXZp4bkkQIYQQz5lqXpZf/dW8nryrbGW8LUfclvG2K4aWCPEcqlbGSlrZx98O8cSSIEIIIWy4naQQnZT7Cb1GReFanEJyPicB332gEJGQ97I37hk4HWXI9STpcf72uDs+elyhhIqPWtvnqmzUfSN3Eo15bmOqTiHijh6jMff716dHSbSZ4ojKFe14pbVLnuvOC6NRITYqFV1a3vdRPDl0N+IxJuZtMrCSZkB/7R6K/vG89orBiPFaDEqq/rHUh8EI16IhNZdDF7/uCw6ZgvZ6lWDQa0XTNvFUkonVQgiRRVKaQt+tRjZeST/h7V5LxU8d1DhqbV+tPxyp0Huzgevx4OEA/2urZnD93F2nMRgVhm4zsOS0EYMC7XxVrOyixdMp+96B6/eMBPySyoWY9Mf2Gvi2vR0jW2b/1d64vIY9Qc50+TmZG/fSA6WZf+qY3MHBZpmEFIV//JxI8DkdahX0amLP4t4u2GdzTDJs/fMBs9bcJ+GBgo+Xhi8HeVC/Ws5BS8XydpT3seNmmA6NGurVccTRseiufd04l8jqb28SF52Gk5uGwCEVaPyaZ5HVJwpf2oW7RHXfRNrZGFTOdnh++RIlP2uZY7nkteeJG74F450HqMu5UXLxWzi+Ua3I2mnYe4XUfr+ghN4DT2ccZnRF+49mRVYfIeeh31wIuwterjCjP/RplX2Zyt5QpTRcCAd7LbzzIrgXbRBfHGTdt/yTnogn0LFjx2jWrBnBwcHF1oaLFy8yfPhwXn31VZo1a8a8efOKrS1CPG5fHzGy4YqCQvoPzKqLCv87avunxqgo9ApODyAA4lIhaIeRG/G5+3n68S8jC0+lBxAAv99Q+HxPznMUhgbrTAEEQJoB3t+q4+/onK+kjt2Zyo17iqnclJA0gv+2fUX0qx3JBJ9Lv4JpVGDZ8TSm703JsZ7bsQam/hJPwoP0uiLvGhj/4z0MueiRWPxLLDfD0us0GGHLbwkcO/kgx3L5YTAorJx6g7jo9KvXyQkG1k2/SXyMLG35NLk9cBtpZ9M/FMoDHXf/by/JB8OzLWOMTeZev/UY76S/t4wRCcT2XoeSXDSLDSg6A6m9fkoPIABiH5A6cBnGyPgiqQ+dHnrNSg8gAO4mwrvzICou+3KDf0gPIADS9DBxFez7u2jaKJ5KEkQIC3q9ntGjRxMaGsqwYcOYOHEir732/HVh7tmzJ8/B07Jly4ok+Dt79izffPMNgwYNok2bNtkGmePHj6dZs2Y2/7p06VLo7XvW/BFqeYJrLS3D9Xi4cd88zajAnrDcBRG7blip72bOgcCua9bz/HE9F2WvWAYpf1y1HUTsumR5QvXHpZyHYfx1ORVDluZE3zNyKzrnIOnsecsgJWO1psIWcyuF+3fN99FoSO+dEE8HY7KO1EORFunJf4RmWy7tYBhKsvl7WYlNJu2vqEJtn2nb56NQIrN8YegMGPddK5L6+DscorIEKDoD7Ltou4zeYD1g2HW6cNsmnmoynOkJ1KRJEw4cOIBWWzwvT3h4OOHh4Xz44Yf07Pn8rgm9Z88eNm/ezNChQ3NdZvny5fj4+NCpU6dCbcuBAwdYvXo1vr6+1KhRg9OnbX+Rv/POO7Ro0cIi/ejRowQHB9OmTZtCbduzqLanioMR5if2L3jZzu/jAiXs4X6Wi9Yv5HKy8gulrKTlomztUvD3HStlvXMu+0JpNcfDjRZpNvOX0XDiliFLWs7XoXzLWk6EdnJQ4e2Rc9lyPnZcu25+UMv7FM3Eag9ve+wd1aSlmB8T74qONkqIJ43KUYu2cgn0N81P0O2z+/AC2lqlQIX5uBZ7DdpqRTOUTVXZE5zt4YH5e1v9gpWJzIWhcilwsofkLF9QtcvZLqPVpE+ivpolkHqhQuG3r5jJ0q35Jz0RT5CkpCQA1Go1Dg4OaDSaYmnH3bvpXZ7u7oV7UydFUXjwoGiGIjytgoKCCAoKyjFft27dCAkJYdWqVfTp0yfbvA0aNCAgIMDi786d9LPNt99+u1Da/iwb86KaMs6PHldyg89a2P66dLZT8c0rajLfq61/HRUtfXL34/SvZhqzIMXDAca2zvnz//2b9thladY7L6h5rUrOX+3/C3DAOdP5+EuV1PRrYvsEfdybTpQt8Wh/fD1VfPKaU4711KpsR+DLj/KpgOFd3HDOxdyGfj1LYp9p6kSNavb4vVw0Y7IdnDW8MaAcmc8nmrX3olxVZ9uFxBNFpVJRatpr6ZODHnJ8pQIub1XPtpy2uieuH79ollZinB+a0rl7rymJqej/isj18CeVuxP2/w00b8Owl1HXz+akPnN9BiPK6VsoMQm5yo+HC/ynu3nacH+oXzH7ctMGmU+sbtcgfV6EEA9JEFFIgoODadasGYcPH2bevHl07NiRl156iV69evHbb79Z5O/UqRNBQUFcuHCBkSNH8sorr9C7d2/A9pwIRVFYv349AwYMoE2bNrRp04aePXsyd+5cs3xpaWksWrSIHj160KpVK9q2bctHH33EhQsXctyPzCe1EyZMMA2BiYiIACA5OZlZs2bx9ttv89JLL9G+fXvGjh1LZKR5F3LmfVi1ahXdu3enVatW/Pzzz6Y8O3bsYPDgwfj5+fHyyy8zYMAAfv/9d6vtOnbsGB988AH+/v60atWKt99+m4kTJxIXF2fKs3r1at577z06dOjAiy++SPv27fnyyy9Nbc9s//79BAUF4e/vz8svv0xgYCCffvopN2/eNB2HzZs3A5gNBcpuqFKzZs2IjIzkxIkTZmWs1Z9XXl5eODnlfMJmS2RkJEeOHKF+/fpUq1Z0kwWfBXEpCoN/M3L7YbzbuDQc76emYonsA4KENNA+/Eb1dCTXk6oBvJxV/PVPOwY1UGOnTp9T0XGVnpAchjQ90GEWCABciVUIy8VcjD3XDOgedix4u8C0Tg442dnexxreGsa/6YTTw/rik+FoaO5WlRn9D3da1XcwXezdsO8BUXdzLqs3KGQ+qw+P1BEeWXQ3xTMaFNNqUE5uGhq+UrLI6hJFw7VzDSqeGoBd7fRehJSQW0R2WocxKYe5LXYaeLhIgLq8G46BNXJVX+pPx7lX7mvuN55JXPmvSduYuzkDqhre4PHwO93JDnWT3F3hV07cRF/1c/QNJ6Iv/28MYzfmXCg0Bn7aZ562/xLcjLGeP0NgU+jrB6qHn8Gbd+Da7Vy1UzwfZDhTIZs5cybJycl069YNSA8uvvjiC9LS0iyGuNy+fZvhw4fTrl07XnvttRyv0o8dO5Zt27ZRr149Bg0ahJubGzdu3GDXrl0MGzYMSJ/P8P7773P69GkCAgLo0aMHiYmJrF+/nsGDB7NgwQLq1Kljs45BgwbRsGFDFi9eTJcuXWjcuDEAJUuWRK/XM3LkSE6dOoW/vz99+/YlNDSUtWvXcvjwYZYuXUqZMubdscuXLyc+Pp7OnTvj5eVlev6HH35g0aJFtGrVimHDhqFWq9m9ezefffYZo0ePpkePHqZtrF27lsmTJ1O6dGm6du2Kj48PUVFR7Nu3j9u3b+Ph4QHAL7/8Qr169ejZsyfu7u5cvXqVDRs2cPToUVasWGHKd/z4cT7++GOqVavGwIEDcXV1JSYmhiNHjhAWFkblypUZNGgQiqJw8uRJJk6caGpLgwYNbB67iRMn8t133+Hh4cGgQYNM6SVLFv+JyKZNmzAajdILkQtfHTSazWU4GQ0//AVjs1nI5PxdhU9CHp3wx6ZA/20Grg3RoFblrjfiehwsOv1oG1FJ0C9Yz/URdmjUlttISlMYsD6N+6nm6advK3y0XcfaXrZXWjoUamDCrkcnVXeSYPCaVM58ZPsnITrByL/WPiDtYeBxL1lhwK9JhE+ww8Uh+33ceTSZP888aui1cD3TV93n6+G2h4vo9Qoz5sSQlmnZ2gcPFGbMjWHa5PLZ1pcfMeEpbFsYjvKwuuQEA2u+v8knP9ZFrZHhDk+ThIVn0F2INT1+sP069745itf4l63mT91zg8TJB0yPjeEJ3BscTOljQ7Ktx3g7gaSg9WR8KJR7ySQNWI1d+P+hcrG9+piSoiO1/68Q9/DGick60kasRhNQB3V5j2zr1L+7BEIf7luaHuNXW1C9WQ91q2wuDn30K5zKMi/kTBh89Aus+9B2uc3HYOGuR48vR8LwefDHRNtlnkry+c4vCSIKWVxcHCtWrMDV1RVIH4bSq1cvvv/+e15//XUcHR+Nrw0PD2fMmDF07tw5x+3u3LmTbdu20aFDByZMmIBa/egqp9H46MRj5cqVHD9+nJkzZ/LSSy+Z0rt160bPnj2ZNm0a8+fPt1nPiy++iFarZfHixaZhMRnWr1/PqVOn6NevHx988IEpvWXLlnz44YfMmjWLr776ymx7UVFRrFmzBk/PRycLFy5cYNGiRQwcOJD33nvPlN6rVy9GjRrF7NmzCQwMxMXFhdu3b/O///0PX19fFi1ahJubmyn/8OHDzfZ9xYoVFlfr/fz8GDFiBBs3bmTAgAEAhISEYDQamT17tlm7/vnPf5odh+3bt3Py5EmzY5CdgIAA5syZg6enZ67LPA5Go5Hg4GCcnZ154403irs5T7x94ZZX8fdbScvsgJXnb96H0Pvgm8tRgQduWfY6hN2Hm/FQ1Uocevq20SKAyLAvNPsejP03LCc1n71tJC5ZwcPGsrJHQvWmACJDfIrCmUgDL/pm/1Ny5opl78GZK9lfGb4drSfByv0oIqP0JCUZcXEp3I70G+eSTAFEhvg7OuLupOFZ1nZAJp48yftvWaSl7LNMy5C633Lite54JEqKHpWj7fe2/ugtsn4olPgUDGei0L5YyWY544XbcDcpy8aMGA/eQN2tkc1yyv1kOGO50pSy/zJkF0TYmkCd3cRqgP3nrZSxkiaeWzKcqZB169bNFEAAuLq60rVrV+7fv8/x48fN8rq7u+d6Au62bdsA+PDDD80CCMDs8bZt2/D19eWFF14gLi7O9KfX62nZsiWnTp0iJSV/q5vs3r0btVrNwIEDzdJbt25NzZo12bt3r9lJPUBgYKDZiXpGG1UqFYGBgWZtjIuLw8/Pj6SkJM6cOQPA77//jk6nY8iQIWYBhLV9zwggjEYjiYmJxMXFUbNmTVxdXTl79qwpX8br88cff6DXP6ab/AAPHjyw2F+9Xo9er7dIL8y5I4cPHyYqKorXX38dZ+cna3x3bGwsqamPzoQTExNJSHg0zjctLc00RydD1qFzWR9HRUWhZDobzGsdDaxMSq7qZP6Dn7WOSvaWY5O9HBXKueZ+P3xU5s8DeDlBeTfr+1HOMRkHjfXgpsHDCc+2jlX9spZf/ZU9VOgf3LN5rOqV1ZC1Q8TRDtyM5jO7rb0eVcpZzu+oWt7Oog54dKxKeWlwsNLDUdJdTVyc+WTPgr7mAFq3LCd1pA9pKuFlV2h1ZD02Zcua3/23KOoo7M/H01CHQ31vstLW9bRZh119ywnNmhqe3I6LyXY/Un3dLC5iK45a1DUfrZRgbT/UVUuBlZ4KdX2f7I+VmyNKZctJ4vfKm3+vZ60ztbaNCdsNKlrWQabXo35lK2UqW63jcbzm4skjPRGFzNfX1yKtSpUqQHrPQ2bly5fP9eTpsLAwSpUqhZdX9qtMXL9+ndTUVNq1a2czT1xcnMWPV25ERETg7e1NiRIlLJ6rVq0aly5dIi4uzixoqFTJ8mrM9evXURTFNOTLmowvl7CwMABq1aqVY/uOHj3KggULOHfunNmXF2D25dWjRw9CQkKYPHkyM2fOpGHDhrRq1Yr27dsX6dCjqVOnmuZZZJX19erYsSPjx48vlHo3bkwfM5ubHq/HLWuAmTkAB7C3t7d4z/v4+GT7OOt7O691jH1Jza6bBtOSrS94woRXzQPYrHW8UdudoWEG5p1K/xG1U8NMfw32D4fB5GY/OjQozfAIPXNOGE3bmP66BoeH47Sz7kdlb1emvK7no+06s0VlSjnDN2/YWa0j4/EbNTT0bqhl+an0INpBA7PedqSUl/mxyXysfL00fPmGIxN3pKAooFbBlI7O1K1q3i5rr0dHT4Xdx1M59bD3wd1FxXtdS1jUkfVYDexbknmLYk09BCoVDBnoRfksJ00Ffc0BGr1UidBAFYe3pI8T12hVdAyqgPbhzPXCqCPrsYmKMg+GiqKOwv58PA11lPzyJR7suon+Wvqypna1PPH6/CW0Wd7fGdt07FQTx64vkLI2/Sq7ytkOj1kdcMxhP9zqVeDBl6+R8tVuMj4ULlPeRO356P1paz/sv+1M2ntryFj/2O7f/qhrlSHrAL/Mx0qlUqGd3RtD93nwcBK3qmczvPqYr7iXtU6H6QPgjckQk2m5Yk8X+Ka3RR2Q6fXo+TL8uhe2n0x/ooQTTB9stY7H8ZqLJ48EEcUo89CmwlS9enU++ugjm88/zjH6tvZRpVIxY8YMi16VDHmd/Hvu3DlGjhxJhQoVGDlyJOXKlcPBwQGVSsXnn39u1kPi4eHB0qVLOXnyJIcPH+bkyZN89913zJs3j+nTp2c776Eg+vfvT4cOHczSpk2bBqT3MGXm7W15JS0/4uLiCAkJoVq1atSvX79Qtvmsq1RCxcXBGn6/qaBVw2uVVGitzEnIau7rGkY0UrgYq9CmgoqyLnkfZ/vDm1qGNzFy4S60qaiirGv22/jgJS1v11ZzJNyI3ggu9iraVVXjYp99OZVKxcdt7Nl52UDMA4U0A2y9qCewtgZVNnM4xndwpk9TB05FGGhRSUNlz9xdBHGwVzFzlCenrqRxP0mh+Qv2ODnk3BH+ahs3NGoV8xffRadPD1xuhupo2ihX1ebZW8Mr0qJDKe7cSqFyHVdKeBbNcrKiaNlVLEHlC4N58PtNUKtw9q+MSmv7/aZSq9CUd3u0zKuLHeoSuRvC5jzhdRz+0QjDqSg0LSqgqZy731e7oS+jCaiD8dAN1PXLobbVW5CFOrABqrApKLsvoqpSClVTK70FWTX2hRvTYOfZ9BvOVfCEN+qDSw7nIHZaCGiSfm8InSE94Am37DF92skSr/knQUQhu3HjhkXa9evXgfSeh/yqVKkSISEh3L17N9veiIoVK3Lv3j2aN29u8wQ9v8qXL8/BgwdJSEiwGFp07do1XFxcTJOXs1OxYkX+/PNPypYta+qlsSWjJ+PSpUtUrmz7y3L79u0YDAZmzJhhdpyTk5PNeiEyaDQa0+pJAJcvX6Zv374sXLiQ6dOnA2R7MmVLdmWqVq1K1apVzdIyjmPLli3zXFdubNmyBZ1OJxOq88heoyKgat5f/wbeKqvDofKifmk19UvnPr9vSTW+JfP+WQ9al0LMw7tIK8CcQzreekHLm7Wy/1moWVpDzdJ5X35apVLRqEbe5hbo9Qq/rLyH7uGoQ4MRVq6Lo0UzZyqUK5oT/LK+TpT1zf9KaOLJoLLT4NKhas4ZgdQ/rpM044jpsXLnAfeGbKbMmWG5Kq+p6Y2mZt4v/KgrlkRdMe8X9VRerqi6Nc1bIRdH6Nwsb2VuxcBHi029JSSlQtDc9FWbXOUzImRORKFbs2YNiYmPugwTExNZu3Ytbm5uNG2axw99JhlXsGfMmGEx7yDzOMTAwEDu3r3Lr7/+anU7Wccg5kXbtm0xGo0sWbLELP3AgQNcvHgRPz+/XAUuGZOOZ8+ejcFgOcEzcxv9/f2xs7NjwYIFZsc1Q8a+ZwwLU7LMjFy0aJHF8cq8LGwGX19fHB0duX//0U2KMuZYxMfHW+S3xcnJyWwbxW3jxo3Y2dk9URO9RfFL0yucjLCctHw4LOe7SD9Od2L0xN+3bOeVqzZmlAuRD2mHLCdd689G57ws7LPu2FUsbjd//wGctz1JXTxfpCeikHl4eDBgwADThOng4GCioqIYM2ZMgYYvtWvXjtdff50tW7YQFhaGn58fbm5uhIaGcvDgQVatWgVA7969OXz4MNOnT+fo0aM0b94cFxcXoqKiOHr0KPb29sybNy9fbejUqRObN2/mp59+IiIigiZNmhAWFsaaNWvw8vIyW2kpO3Xr1iUoKIj58+fTp08f2rVrh7e3NzExMZw/f54DBw5w6NAhAMqUKcOoUaOYMmUKvXr1IjAwEB8fH6KjowkJCWHs2LHUqlWLtm3bsmzZMj744AO6dOmCnZ0dhw8f5sqVKxa9I5MmTSI6OpqWLVvi4+NDamoqO3fuJCkpicDARzcAql+/PqtWrWLy5Mm0bt0arVZLvXr1su1Rql+/Phs3bmTOnDlUqVIFlUqFn59fge7xAOkTzLZs2QKk9/oA7N27l9u309fszjgumZ09e5Zr167x+uuv56qHSDw/7LUq6pdVcybK/AShiZUJ0MWplJcWNzc1CQnm7azqa3v5TCHyyq6p5dh7be1SqLNZpvW50KgKqNWQ+UKcqyPUKvwllotTznfVEbZIEFHI3n//ff766y9Wr15NbGwslSpVYtKkSbz55psF3vZ//vMfGjduzMaNG1mwYAEajYZy5cqZTcrVarVMmzaNNWvWsHXrVlPA4O3tTd26denYsWO+69dqtcyaNYuFCxeyc+dOdu/ejZubG/7+/owYMSJPk7WDgoKoU6cOK1asYPny5SQnJ+Pp6Um1atX45JNPzPJ269aNChUqsHTpUlasWIFOp8Pb25vmzZub7jvRqFEjpk6dyo8//sjcuXNxcHCgRYsWzJ8/nyFDzNf6DggIIDg4mC1btnDv3j1cXFyoWrUqU6ZMwd/f35Svffv2XLx4kR07drBr1y6MRiPjxo3LNogYMWIE8fHxrF69moSEBBRFYdOmTQUOIsLDwy1uKrh79252795t2v+sQUTGhGoZyiSsmdPZgbeWJhP7cCGw/k20BNZ+soIIOzsVQwZ4MXt+DKlpCioVvB1YgkoVn/OTO1GoHN6ohvPgxjxYmD6BWOXhiMdc6b3FtzT8tw98sSy9R8LBDmYNgRJP1ip/oviolKzjP0S+BAcHM2HCBObOnWsaZy+EEE+yB2kKB24aqOCu4oV8zHN4XJKSjFy+lkq5snaU9n42rn3pdDoWL14MwMCBA7Gzk0ncxU13MQbDzXjsX64ovRCZ3YqBs6HQrDqUslyd8Wl3TDUn13mbKcOLsCVPn2fj21gIIUSeOdureL3Gk/8z4OKiplF9mcgpipZdrVLY1SqVc8bnTYVS6X9CZPHk/3oIIYQQQghRBGSJ1/yT1ZmEEEIIIYQQeSI9EYWkU6dOphWZhBBCCCGEeJZJECGEEEIIIZ5LsrpQ/slwJiGEEEIIIUSeSBAhhBBCCCGEyBMZziSEEEIIIZ5LRlmdKd+kJ0IIIYQQQgiRJxJECCGEEEIIIfJEggghhBBCCCFEnsicCCGEEEII8VySO1bnn/RECCGEEEIIIfJEggghhBBCCCFEnshwJiGEEEII8VySO1bnn/RECCGEEEIIIfJEggghhBBCCCFEnkgQIYQQQgghhMgTmRMhhBBCCCGeS7LEa/5JT4QQQgghhBAiTySIEEI88+6lKAzfaaDmQj2d1hk4Ff3krcdxItxAxyUPqPm/REZsSCEu+clroxBPO2NUAkkDVxFf8xsSu/6M4eKd4m5SwRy9DB2+gloj4YOFkJBc3C0SzxEZziSEeOb12mxkx430k/LL9xT+jDBwbYgGd4cnoxs79oGC/48PiEtJf3z5ro7QOCOb33Uu3oYJ8YxJfPsnDEfCADBejkF/OBT3K6NROdoVc8vy4XYc+I9/FDhcioDwu7BmdHG26qkjw5nyT3oihBDPtKgkxRRAZIhNgU1Xnpwr/Rv/1psCiAxbLxmISTIWT4OEeAYZzt82BRAZlPD76HddKaYWFdC6Q5Y9D+uPwP0HxdMe8dyRIEII8Uxz0IDWyjedyxN04dHF3jJNqwZ7jVwhE6LQOFv5oIH1D+DTwMXBMs1eC3aax98W8VySIEII8Uwr6ahiYD3zk/FantCx2pNzgv7WC1qqe5m355/N7Cjh+OS0UYinnaZySey61TdPa1oerV+VYmpRAb3zIviWNk8b3h6crAQXwiYlD3/CnAQRQohnmt6o4OWo4OkAJeyhc3XY30tTZFf5F53QU3dWCr7fpzDuDx0GY84/PY52KqZ3dKSShwoHLbSsqGasf9F0lcQlGhn3UzztP7vD4G9jOXklrUjqEdm7uz+akrOdKDXJmdMfHCUtrmheh1uz/uZQrbX8WXU1N74+jaIU3alQyt93udlhPRfKzCe08ybSrsUXWV2K0UjChD1EV5lG9AuzeLDgeK7KOX39JuqGPuCgRV3NC+dpnVCpsz8VUhQF3ZSdJFebQHLNr9DNCMm5fWGx6LvPRVd2FPrXv0P5KzRX7ePn/VD/M6j8AXyxCvQG23ldneDbAVDBCxztoHVt+KJr7uoRohColKL8RhH5cuzYMYYNG8a4cePo1KlTsbTh4sWLTJs2jQsXLpCQkMCQIUMYOnRosbRFiIL4cr+BSYfMv+Z29VDzWqXCv4ay9ZKBwF/NTwYnvabli1eyDwhikoxUmZpEYqair1bV8MeQwp9Y/a9Z9/jz70cVOdrDhgmlKOUuQyAelwdhSexqEYwx5dGcl7IBFWj5q1+h1hO1/Bp/9zE/4a0xoyUV369TqPUAGNMMXK66GH14oinNvlZJqv/dH5W68AP2xCn7Sfjsd7O0kht64fh27WzL3W84DcPpSNNjlbcL7jc+Q2VrqBOg+2EfuvdWm6XZ/9IP7T+a2y7T5Cs4mSlwKOWK9sZkVNaGIGXYdRbaTTZPG/M2fNXdev5bMVBjJKRk+uLo1Aw2fW67DmFhn+rHXOdto/yzCFvy9JGeCGFBr9czevRoQkNDGTZsGBMnTuS1114r7mY9dnv27GHevHl5KrNs2TKCg4MLvS1nz57lm2++YdCgQbRp04ZmzZrZrOfMmTOMHj2azp074+fnh5+fHz169GD+/PkkJiZaLfMsW3be8jrJcitphWH5GcurhsvPZnMl8aHg8wazAAJg9zUDtxMKd2J1fJLRLICA9POPkNOphVqPyF7k1ltmAQRA1PZw9Im6Qq0nevk1i7TbVtIKw4O94WYBBEDaxXuknIgukvqSl5/JVVpmhnNRZgEEgHInCV0OE6sNyy17OfTLT9jMr1yINA8gAGISUXb+nW09LD+Yu7QMG46YBxAAm4/LxGrx2MgSr0+gJk2acODAAbTa4nl5wsPDCQ8P58MPP6Rnz57F0oYnwZ49e9i8eXOeemCWL1+Oj49PofcgHThwgNWrV+Pr60uNGjU4ffq0zbw3b94kJSWFDh06UKpUKRRF4dy5cyxatIhdu3bx008/4ejoWKjte5KVdASyjKrwKKIhwx5WDqtHLuY1lHSyTHPQgpNd4V7BdbBT4WAHqVnOVd2c5HrS42TnbtkzpXHWoLYv3NdB62F5dd3OSlph0Nj4UKmL6MOmtvJhs5aWmcrdEVQqyDIAQ+Vh5QOYmZXnsy1TwgnUKsg6lNEjh57Fki5W6raSlt1zzg7g8AStGvEUkCVe809+OZ4gSUlJAKjVahwcHNBoimd4wd27dwFwd3cv1O0qisKDB3KFJLOgoCCCgoJyzNetWzdCQkJYtWoVffr0yTZvx44dmTFjBkOHDqVr165069aNcePGMWLECK5evcq+ffsKq/lPhc9aqM1+IjwcYHijovnqe6+FFrdM50xqFfy7dc4XAwJra2lQ1rxNI1oW/sRqR3sVvV81P5GpUlbDKw1lIubjVK5TJZyrupqlVX+vNmr7wv3Or/hhHdROj7ap0qqo9Gn9bErkn1OzMri0q2SWVqJ7DRyqexRJfS6jX4ZM85pUrvY4v98y2zLqCh7Y92tslqZt7Yu2tW+25ew+ec18xSNHO+w+amszv6qcB6r+L5mntaqG6pWa2dbD8HbmgYZKBZ9lc0HqnRehZjnztI87SRAhHhsJIgpJcHAwzZo14/Dhw8ybN4+OHTvy0ksv0atXL3777TeL/J06dSIoKIgLFy4wcuRIXnnlFXr37g2kz4mwNlxFURTWr1/PgAEDaNOmDW3atKFnz57MnTvXLF9aWhqLFi2iR48etGrVirZt2/LRRx9x4cKFHPcj80nthAkTaNasGc2aNSMiIgKA5ORkZs2axdtvv81LL71E+/btGTt2LJGR5l3Emfdh1apVdO/enVatWvHzzz+b8uzYsYPBgwfj5+fHyy+/zIABA/j9d/Mxrpm398EHH+Dv70+rVq14++23mThxInFxcaY8q1ev5r333qNDhw68+OKLtG/fni+//NLU9sz2799PUFAQ/v7+vPzyywQGBvLpp59y8+ZN03HYvHkzgOkYZDeEKCNfZGQkJ06cMCtjrf688vLywskph6tlOfDx8QHg/v37BW7P06RbLTX7emsIrAreTpBqgNEhRm4nZT+kae0FI2WmpaH+bxoOk9MYulVPmiH7MrW91ewfZE+DMirsNeDjCjEPch46ZadRsaGvk9kKTX9c1XM5pvDvEzGysxv/GVSC6uU0ONrB/QdGVu6R4P5x0rpoqfFpHQyuRhS1gkczT6oMzuEEMx/cmpSi+rctsPNyQKVV4fFKWVzqemRbxqgzEDrqT457Leavij8T9f2pXNfnPf5F7KqUAI0K+9ol8R6T/Uk9gGJUiB2zl5ulZxDqM5N7kw7kqi7HgJo4j2yBysUOHLU49qiLtpZX9nWl6cHdMX19Zxd77N6ph+tvg1GpbAfrSmIq+p+OgL0G3B1Rv/kCjsc+Qd20ku0yBiOULgGuDuBkhyqwPpodH2VbDwBVS6cHEq6O6YFAz5bQuant/M4OcPBrGNsdaviAkz2sPADLn68LRaL4yHCmQjZz5kySk5Pp1q0bkB5cfPHFF6SlpVkMcbl9+zbDhw+nXbt2vPbaazlepR87dizbtm2jXr16DBo0CDc3N27cuMGuXbsYNmwYkD6f4f333+f06dMEBATQo0cPEhMTWb9+PYMHD2bBggXUqWN7Ut2gQYNo2LAhixcvpkuXLjRunH7VpmTJkuj1ekaOHMmpU6fw9/enb9++hIaGsnbtWg4fPszSpUspU6aM2faWL19OfHw8nTt3xsvLy/T8Dz/8wKJFi2jVqhXDhg1DrVaze/duPvvsM0aPHk2PHj1M21i7di2TJ0+mdOnSdO3aFR8fH6Kioti3bx+3b9/Gw8MDgF9++YV69erRs2dP3N3duXr1Khs2bODo0aOsWLHClO/48eN8/PHHVKtWjYEDB+Lq6kpMTAxHjhwhLCyMypUrM2jQIBRF4eTJk0ycONHUlgYNGtg8dhMnTuS7777Dw8ODQYMGmdJLliyZ7etaVFJSUkx/58+fZ+bMmdjZ2dGyZc4/7M+aCq6w8yakPZyesPayQnyakZ3drV/5PXfHSI91ejJO4dOMMP8vI55O8PWr2X9t/nDUwOnb6YFDeAIM2qCjuqeKNpWzv8o8MjiFK3cfBRynohTaL3rA1U9dcj75yKNbdwxciUg/GCk6hRnrEyntoebN5gULVEXuJN1I5PS/jqLRpV/HizsWy4nhB3lpzauFWk/y9QQuf3AYRZf+Tr63K5K/++2l0W/tbZaJmHSCqO/Sh0saYlMJ/fgg9pXc8OxaNdu6jMl6wjoHY4hJv/lZ2oV7hL0TTPVL72Y7sfr+tKPE/+dP0+O4L/eh9XHFbXDD7Pdt1VkeTD/86PGik2gqu+M2tq3NMikTfidt5qO6dOvOouvfBPu369osk/bBWgyLH9Vj/O0CyrgUm/kBjN/uQJm63fRY2XIGZc1xVANaZVuOlYfg602PHq84BHXKw5ddbJfxdIOrt+Hywwt5lyKg73SoVQ6aVMu+PgHIcKaCkCCikMXFxbFixQpcXdO7qrt160avXr34/vvvef31183GooeHhzNmzBg6d+6c43Z37tzJtm3b6NChAxMmTECdaUk6o/HR1cqVK1dy/PhxZs6cyUsvPepO7datGz179mTatGnMnz/fZj0vvvgiWq2WxYsX06BBAwICAkzPrV+/nlOnTtGvXz8++OADU3rLli358MMPmTVrFl999ZXZ9qKiolizZg2enp6mtAsXLrBo0SIGDhzIe++9Z0rv1asXo0aNYvbs2QQGBuLi4sLt27f53//+h6+vL4sWLcLNzc2Uf/jw4Wb7vmLFCour9X5+fowYMYKNGzcyYMAAAEJCQjAajcyePdusXf/856NVF1588UW2b9/OyZMnzY5BdgICApgzZw6enp65LlOU5s6dyy+//GJ6XLVqVb7//nsqVKhQjK0qHpuuKqYAIsPvNxXiUhSrcxY2XFKw1gew5oKRr3M4z1v7t+VE6jXnDNkGEal6he2XLMtdv6dw7raRemULd5jLH39ZTqTedTJVgojHJGrbLRSdeQ9V9B+R6BJ02LkV3lCUmE2hpgAiQ+yOCPT309CWsD434t5ay4nXsWuu5RhEJIXcMgUQGdKuxpNyMhqnpmVslIKktRct09ZczDGISFljOUk5Zc3f2QYRaWssJ17r1pzJNogwrPnLPEFRMKw9heZF2/eWUNZaTro2rjmOOqcgYs0RK2lHsw8iANZkmXxtNMK6wxJEiCInw5kKWbdu3UwBBICrqytdu3bl/v37HD9uvsKDu7t7rifgbtu2DYAPP/zQLIAAzB5v27YNX19fXnjhBeLi4kx/er2eli1bcurUKVJSsr+KYsvu3btRq9UMHDjQLL1169bUrFmTvXv3mp3UAwQGBpqdqGe0UaVSERgYaNbGuLg4/Pz8SEpK4syZ9C/733//HZ1Ox5AhQ8wCCGv7nhFAGI1GEhMTiYuLo2bNmri6unL27FlTvozX548//kCv1+frWOTHgwcPLPZXr9ej1+st0gtj7sg777zD7NmzmTx5Mv/4xz+wt7c3G/71JIiNjSU19dEJbWJiIgkJCabHaWlppjk6GbIOncv6OCoqymwt/NjYWEraWb7OJezBSWu9Dged9fXtSzurbNaRsR+lXSyDEi9HY7b7YacGFzvLYU8qFXg9rLMwj5Wnm+VXv6eb+rG9Hs97HQ6lLCcAa93suBN3p1D3w76MZVCoLqFF5fDo9c9ah8rLMrgwlDB/bO1YaUtbmTSsAo23U7b7obFSTlPaOcfXI8XKe5hSj7Zl7VgZPC2Pu6r0o99ra6955ucflXGzWcfdu3ehtOVvVUZatu+rMpbzEPVezjm+5gYvyzZS+tG2nrbPh63H4skjPRGFzNfX1yKtSpX0Kxbh4eFm6eXLl8/15OmwsDBKlSqFl1f2Yz6vX79Oamoq7dq1s5knLi6OsmXL5qrezCIiIvD29qZEiRIWz1WrVo1Lly4RFxdnFjRUqmQ5bvT69esoimIa8mVNxpdLWFgYALVq1cqxfUePHmXBggWcO3fO7MsLMPvy6tGjByEhIUyePJmZM2fSsGFDWrVqRfv27Yt06NHUqVNN8yyyyvp6dezYkfHjxxeovkqVKpmOf7t27Th48CDvv/8+AG+++WaBtl1YsgaYmQNwAHt7e4v3fMbcDluPs763PT096V5C4X8nDJy68yj9s5ZqHLQqwLKOYa1KMuecjsz3ylKrYExrjc06Moxtq6X3Gp1pAZjyJWBYCwe8XM1PYDK3W61W8dUbjny42fx9O7ipFp8Saos6oGDH6t03XDh2KQ3dw9jKzUlF79ec8fQ0/0koqtfjea/Dp1NF3F5wJ+H8ozdYzY/rUq6i+STZgu6Hd5fKuDYoSeLpe6a0Kp83ROPw6HXOWkfFL5tzKWCrqQdD4+lA5dHm90Oweqx8wK1TVRKCH/VkeAysi32lEpjXYL4f7v9+keTt11FS0t+MKld73Ee1wN7H/E7MWev0/uxVYtZfQbn38KKYnZoSYx7dZ8PasXIb/waJHZeAPn3fVF7OOIx81Dtg7TXXj+tAWv9fTCs6qSqVRDuwpc06vLy8MH7WAcPOvyH14QeshBOaUW/YrMPkg/aw7E+4l/Rwg1q0X75jdgHN2muumdgb/vnDo4SqZaB/W+t18OR/Pmw9Lipys7T8kyCiGBXVMpvVq1fno48+svn84xyjb2sfVSoVM2bMsOhVyVCtWt66Yc+dO8fIkSOpUKECI0eOpFy5cjg4OKBSqfj888/Nekg8PDxYunQpJ0+e5PDhw5w8eZLvvvuOefPmMX369GznPRRE//796dChg1natGnTgPQepsy8vb0Lvf6XXnoJLy8v1qxZ88QEEY/L5msKcQ/Pzyu5wX9aq+hb13ZHrKu9ihOD7Zh+1MDO6wqV3WH0SxoalM6587ZnPS1VS6pZfc5AKWcY2FiLt5Xeiaw619Hy03EdJyONOGohqIWWaR2L5juiaU17lv2fF1uPpOBgBx1fdKKsp9xs7nHROGp4acurrPloJZpYFa/+qx0+7Qp/mKHaQUOpzpV4cPk+xlQDJduVo0ION5pzb1eBuie6cXfZZdTOWrzfrYV9BStXuq2ouDaQ+BWXSD4RjXMrH0p0rZFjGccXy1P+1CASfz4LGhWuA+pjV8Ujx3IaXw8cOtUkZdlZUIFTv4bYt/XNtoxd+1q47hrCg3+uwXjlLmjV6HddQfPPFjbLaPs2R1XDG8PaU6hKu6J9tyWqUtkfD/XL1VGdGofx54Ngp0H97suoKmd/ARCAGmXh1H9hyV5I0cE/Xk6fE5EdRYGrUemTqtP00LIGrPt39kvDClFIJIgoZDdu3LBIu379OpDe85BflSpVIiQkhLt372bbG1GxYkXu3btH8+bNbZ6g51f58uU5ePAgCQkJFkOLrl27houLi2nycnYqVqzIn3/+SdmyZU29NLZkXEm/dOkSlStXtplv+/btGAwGZsyYYXack5OTzXohMmg0GtPqSQCXL1+mb9++LFy4kOnTpwPkazJrdmWqVq1K1arm44ozjuPjmuycmpr63K3OdD1OoddmY8bFR0ITYM4phb62h0ED4O6oYmwbLWPb5L3O5uXVNC+ft89fn5XJnIxMb2SKHn44pOeDlxWqehbNpL8qPlreezt3J4ei8Gld7UhulX7DjlKv2J4zUBDRa25wY+Kj1ZXu7Yjg2pgT1PjO9kkzgHM9T5z/m/fvJJWdBo9+L+DR74U8lbOr6UnJr/J2t+7EqQdIWfrofjnJi05i16I8LkObZVsudfoBjJfTe7qV24k8GLIWTf2yaFvaXm1J09IXTUvfPLVPVassmkk5zGWwpqJXznMgMluwE75e9+jxnxfT08bYuMu1EIVI5kQUsjVr1pjdFTgxMZG1a9fi5uZG06bZLNWWg4wr2DNmzLCYd5B5HGJgYCB3797l119/tbqdrGMQ86Jt27YYjUaWLFliln7gwAEuXryIn59frgKXjEnHs2fPxmCwnEyauY3+/v7Y2dmxYMECq3dbztj3jGFhSpabCC1atMjieFmbF+Dr64ujo6PZCXbGHIv4eOvj461xcnIq9pP0mJgYq+mbN28mMTGRevXqPeYWFa+t1xVTAJHhz4jcLb36uMQkGfnzpnkj9UbYeuHxzdkRz56YTaEWaXc2WqY9jVI3WU7ITt2Y8zLmuk2WE7KtpT01Nh21TNtoZYK2EEVAeiIKmYeHBwMGDDBNmA4ODiYqKooxY8YUaPhSu3bteP3119myZQthYWH4+fnh5uZGaGgoBw8eZNWqVQD07t2bw4cPM336dI4ePUrz5s1xcXEhKiqKo0ePYm9vz7x58/LVhk6dOrF582Z++uknIiIiaNKkCWFhYaxZswYvLy+zlZayU7duXYKCgpg/fz59+vShXbt2eHt7ExMTw/nz5zlw4ACHDh0CoEyZMowaNYopU6bQq1cvAgMD8fHxITo6mpCQEMaOHUutWrVo27Yty5Yt44MPPqBLly7Y2dlx+PBhrly5YtE7MmnSJKKjo2nZsiU+Pj6kpqayc+dOkpKSCAwMNOWrX78+q1atYvLkybRu3RqtVku9evWy7VGqX78+GzduZM6cOVSpUgWVSoWfn1+B7/EQGRnJli1bgPReH4C9e/dy+/ZtANNxAfjggw9wd3enQYMGlC1blsTERP766y9CQkIoU6ZMrm5u9yypYGWOo7sDuBXNjXvzxc1BhbsjxGdZ86CCuyw9KPLPoYLlkBbHCjncNfkpoalQAt0R83mG6gqW8/WyUldwx3jjnnlaRY/CbNrjVcHKyARracImWeI1/ySIKGTvv/8+f/31F6tXryY2NpZKlSoxadKkQhmD/p///IfGjRuzceNGFixYgEajoVy5cmaTcrVaLdOmTWPNmjVs3brVFDB4e3tTt25dOnbsmO/6tVots2bNYuHChezcuZPdu3fj5uaGv78/I0aMyNNk7aCgIOrUqcOKFStYvnw5ycnJeHp6Uq1aNT755BOzvN26daNChQosXbqUFStWoNPp8Pb2pnnz5qb7TjRq1IipU6fy448/MnfuXBwcHGjRogXz589nyJAhZtsLCAggODiYLVu2cO/ePVxcXKhatSpTpkzB39/flK99+/ZcvHiRHTt2sGvXLoxGI+PGjcs2iBgxYgTx8fGsXr2ahIQEFEVh06ZNBQ4iwsPDLW4quHv3bnbv3m3a/4wgokuXLvzxxx9s2LCBuLg4tFotFSpUYMCAAfTt2zdXQ86eJYFVVbxcHg5kOt8Y+1LGpOong4NWxTh/Bz7e8mhidavKajrWlq9okX8V3qtN5E9XSItIX+1N7aDBd1yj4m1UIXH9vA2pO66iJKYBoPJ0wvWTHJZQBRwntedB/5VgTO+JVNcpjX3fxjmUeoKNeit9ide7D4ftujjC512Lt03iuaFSso7/EPkSHBzMhAkTmDt3rmmcvRDiyZCqV1h9SeHKPYU3fNW0Kv/kBBCZHbxp4LfLeqp7qeleX/tEBTqicOl0OhYvXgzAwIEDsbMrvPtDmNUTm0rUr1cxJOgo3aMKztVzvlr/tDCExZO8/Axo1Tj9owGaMrmb46M/FYFu49+oy5XAvncjVC5PULdkftyOg2X7QKeHXq2hUuEvzPEs261anOu8ryoDc870HJHLXEKIZ56DVkXfOk/+CflLlTW8lMOdrYXICztPByrmsCLT00pT0R3X0a3zXE7bsBzahuVyzvi0KOMBH+XunlPCklxJzz+ZWC2EEEIIIYTIEwkihBBCCCGEEHkiw5kKSadOnUwrMgkhhBBCCPEskyBCCCGEEEI8l2SJ1/yT4UxCCCGEEEKIPJEgQgghhBBCCJEnMpxJCCGEEEI8l2Q4U/5JT4QQQgghhBAiTySIEEIIIYQQQuSJDGcSQgghhBDPJWNxN+ApJj0RQgghhBBCiDyRIEIIIYQQQgiRJxJECCGEEEIIIfJE5kQIIYQQQojnkqKWJV7zS3oihBBCCCGEEHkiQYQQQgghhDU6PRy6CGExxd0SIZ44MpxJCCGEECKrY1fg7ckQEQtqNbz3Jsz4Z3G3ShQyRUYz5Zv0RAghhBBCZDVkTnoAAWA0wsytsP1E8bZJiCeIBBFCCCGEEJml6uCv65bpUzc89qYI8aSS4UxCCCGEEJk52IGzPTxIM08/f6t42iOKjKzOlH/SEyGEEEIIYcHKyaVGTjiFyCBBhBBCCCFEVilplmmO9o+/HUI8oWQ4kxBCPCfiUxVWXFBISIPuNVVUdperqkLY5GhnOZzJqBRPW4R4AkkQIYQQz4HIRIWWvxoIS0h/PPYAbO+qwa+iBBJCWKUzWKbdT3787RBFSpExOfkmh04IIZ4D/95rNAUQAMl6GP+nsfgaJMSTzsXRMu1uAlyNevxtEeIJ9EQHEePHj6dZs2a5yhsREUGzZs2YN29eEbcqXV7aFhQURKdOnYq4RdnL6/G5ePEiw4cP59VXX32sx1UIUfgMRoW1lyyHYVy+J0MzhLDJv7719J1/PdZmCPGkkuFMwoJer2f06NHo9XqGDRuGm5sbNWrUKO5mPXZ79uzh4sWLDB06NNdlli1bhpubW6EGjYqisG3bNvbt28f58+e5c+cOHh4e1KxZk8GDB1OvXj2LMosXL+bChQtcuHCB8PBwfHx8CA4OLrQ2iadL8FWFB3rL9LjU9PeXSiVDmoQwE5sAu05bfy4mwXq6eCopsuJWvj3RPRFjxozhwIEDxd2M5054eDjh4eH07t2bnj17EhAQ8NwGEQsWLMhTmeXLlxf6yXpaWhpjx47l5s2bvPHGG3z66ad06dKFixcvMnDgQLZu3WpRZvbs2Rw7dozy5ctTokSJQm2PeLpMO26ky0brw5YSdXA48jE3SIinwY+/Q9wD6881qPx42yLEE6rAPREGgwGdToejo5WxgwWk1WrRaqWz5HG7e/cuAO7u7oW6XUVRSE5OxtnZuVC3+zQLCgoCYP78+TbzaDQa5s2bR9OmTc3Su3TpQo8ePZg2bRpvvvkmavWjawIbNmygQoUKAPTo0YPkZJkM+DxKSlP4cn/28x7Oxhh5sZzmMbVIiKfErjPW09UqOHYV3mrxeNsjxBMoT2fowcHBTJgwgdmzZ3PmzBmCg4OJiopizJgxdOrUCUVRWLt2LRs2bOD69euo1Wrq1KnDkCFDLOYPbN68mVWrVhEaGoper8fLy4v69eszatQoSpYsCaTPO9i8eTPHjh0zK/vXX38xY8YMLl68iIuLC/7+/nTt2tVme+fOnWtRf1BQEJGRkWZXjQ8dOsTGjRv5+++/iYmJwc7Ojrp16zJo0CCLE7jCcOLECX788UfOnTuHXq/H19eX7t2707lzZ7N8Z8+eZc2aNZw+fZrbt2+j0WioXr06/fr149VXX7XYbm6PjzVBQUGcOHECgAkTJjBhwgQANm3aRLly5UhOTmbhwoXs3LmT6OhoSpQoQcuWLRk+fDg+Pj6m7Rw7doxhw4Yxbtw4kpOTWb16Nbdu3eLdd981DQ/asWMHK1eu5PLlyxgMBtM+tWvXzqJdx44d4+eff+bs2bMkJyfj7e1N06ZN+de//oWHhwcAq1evZs+ePVy7do179+7h7u5OixYtGD58OOXKlTPb3v79+1m6dClXr14lJSUFDw8P6tSpw8iRI6lcubLZccj83hk3bpzNoUoZ+SIjI83KZBy7/NJqtVbff15eXjRp0oTdu3cTGxtLqVKlTM9lBBDi+Xb7QXpvQ3aWn1f4Z4PH0x4hnhrJqdbTjQp8tRpa1ICOuZsXKcSzKl+X+adPn45er6dLly64uLhQuXJ6197YsWP57bff8Pf3p1OnTuh0OrZt28Z7773H1KlTeeWVVwDYsmUL48ePp3HjxgwbNgwHBwdu377NgQMHiI2NNQUR1pw9e5YRI0bg7OxM//79cXNzY8eOHYwbNy4/u2ImODiY+Ph4AgICKFOmDNHR0WzcuJERI0Ywd+5cGjduXOA6Muzdu5dPP/0ULy8v+vbti7OzMzt27GDSpEmEh4fz3nvvmfLu2bOHGzdu0K5dO3x8fIiPj2fz5s18+umnTJo0iTfffNOUt6DHZ9CgQTRs2JDFixfTpUsX0z6XLFkSvV7PyJEjOXXqFP7+/vTt25fQ0FDWrl3L4cOHWbp0KWXKlDHb3vLly4mPj6dz5854eXmZnv/hhx9YtGgRrVq1YtiwYajVanbv3s1nn33G6NGj6dGjh2kba9euZfLkyZQuXZquXbvi4+NDVFQU+/bt4/bt26Yg4pdffqFevXr07NkTd3d3rl69yoYNGzh69CgrVqww5Tt+/Dgff/wx1apVY+DAgbi6uhITE8ORI0cICwujcuXKDBo0CEVROHnyJBMnTjS1pUED22dbEydO5LvvvsPDw4NBgwaZ0rN7PxdUdHQ0dnZ2uLm5FVkd4ulVxR3c7CHByj2zMuwOS59gXaOkjAsWAoCb0XDkSvZ5tp+QIOIZYVTLd19+5SuISElJYdmyZWZDmHbv3s22bdv4/PPPeeedd0zpvXr1YuDAgXz77bf4+fmhUqnYs2cPLi4uzJkzx2y40rBhw3Ks+7vvvsNoNLJw4UJT8NK9e3cGDx6cn10xM2bMGJycnMzSunbtSo8ePVi8eHGhBREGg4GpU6fi5OTETz/9hLe3N5A+7GTo0KH89NNPdOrUiUqVKgEwePBgRo4cabaNXr160adPHxYuXGgWRBT0+Lz44ototVoWL15MgwYNCAgIMD23fv16Tp06Rb9+/fjggw9M6S1btuTDDz9k1qxZfPXVV2bbi4qKYs2aNXh6eprSLly4wKJFixg4cKBZsNSrVy9GjRrF7NmzCQwMxMXFhdu3b/O///0PX19fFi1aZHayPHz4cIzGR0M1VqxYYfH6+fn5MWLECDZu3MiAAQMACAkJwWg0Mnv2bLN2/fOf/zQ7Dtu3b+fkyZNmxyA7AQEBzJkzB09Pz1yXKYj9+/dz7tw5AgICcHBwKPL6xNNHpVJRqyQcu207jwJ8f8zID6/LkCYhAFi6B1Jz6MLTyudFiHxNrO7WrZvFHIitW7fi4uJC27ZtiYuLM/0lJibSpk0bIiIiCA0NBcDV1ZWUlBT279+PouR+icHY2FhOnz7NK6+8YjpBBrCzs6NPnz752RUzmU9AHzx4QFxcHBqNhnr16nHu3LkCbz/D+fPniYqK4q233jIFEJC+H/3798doNBISEmK1XSkpKcTFxZGSkkLz5s25fv06iYmJQNEfn927d6NWqxk4cKBZeuvWralZsyZ79+41O6kHCAwMNDtRB9i2bRsqlYrAwECz90pcXBx+fn4kJSVx5kz6eNTff/8dnU7HkCFDrF5tzzwPIOM4GY1GEhMTiYuLo2bNmri6unL27FlTPldXVwD++OMP9HorS9YUkYz3VOY/vV6PXq+3SH/wwMaEvodCQ0MZN24cpUuX5qOPPnpMe1D4YmNjSU19NGwgMTGRhIRHK5+kpaWZ5uhkiIyMzPZxVFSU2ffK815H5VzMq98frjzx+/Es1lG2bNlnYj+euToMubh/SkDTJ38/nrE6xJMnXz0RGVfIM7tx4wZJSUm88cYbNsvFxsZSuXJlBg4cyIkTJ/jkk09wd3enSZMmvPzyy7z++uu4uLjYLB8eHg6Ar6+vxXNVq1bN+45kcevWLWbPns2hQ4fM3uxAoS6BGBERAVhvc7Vq1YBH+wrpx23OnDmEhIQQGxtrUSYxMRFXV9ciPz4RERF4e3tbXe2nWrVqXLp0ibi4OLOgwdp75fr16yiKQrdu3WzWlfHlEhYWBkCtWrVybN/Ro0dZsGAB586dM/vyAsxezx49ehASEsLkyZOZOXMmDRs2pFWrVrRv375Ihx5NnTqVzZs3W30u6zyQjh07Mn78eKt5w8PDGT58OAAzZswo0jYXtawBZkaAl8He3h4vLy+ztMxzb6w9znpi9rzX0dzHwNrL2V+syejNf5L341msIyrK/KZlT+t+PHN19H0FJqzCptrl4fWGuGY5L3ji9uMZq6OoyB2r8y9fQYS1lZgURaFkyZJMmjTJZrmME+RKlSqxevVqjhw5wtGjRzlx4gSTJk1i3rx5LFiwoNAmhWZ34m8wmN/O/sGDBwwZMoTk5GR69+5N9erVcXFxQaVSsWTJEo4ePVoobcorRVEYOXIk169fp1evXtSpUwdXV1fUajXBwcFs377d4ur/k8TWql0qlYoZM2aY9SRklvFeya1z584xcuRIKlSowMiRIylXrhwODg6oVCo+//xzs2Pk4eHB0qVLOXnyJIcPH+bkyZN89913zJs3j+nTp2c776Eg+vfvT4cOHczSpk2bBsCHH35olp65hyqziIgIhg0bRnJyMj/88APVq1cviqaKZ8i7ddV8vtdAdt8SnarJmGAhTKr7QCk36/eDaFwFto4BubeKEIV3s7mKFSsSGhpK/fr1c7WEp729Pa1bt6Z169ZA+vjuDz/8kF9//ZV///vfVstkrHBz48YNi+euXbtmkZZxxfz+/fsWz0VERJjNxzhy5Ah37txh7NixvPXWW2Z558yZk+P+5EX58uUB623OSMvIc/nyZS5dusSQIUMsbnq2YcMGs8d5PT55Vb58eQ4ePEhCQoLF0KJr167h4uJimrycnYoVK/Lnn39StmxZqlSpkm3ejJ6MS5cumQ3Rymr79u0YDAZmzJhhOnYAycnJFr1KkL5sarNmzUyrKF2+fJm+ffuycOFCpk+fDuSv9ym7MlWrVrXoEco4ji1btsxx2xEREQwdOpTExER++OEHateunef2iedPGRcVIxqrmHXSem/EqxXh/1rKpTghzAQ0TZ8bkVVsIpR9ent/hShMhfbLERgYiNFoZNasWVafzzz2LS4uzuL5jBOi+Ph4m3VkLAMbEhLCzZs3Tek6nY5ly5ZZ5M84AT1y5IhZ+vbt27lz545ZmkaTPkkq6xyNQ4cOmY2nLwy1a9embNmyBAcHExMTY0rX6/X8/PPPqFQq00pWGVfqs7brypUr7Nmzxywtr8cnr9q2bYvRaGTJkiVm6QcOHODixYv4+fnZ7FnILGPS8ezZsy16hMD8veLv74+dnR0LFiwwzf3ILOO42Hr9Fi1aZNFTY+395+vri6Ojo1nAmTHHIrv3ZFZOTk5Wg9aCioyMZNiwYSQkJDBr1ixeeOGFQq9DPLu+baumoqv15ya1VuNsJ1dVhTDTv6319FjL3yHxdFPUqlz/CXOF1hPRrl07OnXqxKpVq7hw4QJt2rTBw8OD6OhoTp8+za1bt9i4cSMA7733Hm5ubjRu3JgyZcqQkJBAcHAwKpUqx1VtPvroI4YOHcrgwYPp3r27aQlTayejvr6+tGjRgnXr1qEoCjVr1uTSpUvs2bOHihUrmk2qbdSoEV5eXkybNo3IyEhKly7NpUuX2Lp1K9WrV+fKlRyWe8sDjUbD6NGj+fTTTxkwYABdunTB2dmZnTt3cubMGQYOHGgKgKpUqULVqlVZunQpKSkpVK5cmdDQUNatW0f16tU5f/58vo9PXnXq1InNmzfz008/ERERQZMmTQgLC2PNmjV4eXmZrbSUnbp16xIUFMT8+fPp06cP7dq1w9vbm5iYGM6fP8+BAwc4dOgQAGXKlGHUqFFMmTKFXr16ERgYiI+PD9HR0YSEhDB27Fhq1apF27ZtWbZsGR988AFdunTBzs6Ow4cPc+XKFYvekUmTJhEdHU3Lli3x8fEhNTWVnTt3kpSURGBgoClf/fr1WbVqFZMnT6Z169ZotVrq1atn1tORVf369dm4cSNz5syhSpUqqFQq/Pz8LFaNyoukpCSGDRtGREQEPXv25ObNm2ZBIqT3ZGQeX7plyxbTpLS4uDh0Oh0//vgjkD7ONPN+imefvUbFkAYqxv5p2RtRr5SVAkI87+7bWNwiIRmOX4WmeRtyK8SzqFBvBz1u3DiaNWvG+vXrWbJkCTqdDi8vL2rXrm12gtmtWzd27tzJunXriI+Px93dnVq1ajF69GiLm8Jl1aBBA2bPns2sWbP46aefcHV1Nd1MrVevXhb5J06cyDfffMP27dvZunUrjRs3Zu7cuXz99ddmM//d3NyYNWsWM2bMYOXKlRgMBmrXrs306dPZuHFjoQYRkL706A8//MDChQv5+eef0el0+Pr6MmbMGLObzWk0GqZPn860adPYvHkzycnJVKtWjfHjx3Pp0iWLICKvxycvtFots2bNMt1sbvfu3bi5ueHv78+IESMsJlZlJygoiDp16rBixQqWL19OcnIynp6eVKtWjU8++cQsb7du3ahQoQJLly5lxYoV6HQ6vL29ad68uem+E40aNWLq1Kn8+OOPzJ07FwcHB1q0aMH8+fMZMmSI2fYCAgIIDg5my5Yt3Lt3DxcXF6pWrcqUKVPw9/c35Wvfvj0XL15kx44d7Nq1C6PRyLhx47INIkaMGEF8fDyrV68mISEBRVHYtGlTgYKI+Ph406T5lStXWs0zd+5csyBi48aNppvlZc4D0KRJEwkinkOvVVYz9k/ziwl1vaCEgwxlEsLCizXBTgM6KxfgNh6RIEIIQKXkZY1VIYQQT61xBwxMPqKQZki/Ed26tzU0Ki1d9MVBp9OxePFiAAYOHIidnV0xt0hYeHMi/PaXZfqcoTCs/WNvjigaG0vmfrj32/cKvlz+4xYeHs7evXuJjo6ma9euVKhQAYPBYLqInzEcPD8KtSdCCCHEk2vCyxr+1UQhMhHqlAK1rDAjhG13razOpAL+4ffYmyKKjvKMfg0qisKoUaOYNWsWer0elUpF/fr1qVChAomJifj6+jJx4kSL1SHzQvqxhRDiOeLlpKKet0oCCCFycinCMs3FAdzyPzxViMflm2++Yfr06XzyySfs3LnTbOEZd3d33nnnHdauXVugOiSIEEIIIYTI7JcQuJ9smV6rcO5jJURRW7BgAf379+e///0vjRo1sni+QYMGXLp0qUB1yHAmIYQQQojMvt9kPX2Qv/V08dR6VpduDQsLo1WrVjafd3FxKfCS9NITIYQQQgiR2c0YyzQ7LQyWIEI8HUqXLk1YWJjN548fP266nUB+SRAhhBBCCJFZWQ/LNA8XcJBVtMTT4Z133mHu3Llcu3bNlKZ6OBdux44dLFmyhO7duxeoDgkihBBCCCEys3bHar8XHnszhMivCRMm4OPjQ6NGjejfvz8qlYopU6bQunVrOnToQIMGDfj8888LVIcEEUIIIYQQmY0MgNfqP3pcpQxM6V987RFFxqjK/d/TxN3dnUOHDjF69GjCw8NxdHQkJCSEuLg4xo0bx759+3B2di5QHTKxWgghhBAiM2cH2DUBTlyFhBR4uTZo839TLiGKg5OTE2PGjGHMmDFFsn0JIoQQQgghrGlSrbhbIMQTS4IIIYQQQgjxXHpWl3gdNGhQjnlUKhULFy7Mdx0SRAghhBBCCPEM+eOPP0yrMWUwGAxERkZiMBjw9vbGxcWlQHVIECGEEEIIIcQz5MaNG1bTdTod8+bNY9q0aezcubNAdcjqTEIIIYQQ4rmkqHL/9yyws7Nj5MiRvPHGG4wcObJA25IgQgghhBBCiOdIw4YN2bt3b4G2IUGEEEIIIYQQz5GdO3fKfSKEEEIIIYQQj0ycONFqelxcHHv37uXEiRN89tlnBapDggghhBBCCPFcUlTPyGSHLMaPH281vWTJklSrVo25c+cyZMiQAtUhQYQQQgghhBDPEKPRWOR1yJwIIYQQQgghRJ5IT4QQQuQg5oFC8FUFdwfoWE2FvSb77u/D4UZO3lZoVUFFg9JPzrWav27pOXRTT9OKWppXkq9/ITJTDEaU7WchMh5Vh3qoypcs7iaJx8D4jIxmCg0NzVe5SpUq5btO+RURQohsHI5UeH21gYS09Md1vWBfbw0lHa3/8rz/m55Zxx91I0/00/Bla83jaGq2xm17wMTfUkyPP27ryLedC7YyhxDPCiVFh6HddygHrqYnOGjRrB+OukP94m2YELnk6+trcYfq3DAYDPmuU4IIIYTIxuf7jKYAAuDcXZh7SuH/Wlp+WV+8q5gFEABf7TcwtLGa0i7Fd7krMt7If3emmKV9H5LCiNYOVCtV/AGOEMVNWX7kUQABkKrH8MkaCSLEU2PRokX5CiIKQoIIIYTIxsVYJVdpAJespOuMcD1OKdYg4tpdA/osc+wUBS7fMUgQIQSgXLptmXjRSpp45ijqZ2M807vvvvvY63xyBusKIcQTqF1lyx8Ya2kAL1dQ4ZTl0kwpJ2hUpnh/pJpU0OLpbN4GF3t4yVeuIwkBoGr3Qq7ShBCPyC+IEEJk43+vqAlPNPL7TQWtCvwqQgdf63k9nVQs7aRhyFYDcang4wq/vqXFQZtzEJGUprDmbwNxyfBOHTUV3bO/xmMwKgSf13PlrsLr1TU0LGe7R8HJXsWKAa784+dE7iQqlHJRsai3C+5OhXsdyWhUOH4ymcjbOhrUdcK3sn2hbl/knaI3ErvpJinXEvB4swIu9TxzLJN6LZ77G6+h9XbCvWt11Fkj40KgO32blB1X0VbzxLFTTVTawnsvKvdT0K8+CQ90aLo2RF3OPccyav8XUCa+hfG/WyFFDy/4oJnXt9DaZBKXBKv/hDQ9dHsJynhknz/0Dqw/DB4u6fldHAu/TeKZduDAAU6cOEF8fLzFsq8qlYovv/wy39uWIEIIIbJRylnF923VtF5hID4V/giFOkuM/NlHRTUP8+BAb0yfExGXmv44KhGuxim8mkMdMUkKL/2YypWHw6E++x229bWnbRXrgYHRqNBhcTI7Lz+aEDf7bQdGvGT7pH3NX2ncSVRM9e25oqdTvcI7yTcaFb7+NprT59LnXvxKHIP6etK+nVuh1SHyRtEbOdtuK/dDItMTRh+m2vw2lP1nbZtl7m+9wY3OW1B06ScbjpOPU/3P7mhKFN57JWneceKGb4GHo//sX/Wl1M6+qDQFDySMEfGkvPgdSlhcesLnm3H8fQSalr45F46MTw8gAM5HYvz+dzTTeha4TSY3o+Gl/4PIe+mPv/gVdk+ExlWt5999BgL+AykPJ2VNWgOHJoOXfKZEzmJjYwkMDOTIkSMoioJKpUJR0j90Gf8XNIiQ4UxPoGPHjtGsWTOCg4OLrQ0XL15k+PDhvPrqqzRr1ox58+YVW1uEKG7/OWwkPvXR4+gHMPWI5Y18gi8rhIQ+mhehAJ/vMaA3Wp9DkWHuMb0pgID085gxf+ht5v/tssEsgAD44rdUUvU25mpEG5h/MNUsbVpICmH38r8qR1anzqaYAogMK9fFodNlv++i6MQG33wUQAAoEPr5UZSsE2Qyify/P00BBEDKuVhiF/9daG1SdAbiP//DFEAApO2+QcrWy4Wyff30kEcBBEBiKrrx23Nu15VojHP3mqUZZ/6BcvNuobQLgG83PQogAOIfwFerbecfs+xRAAFwJRLm/lZ47REAKKrc/z1NPv30U06fPs2yZcu4du0aiqLw22+/cenSJYYNG0ajRo2IiIgoUB0SRAgLer2e0aNHExoayrBhw5g4cSKvvfZacTfrsduzZ0+eg6dly5YVSfB39uxZvvnmGwYNGkSbNm3yFGTGxMSYgsGff/650Nv2PLgeb3kifD3eSr44y3x3HkBimmVes3L3rGz/nu0Tveuxls/FpUBcsvUT9htW8hsVCM2mjryKvmMZ9CQ9MJKUVPR3TRXWpVxPsEjT3UnBkKizWSbt+v1cpeWX8X4qSmyyRbrhelzhbP+65Um/tbSslBsx6asNmBVUCjeIuB6du7Rs88tkb5E7W7duZejQofTs2RM3t/TeK7VaTfXq1Zk9eza+vr58+OGHBapDgognUJMmTThw4AABAQHFUn94eDjh4eH07t2bnj17EhAQQI0aNYqlLcVpz549LFiwIE9lli9fXiRBxIEDB1i9ejWJiYl5fi2mTp1aoHWgBQRUsfyqDKhqeVmqfVUVWVNfKq/Cw8Y9JUzbqmk5bCmghu05Dm/U0JJ1QZEm5dWUcbP+ld6qihb3LG3wdlXRrBBvONewviPqLNX7VrbHw0NWfyouJd+sSNY3pNtLpdF6ONgsUyLAN1dp+aXxcsaueTnzRLUKh/bVCmf7HSwnQ2sC6uRYTvVSNfDIct8ULxdULaoUSrsA6NDYMi2gSTb5rTwX0LTw2iOeaXFxcdStWxcAV1dXABITE03Pv/HGG/z2W8F6tiSIeIIkJSUB6ZGig4MDGk3x/PjevZt+5cXdPefJaHmhKAoPHjwo1G0+7YKCgggKCsoxX7du3QgJCWHVqlX06dMn19sPCQlhz549/POf/yxIM597/3gBmpUBtQrs1TCikYqRjS0Dg7reahYGaij98Fykghu8U0tlc5hRhs611XSro8ZOnX7O17m2mm/esLOZv3opNbPecsDt4blgw7Iqlvdyspnf1UHFVwFOlHyYpaa3ivWDXHM14Tu3ypa2Y/hgT1xd0n9WypbR8v5Qr0Lbvsg75zolqTi+CWqX9GDRtaU3NX/JfoZO+Zmv4NLGB1SgctJQZnwL3N7I/o62urD73Jt6mHvfHEEfkZhtXgDPZe+gqesNgKqEPe5zA7GrVSrbMkpCKinzDpM84Xf0pyJt5tO+2xK7T18Dh4cBcrkSqFvbmHOQicrFAfXaYZAxCbu8B5q1w1A52v4cAvDrAWg7CfrPgdtx2ecd0i49aNCqQaOGfq/AmG6283/7bnp+lQrstTCyA7zzYo77IvJGUaly/fc0KVeuHFFRUQA4ODhQunRpTp06ZXo+PDy8wPeVkInVhSQ4OJgJEyYwe/Zs/vrrL4KDg7l79y6VK1dm4MCBtG/f3ix/p06d8PHx4eOPP2bWrFmcOXMGd3d3Nm3axLFjxxg2bBjjxo2jU6dOpjKKorBhwwY2bNjAtWvXgPQ3yauvvsqwYcNM+dLS0vjll1/Yvn07t27dwt7ensaNGzN06FBq17Y9oQ7ST2pPnDgBwIQJE5gwYQIAmzZtoly5ciQnJ7Nw4UJ27txJdHQ0JUqUoGXLlgwfPhwfHx/TdjLvQ3JyMqtXr+bWrVu8++67DB06FIAdO3awcuVKLl++jMFgoHr16vTr14927dpZtOvYsWP8/PPPnD17luTkZLy9vWnatCn/+te/8PDwAGD16tXs2bOHa9euce/ePdzd3WnRogXDhw+nXDnzK1/79+9n6dKlXL16lZSUFDw8PKhTpw4jR46kcuXKZsehWbNmpnJZX5PMMvJFRkaalck4dgXh5ZX3k7GkpCSmTp1K165dqVMn5ytxwrozdxRaLzdy/+GQJEc7GNZQjdbG2uIDG2q4m6zw6R9GbiXAp38YWXdRYW8/rc0yPValse78o2E/vh4qPJxsf7mHxhmZ+EcaCQ+nOVyIUYhMMFLT2/p1oVn7UvjXukcBvLuTmuaF2AuR4eLlNBIfDl+Kuq1nffB93h+a/cmhKDoxq64SNuFk+tg1QH8vDa2n7V4IgKQDEST9GQUKKMkG7i29QKmRDdB6WQ9SU09Fc6vNcpSHd2S8999DlN/fB4e6tl/3lN+uYjh3BwDlfhoP5p/AZUBDVPY2FhKIT+F+yx8wXkwvkzzxD1yW9cKhZwOLvCqVCip7QurD4XUR90nrugjj56/j8J+O2e47K49CxMNxiuFxGH/cj/qVWrbzBy2EBbsfPV51GG5Mg7Ie1vP3/h62nnj0uKQrOGXzejxIhVM30odZpelh/k54qzm83ij7/RAC8PPzY+fOnXzxxRcA9OzZk6lTp6LRaDAajUybNs3i3DSvJIgoZDNnziQ5OZlu3dKvLgQHB/PFF1+QlpZmcfJ5+/Zthg8fTrt27XjttddyvEo/duxYtm3bRr169Rg0aBBubm7cuHGDXbt2mYIIvV7P+++/z+nTpwkICKBHjx4kJiayfv16Bg8ezIIFC7I9oRw0aBANGzZk8eLFdOnShcaN07tfS5YsiV6vZ+TIkZw6dQp/f3/69u1LaGgoa9eu5fDhwyxdupQyZcqYbW/58uXEx8fTuXNnvLy8TM//8MMPLFq0iFatWjFs2DDUajW7d+/ms88+Y/To0fTo0cO0jbVr1zJ58mRKly5N165d8fHxISoqin379nH79m1TEPHLL79Qr149evbsibu7O1evXmXDhg0cPXqUFStWmPIdP36cjz/+mGrVqjFw4EBcXV2JiYnhyJEjhIWFUblyZQYNGoSiKJw8eZKJEyea2tKggeWPVoaJEyfy3Xff4eHhwaBBg0zpJUuWzPZ1LSqzZs3CYDDw3nvvceHChWJpw7NgypFHAQTA/bT0tF8CrZ/wpOoVJh0wnwdwMFxh82WFzrUsA4PjEUazAAJg5hEDo1sr+LhZDyRm/plGVMKj3o1UPXz1RxqvVLX8StcbFMZtMx+DfjTUwPrTafRskv0JZV7cidGzK8T8KvT+g0l06ViCCuVlqdficPPL46YAAiDlUjzRP12m3Af1bJaJGncYDI/KpF27T+zCvyk92vowmntfHzYFEADGuFTivjlCmSXWh+MqeiMJ4/aYpemORZC8/gLOPetaLZO29IQpgEivRCH5yx1WgwjFYET3+WaLdP03f2A/2h+Vu/VgSLkRg3HBfvO0Xw6jfB6A6gUfKwUUWBRinpaqh0+Xw8/DLfOfvAZrD5mnzd4Gn3UBHxvL7v6wHcJjHz1O08OEVRJEiFz5+OOP2blzJ6mpqTg4ODB+/HjOnTtnWo3Jz8+PmTNnFqgOCSIKWVxcHCtWrDCNP+vWrRu9evXi+++/5/XXX8fR8dEaz+Hh4YwZM4bOnTvnuN2dO3eybds2OnTowIQJE1BnGnyced3flStXcvz4cWbOnMlLL71kSu/WrRs9e/Zk2rRpzJ8/32Y9L774IlqtlsWLF9OgQQOzeRnr16/n1KlT9OvXjw8++MCU3rJlSz788ENmzZrFV199Zba9qKgo1qxZg6fnoy/JCxcusGjRIgYOHMh7771nSu/VqxejRo1i9uzZBAYG4uLiwu3bt/nf//6Hr68vixYtMk0OAhg+fLjZvq9YsQInJ/MfCD8/P0aMGMHGjRsZMGAAkD7Ex2g0Mnv2bLN2ZR7y8+KLL7J9+3ZOnjyZ67kpAQEBzJkzB09Pz2Kbz5LhzJkzrF27lkmTJpnei0+i2NhYXFxccHBIP5lNTExEURTT65yWlkZCQoJZT0xkZKRZr1fWx1FRUZQpU8bUTVvQOsKtjM64HpuKojhZrSMxDbOVnDJcikqEWiUs6gi/bznUyWCEszfuULaet9U6blmZ6B0WZ+Tu3bsW++FasiyxDyzzh8cbC/VY3YszWMxLBbhyLYby5XwK7fWw9riwX/PHVUfZsmVNww2Koo608CSL1+PepWh8Hi7taK2OtDDLN3zClRhKZ3qcuQ59uOXk7QfX7pqWj8xah5Ksw3jXcmJ1wsVInHkURGSuw3jLchUDQ1i81TrsdcD9FIv86Azcu3wLz2aP5pRlrkOJiLecWA0Yw2LRPAwizI6V3oBiMFrMgdJdiyLzAChTHbesTNA2GIk5cwWvss2tvx7hlmWUW3eJtfI5fxY/H1kfi7ypX78+9evXNz0uWbIkv//+O3FxcWg0GrPzqfySORGFrFu3bmYnba6urnTt2pX79+9z/Phxs7zu7u42h8ZktW3bNgA+/PBDswACMHu8bds2fH19eeGFF4iLizP96fV6WrZsyalTp0hJsfIFmwu7d+9GrVYzcOBAs/TWrVtTs2ZN9u7da3Ejk8DAQLMT9Yw2qlQqAgMDzdoYFxeHn58fSUlJnDlzBoDff/8dnU7HkCFDrL7hM+97RgBhNBpJTEwkLi6OmjVr4urqytmzZ035Ml6fP/74A73e9jKahe3BgwcW+6vX69Hr9RbpBZk7otfrmTRpEi1btuSNN94oxD0ofJ6enqYfGUh/bTK/zvb29hZDubL+qGR9XLZsWbNxngWt4+3qlr0B3V5wtFmHl7OKlyuYl9GqoXtD8/dvRh1tfdWUyNIh4Ouhwr+ut8063q5jef2nc107q/vh5qji1Rrm+TVq6FjXvlCPVVVfe0pmmUTt5qrmpRaF+3pYe1zYr/njqiNzAFEUdXi+XZmsKvauk20d7p0t5w+U7mnee525Dpe3q1vkL9m9rs061G4OOLzma15Ao8KzZyObddi9ZTlZ2qGz9f1QuTqgbmNlDkQNb7MAImsdquaVoZyHeRkvF9RtHpUxO1Z2WlQ+lvMG7Ya/br2OtvXAPcvEbd/SlPJvavv1eLuFxfZVb7d4It67xVFHUTGqcv/3NPn7b+tLM3t4eBRKAAHSE1HofH19LdKqVElf3SE8PNwsvXz58rmePB0WFkapUqVyHBt//fp1UlNTrc4ryBAXF0fZsmVzVW9mEREReHt7U6JECYvnqlWrxqVLl4iLizMLGipVspyQd/36dRRFMQ35siZjcndYWBgAtWplMy71oaNHj7JgwQLOnTtHaqr5peCEhEdXy3r06EFISAiTJ09m5syZNGzYkFatWtG+ffsiHXo0depUNm+27GYHLF6vjh07Mn78+HzVs2TJEm7dusW3336br/LC3PuNVdxKUDHnLwW9EZqUgY45zNP8vp2GPhv1XLkH5V1hZnstVTys/wKVcFQR3MeekVt1nLmt8GIFFfPfskdtY/4EQK+Gdly9a+TbfWkk66BvYzsmtLM9ZOjnf7jy9sIEjocZ8HJW8V1nZ2qWLtyFG7RaFaM/9ObHn2K5ej0N30p2DO7vhYODXKsqLtVmvYyiMxK7/gZabycqjWtCidbZf/eXn+aHRWI0gAABAABJREFULjSBxN23UDvbUebLZrj5V7SZ3+OjZugjErk//zSoVbgPb4T7e1ZWIcqk5M9duPfPYFK3X0FT2YMSU/yznVht97IvzvO7kDzud5Q7Sdh1roPz7Ldt5ndY8S6pnRdgPJr++6F6oQyOG7NfXEJlp0X9eQeMX22B2/ehfnk08/qicspmKN6uz8H/a4iMA40K3vWDvq2t53Vzgk3/B+//CKdvwos1Yd4wyO4coHNLmNIPpm6AhGTo0wa+LoK7aItnUr169ahXrx69evWiR48eVK9uGfAXlAQRxSjz0KbCVL16dT766CObzz/OMfq29lGlUjFjxgyLXpUM1arlbbm/c+fOMXLkSCpUqMDIkSMpV65c+lUplYrPP//crIfEw8ODpUuXcvLkSQ4fPszJkyf57rvvmDdvHtOnT8923kNB9O/fnw4dOpilTZs2DcBirWZvb+981RETE8PixYsJDAxEURRTEHbnTvp44vj4eFNAmnXol7BOo1bRtaaaWScNpBnhUCQ0+dnI/t4qGpa2PNG/Ga8QsFJPzMMRG1FJYJfDebSfr4bTIzQYjUq2wUNmX7zmwBevOZgN6bBl7p8pHA9LX+b37gOFmftS6NPUHq2mcC+tVfV14L/jfPK0H6LoaEs6UHtVOxSjgiqXr8e9Xy+SuOsWAMZEHXfn/43X0Ppo3K3Pn1Fp1Hh/9xqlvk1f9Sk3q71oyrlRamufPLXLcUgLHIe0QDEaUdn43cigLueO05FPUB5+7+eUH8AwZTvGz9Y9SlAUVI2zX5WKF8pDxCzQ60Gbi9Mpv7pw6nswGrFYD9mW0V3S//JSRghgzpw5rFq1irFjx/Lll1/SqFEjU0BRubJlL2V+SBBRyG7cuGGRdv36dSC95yG/KlWqREhIiMWY56wqVqzIvXv3aN68uc0T9PwqX748Bw8eJCEhwaIr7Nq1a7i4uJgmL2enYsWK/Pnnn5QtW9bUS2NLRk/GpUuXsn3Tb9++HYPBwIwZM8yOc3JyslkvRAaNRkOzZs1MqyhdvnyZvn37snDhQqZPnw7k7scwq+zKVK1alapVzS9hZxzHli1b5rkua+7evUtqairr1q1j3bp1Fs8vWbKEJUuWMHny5Gx7q4S5qUeMpGa61UaiDr47ZuSnAMuriD8cN5gCCEifo/qfPw10rJHz5zE/J945vU8TUxW+3W0+hPFYmIGt53W8Va9oJjxLAPFkye2JOsDtr46aPU67Gs+9ZZcoNby+jRIP68jP92V+3u95+F3LbV5Fp8f49TbzxLMRKOtOoOqTi+/m3AQQmeXnt1kCiCLztC3dmltDhw5l6NCh3L59m9WrV7Nq1So+++wzPvvsM1q0aEGvXr3o3r17gVaPlHdlIVuzZo3ZzTwSExNZu3Ytbm5uNG2a/5vEZFzBnjFjhsW8AyXTZLDAwEDu3r3Lr7/+anU7GcOE8qNt27YYjUaWLFliln7gwAEuXryIn59frgKXjEnHs2fPtnoTtMxt9Pf3x87OjgULFpgd1wwZ+54xLEzJMjFu0aJFFscrLi7OYju+vr44Ojpy//6jO7NmXKmPj7dya2IbnJyczLbxuJUvX57Jkydb/GXciyIwMJDJkycXWW/LsyraysTkaBvTVqylRydlf5+IopSYqpBs5QbF0QlyJ2lhTlEU9HcsJz3rbb3ZnxUpequTsZVoywtQQjxtypQpw8iRI9m7dy+hoaF8++23qFQqRo0aVeAeCemJKGQeHh4MGDDANGE6ODiYqKgoxowZU6DhS+3ateP1119ny5YthIWF4efnh5ubG6GhoRw8eJBVq1YB0Lt3bw4fPsz06dM5evQozZs3x8XFhaioKI4ePYq9vT3z5s3LVxs6derE5s2b+emnn4iIiKBJkyaEhYWxZs0avLy8zFZayk7dunUJCgpi/vz59OnTh3bt2uHt7U1MTAznz5/nwIEDHDqUvhRemTJlGDVqFFOmTKFXr14EBgbi4+NDdHQ0ISEhjB07llq1atG2bVuWLVvGBx98QJcuXbCzs+Pw4cNcuXLFondk0qRJREdH07JlS3x8fEhNTWXnzp0kJSURGBhoyle/fn1WrVrF5MmTad26NVqtlnr16mXbo1S/fn02btzInDlzqFKlCiqVCj8/vwIPHYqMjGTLli0ApnuE7N27l9u3bwOYjourq6vN+2xA+lA36YHIu+611PwZYX7S3c3Kcq0A3WurWXI6S97axXe9pmwJNa2ratl/7dEiAk52EFhHll0V5lQqFR5dqxG38vKjRI0K9y6FczfpJ5XKzRFV+zoo2889SrTToH6rYfE1Sogi4OPjQ926dXnhhRc4e/as6SbH+SVBRCF7//33+euvv1i9ejWxsbFUqlSJSZMm8eabbxZ42//5z39o3LgxGzduZMGCBWg0GsqVK2d2UqjVapk2bRpr1qxh69atpoDB29ubunXr0rFjDjfbyYZWq2XWrFmmm83t3r0bNzc3/P39GTFiRJ4mawcFBVGnTh1WrFjB8uXLSU5OxtPTk2rVqvHJJ5+Y5e3WrRsVKlRg6dKlrFixAp1Oh7e3N82bNzfdd6JRo0ZMnTqVH3/8kblz5+Lg4ECLFi2YP38+Q4YMMdteQEAAwcHBbNmyhXv37uHi4kLVqlWZMmUK/v7+pnzt27fn4sWL7Nixg127dmE0Ghk3bly2QcSIESOIj49n9erVJCQkoCgKmzZtKnAQER4ezty5c83Sdu/eze7du037L0vhFZ1/NVFxN1nF/NMKWjW810jN4PrWA4OA6mp+aK9h6iED99Ogb101E/2K5+7zGVb0d2Xk2iS2n9fh4qCifS1t5lsBCGFSYe6rqOzVxG+8jl15F8pOfBGnBs/+DQM1Pw3EMHI5yrazUKUUmq+7oKqav7lp4umiPJujmUwURWHPnj2sXLmS9evXExMTQ8mSJenVqxc9e/Ys0LZVStbxHyJfMu5YPXfuXLO7FQshxJNgwcEUglY+GpZSxk3FyU/c8XGXUa3FQafTsXjxYgAGDhyInZ1dDiWEEEXhpyprcp13wHXbq0o+afbt28eqVatYs2YN0dHRlChRgs6dO9OzZ0/atWuHNq9zeayQngghhHgOfP27+Zjv2wkKi4+k8vnrskqXEEI8a1555RVcXV3p1KkTPXv25M0338TevnCHsUoQIYQQz4G4ZMtOZ2tpQgghnn6rV68mMDCwyG4nALI6kxBCPBf+0dT8CpRaBT0by+RqIcTzzahS5frvadK1a9ciDSBAeiIKTadOnUwrMgkhxJPmm7ecsdeoWP1XGqXdVIx53YmmFeUnQAghRP7IL4gQQjwHHO1UfNvZmW87Oxd3U4QQQjwDJIgQQgghhBDPpWd9ideiJHMihBBCCCGEEHkiQYQQQgghhBAiTySIEEIIIYQQzyVFpcr139Pm/v37TJ48mfbt29O4cWOOHDkCQGxsLN999x1Xrlwp0PZlToQQQgghhBDPkFu3bvHKK68QFhZGjRo1uHDhAomJiQB4enoyb948bt68yfTp0/NdhwQRQgghhBBCPEM+/fRTEhIS+OuvvyhdujSlS5c2e75z585s3ry5QHXIcCYhhBBCCCGeITt27OBf//oXderUQWVlKFbVqlUJCwsrUB3SEyGEEEIIIZ5LT+Nch9xITk7G29vb5vMJCQkFrkN6IoQQQgghhHiG1KlTh71799p8fsOGDTRu3LhAdUgQIYQQQgghxDPkww8/ZMWKFUyZMoX4+HgAjEYjV65coV+/fhw8eJCPPvqoQHXIcCYhhBBCCPFcelbvWN23b19u3rzJmDFj+OKLLwB48803URQFtVrNf//7Xzp37lygOiSIEEKI54iiKABWJ9oJIYR4dnzxxRf069ePtWvXcuXKFYxGI9WqVeOdd96hatWqBd6+BBFCCPEcMBgVPg0xMv+0gloFwxqqmOynRi3BhBBCPFMePHhAmzZtGDJkCMOGDSvwsCVbZE6EEEI8B74/rvD9cYUkHSSkwTdHFWafVIq7WUIIIQqZs7Mz169fL/IeZwkihBDiObDuktEibeMVCSLEc05RYOp6qDUSGnwEP+4s7haJx0xRq3L99zR58803+e2334q0DhnOJIQQz4HIJMs0NzsJIsRzbuZW+PfPjx4PmQNebtDlxeJrkxCF4Msvv6R79+7069ePoUOHUqVKFZycnCzyeXp65rsOCSKEEOIZZ1QUwhMt0yuVeLqurAlRqPQG+N9Gy/T5OyWIEE+9unXrAvD333+zbNkym/kMBkO+65AgQgghnnFqlQqtGnRZRjS5OxZPe4R4Iny0CMJiLNP3/Q0paeBo//jbJB67Z/WO1WPHji3yORESRAghxHNAY+W3ZP1lhfa+Ci+XfzZ/RIWwSW+AhbusP5eUCltPwDvSGyGeXuPHjy/yOmRitRBCPAccNJZpZ2PAb4WBLVctJ10L8VyTuFqIHElPhBBCPAfKusDdFMt0owLfHVcIrPb42yREsdFq4B9+8OPvls+pVNChyeNvkygWT9uqS7k1ceLEHPOoVCq+/PLLfNfxRAcR48ePZ/PmzRw7dizHvBEREbz11lsMGTKEoUOHPlFtCwoKIjIykuDg4CJvly15PT4XL15k2rRpXLhwgYSEhMd2XIUQRcOYzUJMCWmySpN4Do3ubD2IUAP2T/TpkRA5ym44k0qlQlGUZzuIEMVDr9czevRo9Ho9w4YNw83NjRo1ahR3sx67PXv2cPHixTwFT8uWLcPNzY1OnToVWjsURWHbtm3s27eP8+fPc+fOHTw8PKhZsyaDBw+mXr16Zvlv3LjBjz/+yIULF7hz5w56vZ6yZcvy8ssv079/f0qVKlVobRNPh9B4I9fibD/fr46MbBXPobIlraeX9gC1fCbE081otBymajQauXnzJrNnz2bv3r1s27atQHU80Z+SMWPGcODAgeJuxnMnPDyc8PBwevfuTc+ePQkICHhug4gFCxbkqczy5csLvccpLS2NsWPHcvPmTd544w0+/fRTunTpwsWLFxk4cCBbt241yx8dHU1MTAyvvvoqI0eOZNSoUbRs2ZL169fTt29fYmNjC7V94sm27ZqRmouMpNqY9tC5Ooxs/Gx25wuRrXtW1j0G0DzRp0ZC5JtaraZKlSr873//o0aNGrz//vsF2l6BeyIMBgM6nQ5Hx8JfK1Cr1aLVSmfJ43b37l0A3N3dC3W7iqKQnJyMs7NzoW73aRYUFATA/PnzbebRaDTMmzePpk2bmqV36dKFHj16MG3aNN58803UD6+ctWjRghYtWlhsp0mTJnz22WcEBwczYMCAQtwL8SQbtcdIajbLgFd0o8iXARTiiWTlSi0A8VbuzCieXc/p95+fnx///ve/C7SNPJ2hBwcHM2HCBGbPns2ZM2cIDg4mKiqKMWPG0KlTJxRFYe3atWzYsIHr16+jVqupU6cOQ4YMoVmzZmbb2rx5M6tWrSI0NBS9Xo+Xlxf169dn1KhRlCyZ3sVoa97BX3/9xYwZM7h48SIuLi74+/vTtWtXm+2dO3euRf3W5ikcOnSIjRs38vfffxMTE4OdnR1169Zl0KBBFidwheHEiRP8+OOPnDt3Dr1ej6+vL927d6dz585m+c6ePcuaNWs4ffo0t2/fRqPRUL16dfr168err75qsd3cHh9rgoKCOHHiBAATJkxgwoQJAGzatIly5cqRnJzMwoUL2blzJ9HR0ZQoUYKWLVsyfPhwfHx8TNs5duwYw4YNY9y4cSQnJ7N69Wpu3brFu+++axoetGPHDlauXMnly5cxGAymfWrXrp1Fu44dO8bPP//M2bNnSU5Oxtvbm6ZNm/Kvf/0LDw8PAFavXs2ePXu4du0a9+7dw93dnRYtWjB8+HDKlStntr39+/ezdOlSrl69SkpKCh4eHtSpU4eRI0dSuXJls+OQ+b0zbtw4m0OVMvJFRkaalck4dvml1Wqtvv+8vLxo0qQJu3fvJjY2NsdhSmXLlgUgISEh320RT5+L97J//nDk42mHEE+U307CO1OtP5eQAncT0u9cLcQz6tixY6aLj/mVr8v806dPR6/X06VLF1xcXKhcuTKQfmOL3377DX9/fzp1+n/27jw+pnt//PhrsghZJOQGsSVIcW1FLL0twY1WK+IrFaS+aEMTQW6rtdzefl3B9f1d1XtdNCGoLVpCbJFYStskKq2t1FYSe8giNBIJE2Yy5/dHvpkaM4lsEon38/GYRzuf8znn8zmfjJnzPp/leKPRaNi7dy9Tpkxh4cKF9OvXD4Ddu3czZ84cunXrRlBQEFZWVty6dYvExESysrL0QYQpZ8+eZfLkyVhbWzNu3Djs7OzYv38/ISEh5TkVAzExMeTk5DB48GAaN25MZmYm0dHRTJ48mfDwcLp161bhMoocPHiQGTNm4OjoyJgxY7C2tmb//v3Mnz+f1NRUpkyZos8bHx/PtWvXGDhwIM7OzuTk5BAbG8uMGTOYP38+b775pj5vRdtn/PjxvPzyy6xduxYfHx/9OTdo0ACtVktwcDCnTp3C09OTMWPGkJKSwrZt2zhy5AgRERE0btzY4HibNm0iJyeHYcOG4ejoqN++bNky1qxZw6uvvkpQUBBmZmbExcXxySefMHPmTEaOHKk/xrZt21iwYAGNGjVi+PDhODs7k5GRwQ8//MCtW7f0QcRXX31Fp06dGDVqFPb29ly+fJmdO3dy7NgxIiMj9fl+/vlnPv74Y9q0aYO/vz+2trbcuXOHo0ePcuPGDVxcXBg/fjyKonDy5EmDFQ66dOlSbNvNmzePRYsW4eDgwPjx4/XpJX2eKyozMxNLS0vs7Ix/7B4+fIharebhw4dcvXqVpUuXAvDaa689s/qI58v9R8pTV6o8nwWaAgVLUw+SEKI20ulgYjg8eFh8nvBv4H98q65OQlSyiIgIk+nZ2dkcPHiQ7du38/7771esEKUMdu3apbi7uys+Pj6KWq022Pb9998r7u7uyrZt2wzSNRqNMmbMGMXb21vR6XSKoijK9OnTFQ8PD0Wj0ZRYXkhIiOLu7m6Q5u/vr/Tu3Vu5du2aPu3Ro0fK2LFjFXd3dyU8PNyovseOHTM6dkBAgDJkyBCDtAcPHhjlu3PnjvLnP/9Z+ctf/vLUuhXnybK0Wq3i5eWl9OvXT8nMzDQ4D39/f6Vnz57K9evXS6yXWq1WfHx8FF9fX4P0srRPcY4dO6a4u7sru3btMkjfvn274u7urixevNgg/YcfflDc3d2VWbNmGR1jwIABym+//WaQ//z584q7u7sSGhpqVPbHH3+seHh4KHl5eYqiKEpGRobyyiuvKL6+vsq9e/eM8hcUFOj/31Q7HTlyRHF3d1fWrVunT/v3v/+tuLu7G9XrSWX5GxcZMmSIEhAQUOr8AQEBZcr/uKJ2//vf/25ye2RkpOLu7q5/eXt7K3v27ClXWc/Kb7/9puTn5+vf5+bmGvydHz58qNy5c8dgn7S0tBLfp6en679rXvQyDpy7pfC55qmvq9m65/o8amMZjx49UqKjo5UVK1Yojx49qrHnUSPLyMxWFHxKfr392fN/Hi9YGc/Kss4xpX7VJCqVqtiXk5OT8re//c3oWr6sytUT4evrazQHYs+ePdjY2NC/f3+ys7MNtvXt25eVK1eSkpKCi4sLtra25Ofnc+jQIfr161fq8bhZWVmcPn0aT09Pfe8HgKWlJaNHj2bWrFnlOR29evXq6f//wYMHPHr0CHNzczp16sTZs2crdOzHnT9/noyMDEaPHo2Tk5M+3dLSknHjxjF9+nQSEhIYO3asUb3y8/PJzy9c7L1nz55s27aNvLw8bG1tn3n7xMXFYWZmhr+/v0F6nz59aNu2LQcPHkSn0xl0j3l5edGwYUOD/Hv37kWlUuHl5WX0WfHw8CAhIYEzZ87wyiuv8O2336LRaAgICDB5t/3xsoraSafT8eDBA7RaLW3btsXW1tbg72drawvA999/z7Bhw6ps3k3RZ+pxWq0WwKgd6tSpU+LckZSUFEJCQmjUqBEfffSRyTz9+/fH1dUVtVpNUlISCQkJRuVUtyc/G0V/myJ16tTB0dHRIO3xYXOm3hcN25Iy4LWXnGhQt4C7Jp4PUaSRNTS3e77Po7aWkZGR8czLqC1tVall/KE+uDnDpRLG8r3S9vk/jxesDFE2V69eNUpTqVQ0aNDA5PVUeZTr6qlly5ZGadeuXeP+/fu88cYbxe6XlZWFi4sL/v7+nDhxgunTp2Nvb0/37t157bXXeP3117GxsSl2/9TUVABcXV2NtrVu3brsJ/KEmzdvEhYWxuHDh43GjVfmxMO0tDTAdJ3btCl84lPRuUJhuy1fvpyEhASTK+sUBRHPun3S0tJwcnKifv36JuudnJxMdna2wZeHqc/K1atXURQFX9/iu4qLJnffuHEDgHbt2j21fseOHWPVqlWcO3eOhw8Nu6kf/3uOHDmShIQEFixYwBdffMHLL7/Mq6++yqBBg57p0KOFCxcSGxtrctuT80CGDBlS7BrPqampTJo0CYClS5cWW+fGjRvrh4/179+fP//5z4wbN478/HyjQFDUTvUsVaweZMa7e3XkPjKdp28zsKilD1sSwiSVClZPhtfnwiOt8XbrOjDlraqvlxCVSKVS4eTkZHAj+nFqtZrbt2+bvE4rrXIFEaZWYlIUhQYNGjB//vxi9yu6QG7ZsiVRUVEcPXqUY8eOceLECebPn8+KFStYtWoVzZs3L0+1jJR04V9QYLhcyYMHDwgICECtVvPOO+/g5uaGjY0NKpWKdevWcezYsUqpU1kpikJwcDBXr17Fz8+PDh06YGtri5mZGTExMezbt8/kWsDPi+JW7VKpVCxdurTYST1Fn5XSOnfuHMHBwTRv3pzg4GCaNm2KlZUVKpWKTz/91KCNHBwciIiI4OTJkxw5coSTJ0+yaNEiVqxYwZIlS0qc91AR48aN4623DH+YFi9eDMDUqVMN0h/voXpcWloaQUFBqNVqli1bhpubW6nLf+mll2jXrh1bt26VIOIF4vOSGa+7qBgYVWByEvX3KfBQq2BlIYGEeIF4dISPvOGzHcbbFMDaqsqrJERlatWqFRs2bGD06NEmt+/atYvRo0cbXQ+XRaWN42jRogUpKSl07ty5VEt41qlThz59+tCnTx+gcLWcqVOn8vXXXxe75FTRCjfXrl0z2nblyhWjtKI75vfu3TPalpaWZjCM5ejRo9y+fZvZs2czdOhQg7zLly9/6vmURbNmzQDTdS5KK8pz8eJFkpOTTT4xeufOnQbvy9o+ZdWsWTN++ukncnNzjbrCrly5go2NjX7ycklatGjBjz/+SJMmTWjVqlWJeYsi5OTkZIMhWk/at28fBQUFLF26VN92UBhpm1qNyNzcnB49euhXUbp48SJjxoxh9erVLFmyBChf71NJ+7Ru3dqoR6ioHXv37v3UY6elpTFx4kTy8vJYtmwZ7du3L3P9Hj58SE5OTpn3EzWbbR1VsROs7z6E47fgtWbFZBCitpoxDD7fafw4d/UjuJIBrZuY2kvUMkotXeJVUZQSt2s0mgqvzlRpT1Tx8vJCp9MRGhpqcnvR8BQwHv8N6C+ISrrAKVoGNiEhgevXr+vTNRoNGzduNMpfdAF69OhRg/R9+/Zx+/ZtgzRzc3PAuNEPHz5cqfMhoPBcmzRpQkxMDHfu3NGna7VaNmzYgEql0q9kVfQHfrJely5dIj4+3iCtrO1TVv3790en07Fu3TqD9MTERJKSkvDw8CjVB3Lw4MEAhIWFmYyAH/+seHp6YmlpyapVq8jLM34wUFG7FPf3W7NmjVFPjanPn6urK3Xr1jUIOIu6AMty0V2vXj2TQWtFpaenExQURG5uLqGhofzxj38sNu/jn6nHHT9+nMuXL9O5c+dKr594vimKwoVinjFopip8VoQQLxxHO6hXxzjdTAVOlfucJCGqwr1790hJSSElJQUovJ4qev/46/Tp00RGRlZ43kml9UQMHDgQb29vtmzZwoULF+jbty8ODg5kZmZy+vRpbt68SXR0NABTpkzBzs6Obt260bhxY3Jzc4mJiUGlUukvMIvz0UcfMXHiRCZMmMCIESP0S5iauhh1dXWlV69ebN++HUVRaNu2LcnJycTHx9OiRQv9pFaArl274ujoyOLFi0lPT6dRo0YkJyezZ88e3NzcuHTpUmU1Febm5sycOZMZM2bw7rvv4uPjg7W1NQcOHODMmTP4+/vrA6BWrVrRunVrIiIiyM/Px8XFhZSUFLZv346bmxvnz58vd/uUlbe3N7Gxsaxfv560tDS6d+/OjRs32Lp1K46OjgbL0pakY8eOBAYGsnLlSkaPHs3AgQNxcnLizp07nD9/nsTERA4fPgwUjuufNm0an332GX5+fnh5eeHs7ExmZiYJCQnMnj2bdu3a0b9/fzZu3MiHH36Ij48PlpaWHDlyhEuXLhn1jsyfP5/MzEx69+6Ns7MzDx8+5MCBA9y/fx8vLy99vs6dO7NlyxYWLFhAnz59sLCwoFOnTgY9HU/q3Lkz0dHRLF++nFatWqFSqfDw8Ch2TGJp3L9/n6CgINLS0hg1ahTXr183CBKhsCejaJLaggULuHPnDj179qRJkyY8evSI8+fPs3//fqytrY2GTona75dMyC5mNcs/t4SW9WvnnTghnqrAxHDgOhZgV/7vbCGqy3/+8x/9svQqlYqpU6cW+5uvKEqJUxBKo1KXpQkJCaFHjx7s2LGDdevWodFocHR0pH379gYXmL6+vhw4cIDt27eTk5ODvb097dq1Y+bMmUYPhXtSly5dCAsLIzQ0lPXr12Nra6t/mJqfn59R/nnz5vH555+zb98+9uzZQ7du3QgPD+ef//wn6em/DxC2s7MjNDSUpUuXsnnzZgoKCmjfvj1LliwhOjq6UoMIKFyFaNmyZaxevZoNGzag0WhwdXVl1qxZBg+bMzc3Z8mSJSxevJjY2FjUajVt2rRhzpw5JCcnGwURZW2fsrCwsCA0NFT/sLm4uDjs7Ozw9PRk8uTJRqszlCQwMJAOHToQGRnJpk2bUKvVNGzYkDZt2jB9+nSDvL6+vjRv3pyIiAgiIyPRaDQ4OTnRs2dP/cThrl27snDhQr788kvCw8OxsrKiV69erFy5koCAAIPjDR48mJiYGHbv3s3du3exsbGhdevWfPbZZ3h6eurzDRo0iKSkJPbv3893332HTqcjJCSkxCBi8uTJ5OTkEBUVRW5uLoqisGvXrgoFETk5OfpJ85s3bzaZJzw8XB9EDBo0iN27d7Nnzx7u3r2LSqWiSZMmvP3224wbN65MfydRO1hbFN+t/UH3SuuQFqLmsasH+RrDtEdayMqFhtJF9yJQVLXnO/CNN97A1tYWRVGYOXMm77zzDt27dzfIo1KpsLGxwd3d/anX3E+jUp42aEoIIUSNFnNZx9AdxndcOzSEU++Zy+pM1UCj0bB27VoA/P39sbS0rOYavaAWbIO/fW2cvmoSvP961ddHVLmwrntLnXfKLzVn1a65c+cyfPhwOnXq9MzKqD3hlxBCCJMsi/mm7/gHWd5VvOAmFrMsfZ2qeX6QEM9KSEjIMw0goJKHMwkhhHj+DHRR0dQG0u4bpu+8BPceKtS3kkBCvKASk0ynv1b84hWidlFq+Y2UxMRETpw4QU5OjtFCMyqVir///e/lPrYEEUIIUctZmKn4ay8VH8YZjl7V6kDz/D5mRohnL7+YpzBKT4So4bKysvDy8uLo0aMoioJKpdKvYFn0/xUNImQ4kxBCvADGdjSjwRPPfhzqpsKxXu2+CydEid7qDo0dDNM8u0CLP1RLdYSoLDNmzOD06dNs3LiRK1euoCgK33zzDcnJyQQFBdG1a1fS0tIqVIYEEUII8QJoUFdF/Chzhrmp6OgIH3ZXEfGW/ASIF5xNXYifB75/gg4tYPKbEDX96fsJ8Zzbs2cPEydOZNSoUfoH25qZmeHm5kZYWBiurq4VXvJd+uuEEOIF0cVJxY5h5tVdDSGeL+2bQ9SM6q6FqCa19YnV2dnZdOzYEQBbW1sAg4f2vvHGG3z66acVKkNuQwkhhBBCCFGLNG3alIyMDACsrKxo1KgRp06d0m9PTU1FVcEASnoihBBCCCGEqEU8PDw4cOAA//M//wPAqFGjWLhwIebm5uh0OhYvXsygQYMqVIYEEUIIIYQQ4sVUO0cz8fHHH3PgwAEePnyIlZUVc+bM4dy5c/rVmDw8PPjiiy8qVIYEEUIIIYQQQtQinTt3pnPnzvr3DRo04NtvvyU7Oxtzc3P9ZOuKkCBCCCGEEEKIF4CDg0OlHUsmVgshhBBCiBeSolKV+lXTpKSkEBQURLt27WjYsCEHDx4E4M6dO3zwwQecPHmyQseXngghhBBCCCFqkV9//ZW+ffui0+no3bs3ly5dQqvVAvCHP/yBQ4cOcf/+fVavXl3uMiSIEEIIIYQQohaZOXMmDg4OHD58GJVKRaNGjQy2e3l5sXnz5gqVIcOZhBBCCCGEqEUOHjzIpEmTcHJyMvk8iJYtW5KamlqhMqQnQgghhBBCvJAUs5o316E0dDod1tbWxW6/ffs2VlZWFSpDeiKEEEJUqivZCnMSC5iTWMDlbKW6qyOEEC+c7t27s3v3bpPbtFotkZGRvPLKKxUqQ4IIIYQQlebELYUu6wuY+5PC3J8UOq0tIPGmrrqrJYQQL5S//e1v7Nu3j0mTJnH27FkAbt26xbfffssbb7zB+fPn+eSTTypUhgxnEkIIUWk+P6bjvub39/kFMGCLjqih8F9uct9KCPF8qYlLt5bGW2+9xbp16/jwww9ZuXIlAGPGjEFRFOrXr09ERAQeHh4VKkOCCCGEEJUm84FxmkYHfjE60iZBg7oSSAghRFUYO3Ysb7/9Nvv37+fSpUvodDratGnDoEGD5InVQgghni9vv6Ti+xTjeRD5BfD+Nzq2/ZcEEUII8Sx8+umn+Pn50aVLF32ajY0NPj4+z6Q8+TYXQghRaSZ3VfHf7U1v23MFFEUmWgshxLOwYMEC/fwHgN9++w1zc3O+//77Z1Ke9EQIIYSoNCqViss5prfZ1MHkeuVCCFFdauuciCLP8saN9EQIIYSoNCt+KeBwuultH7vLT44QQtQW0hMhhBCiUiTcUAj61vRdr9dd4NNXJIgQola7ngk7jkBDW/B9Fawr9jAz8XyTIEIIIUSlWH2m+OdBHEqF+BQd/VtKICFErfTtKRjy/+Dh/63xPH8bHP4nNKz4KkDPUm0bznTt2jVOnDgBQE5O4djSixcv4uDgYDJ/9+7dy13Wc/1tPmfOHHr06FGqvGlpafTo0YMVK1Y841oVKkvdAgMD8fb2fsY1KllZ2ycpKYlJkyYxYMCAKm1XIUTNlX6/+LG3ai38PVEeOidErfU/G38PIAAupsGYxdVWnRfV3//+d3r27EnPnj0ZOHAgAJMnT9anFb169OhBz549K1SW9EQII1qtlpkzZ6LVagkKCsLOzo6XXnqpuqtV5eLj40lKSmLixIml3mfjxo3Y2dlVetB49uxZ9u7dy/nz57l48SJqtZqQkBCT5Tx48ICvvvqK8+fPk5SURGZmJt27d9c/bEaIZ6VdA/j2evHbrxYz4VoIUQtcvWWctvckJJ6H1/5Y9fV5Aa1du7ZKy3uug4hZs2bxt7/9rbqr8cJJTU0lNTWVqVOnMmrUqOquTrWJj48nNja2TEHEpk2bcHZ2rvQgIjExkaioKFxdXXnppZc4ffp0sXmzs7NZuXIljo6OtG/fnt9++61S6yJEcbo2Knn74Na1a9iAEOIxr/0Rdh4xTj9w6rkOImrTcKZ33323SsurcBBRUFCARqOhbt26lVEfAxYWFlhYPNdxTq1UdNFpb29fqcdVFAW1Wo21tXWlHrcmCwwMBHhqL4Gvry/jxo2jXr16fPvttyUGEX/4wx/YvXs3jRs3BqBv376VV2EhSnD9ngowPaTJ2QY+7/dcj6AVQlREO2fT6S8Vky5qvDJdocfExDB37lzCwsI4c+YMMTExZGRkMGvWLLy9vVEUhW3btrFz506uXr2KmZkZHTp0ICAgwGj+QGxsLFu2bCElJQWtVoujoyOdO3dm2rRpNGjQACicdxAbG8vx48cN9v3ll19YunQpSUlJ2NjY4OnpyfDhw4utb3h4uFH5gYGBpKenExMTo087fPgw0dHR/Prrr9y5cwdLS0s6duzI+PHjcXd3L0tTlcqJEyf48ssvOXfuHFqtFldXV0aMGMGwYcMM8p09e5atW7dy+vRpbt26hbm5OW5ubowdO5YBAwYYHbe07WNKYGCgfkLO3LlzmTt3LgC7du2iadOmqNVqVq9ezYEDB8jMzKR+/fr07t2bSZMm4ez8+xfF8ePHCQoKIiQkBLVaTVRUFDdv3uS9997T39nfv38/mzdv5uLFixQUFOjPqWgM3+OOHz/Ohg0bOHv2LGq1GicnJ9zd3fnggw/0k4WioqKIj4/nypUr3L17F3t7e3r16sWkSZNo2rSpwfEOHTpEREQEly9fJj8/HwcHBzp06EBwcDAuLi4G7fD4Z6e4IUSP50tPTzfYp6jtKsLR0bHUeevUqaMPIISoSpEXip8T0dtZhb1V7bnjJ4R4jKLAvpOmt9WTFZpqq3Ld5l+yZAlarRYfHx9sbGxwcXEBYPbs2XzzzTd4enri7e2NRqNh7969TJkyhYULF9KvXz8Adu/ezZw5c+jWrRtBQUFYWVlx69YtEhMTycrK0gcRppw9e5bJkydjbW3NuHHjsLOzY//+/YSEhJTnVAzExMSQk5PD4MGDady4MZmZmURHRzN58mTCw8Pp1q1bhcsocvDgQWbMmIGjoyNjxozB2tqa/fv3M3/+fFJTU5kyZYo+b3x8PNeuXWPgwIE4OzuTk5NDbGwsM2bMYP78+bz55pv6vBVtn/Hjx/Pyyy+zdu1afHx89OfcoEEDtFotwcHBnDp1Ck9PT8aMGUNKSgrbtm3jyJEjREREGF28btq0iZycHIYNG4ajo6N++7Jly1izZg2vvvoqQUFBmJmZERcXxyeffMLMmTMZOXKk/hjbtm1jwYIFNGrUiOHDh+Ps7ExGRgY//PADt27d0gcRX331FZ06dWLUqFHY29tz+fJldu7cybFjx4iMjNTn+/nnn/n4449p06YN/v7+2NracufOHY4ePcqNGzdwcXFh/PjxKIrCyZMnmTdvnr4ujz9K/knz5s1j0aJFODg4MH78eH16SZ9nIWqTG/eK3xb0sgQQQtRaa7+HU8VMiDI1V0LUCuUKIvLz89m4caPBEKa4uDj27t3Lp59+yttvv61P9/Pzw9/fn3//+994eHigUqmIj4/HxsaG5cuXGwxXCgoKemrZixYtQqfTsXr1an3wMmLECCZMmFCeUzEwa9Ys6tWrZ5A2fPhwRo4cydq1aystiCgoKGDhwoXUq1eP9evX4+TkBMDIkSOZOHEi69evx9vbm5YtWwIwYcIEgoODDY7h5+fH6NGjWb16tUEQUdH2eeWVV7CwsGDt2rV06dKFwYMH67ft2LGDU6dOMXbsWD788EN9eu/evZk6dSqhoaH84x//MDheRkYGW7dupWHDhvq0CxcusGbNGvz9/Q2CJT8/P6ZNm0ZYWBheXl7Y2Nhw69Yt/vWvf+Hq6sqaNWuws/t9qbhJkyah0/2+2ktkZKTR38/Dw4PJkycTHR2tHyuYkJCATqcjLCzMoF7vv/++QTvs27ePkydPGrRBSQYPHszy5ctp2LBhqfcRojZp5QAXsozTzYBBrWQokxC11tYfi982sPibb8+D2jQnoqqV61vd19fXaA7Enj17sLGxoX///mRnZ+tfeXl59O3bl7S0NFJSUgCwtbUlPz+fQ4cOlelx3FlZWZw+fZp+/frpL5ABLC0tGT16dHlOxcDjF6APHjwgOzsbc3NzOnXqxLlz5yp8/CLnz58nIyODoUOH6gMIKDyPcePGodPpSEhIMFmv/Px8srOzyc/Pp2fPnly9epW8vDzg2bdPXFwcZmZm+Pv7G6T36dOHtm3bcvDgQYOLegAvLy+DC3WAvXv3olKp8PLyMvisZGdn4+Hhwf379zlz5gwA3377LRqNhoCAAIMAooiZ2e8f4aJ20ul05OXlkZ2dTdu2bbG1teXs2bP6fLa2tgB8//33aLXaCrRI2RR9ph5/abVatFqtUfqDBw+qrF7VKSsri4cPH+rf5+XlkZubq3//6NEjo4nh6enpJb7PyMgw+F6RMqqujKFtMOnxb4WacB5VVUaTJk1qxXlIGVJGXnMHTLK3hpdbVUoZ4vlTrp6Iojvkj7t27Rr379/njTfeKHa/rKwsXFxc8Pf358SJE0yfPh17e3u6d+/Oa6+9xuuvv46NjU2x+6empgLg6upqtK1169ZlP5En3Lx5k7CwMA4fPmzwYQdQVWKkmpaWBpiuc5s2hb/CRecKhe22fPlyEhISyMoyvs2Xl5eHra3tM2+ftLQ0nJycqF+/vsl6Jycnk52dbRA0mPqsXL16FUVR8PX1Lbasoi+XGzduANCuXbun1u/YsWOsWrWKc+fOGXxBAgZ/z5EjR5KQkMCCBQv44osvePnll3n11VcZNGjQMx16tHDhQmJjY01ue3IeyJAhQ5gzZ84zq8vz4skAsyjAK1KnTh2j+SCPz70x9f7JCzMpo+rKGOSiYuEx0zeGbj9QcLJW1YjzqKoyMjIynnkZtaWtpIznuwzbkNGwOh50T/z7z3kAyWnYtjWcF1ieMsTzp1xBhKmVmBRFoUGDBsyfP7/Y/YoukFu2bElUVBRHjx7l2LFjnDhxgvnz57NixQpWrVpF8+bNy1MtIyVd+BcUFBi8f/DgAQEBAajVat555x3c3NywsbFBpVKxbt06jh07Vil1KitFUQgODubq1av4+fnRoUMHbG1tMTMzIyYmhn379hnd/X+eFLdql0qlYunSpQY9CY8r+qyU1rlz5wgODqZ58+YEBwfTtGlTrKysUKlUfPrppwZt5ODgQEREBCdPnuTIkSOcPHmSRYsWsWLFCpYsWVLivIeKGDduHG+99ZZB2uLFiwGYOnWqQfrjPVRC1BTNje8v6H31q46PephXXWWEEFWnsQPYWEFuvvG28zehbcUWF3mWZDhT+VXa+qktWrQgJSWFzp07l2oJzzp16tCnTx/69OkDFK6WM3XqVL7++mv++te/mtynaIWba9euGW27cuWKUVrRHfN794xn+6WlpRnMxzh69Ci3b99m9uzZDB061CDv8uXLn3o+ZdGsWTPAdJ2L0oryXLx4keTkZAICAoyeV7Bz506D92Vtn7Jq1qwZP/30E7m5uUZDi65cuYKNjU2xj1V/XIsWLfjxxx9p0qQJrVq1KjFvUU9GcnKywRCtJ+3bt4+CggKWLl2qbzsAtVpt1KsEYG5uTo8ePfSrKF28eJExY8awevVqlixZApSv96mkfVq3bm3UI1TUjr179y5zWUI8bz45WPzw1P89ovCX7goWZvKDLUStc+KK6QDCwhz+1Lbq6yOqRKXNdPPy8kKn0xEaGmpy++Nj37Kzs422t2/fHoCcnOIfaVq0DGxCQgLXr/++CoBGo2Hjxo1G+YsuQI8ePWqQvm/fPm7fvm2QZm5eeIfsyTkahw8fNhhPXxnat29PkyZNiImJ4c6dO/p0rVbLhg0bUKlU+pWsiu7UP1mvS5cuER8fb5BW1vYpq/79+6PT6Vi3bp1BemJiIklJSXh4eBTbs/C4oknHYWFhRj1CYPhZ8fT0xNLSklWrVunnfjyuqF2K+/utWbPGqKfG1OfP1dWVunXrGgScRXMsSvpMPqlevXomg1Yharur2Qo7LhW//Tc17L9W+jlwQogapGkDMPX7P88PGjlUeXVE1ai0noiBAwfi7e3Nli1buHDhAn379sXBwYHMzExOnz7NzZs3iY6OBmDKlCnY2dnRrVs3GjduTG5uLjExMahUqqeuavPRRx8xceJEJkyYwIgRI/RLmJq6GHV1daVXr15s374dRVFo27YtycnJxMfH06JFC4NJtV27dsXR0ZHFixeTnp5Oo0aNSE5OZs+ePbi5uXHpUgm/jmVkbm7OzJkzmTFjBu+++y4+Pj5YW1tz4MABzpw5g7+/vz4AatWqFa1btyYiIoL8/HxcXFxISUlh+/btuLm5cf78+XK3T1l5e3sTGxvL+vXrSUtLo3v37ty4cYOtW7fi6OhosNJSSTp27EhgYCArV65k9OjRDBw4ECcnJ+7cucP58+dJTEzk8OHDADRu3Jhp06bx2Wef4efnh5eXF87OzmRmZpKQkMDs2bNp164d/fv3Z+PGjXz44Yf4+PhgaWnJkSNHuHTpklHvyPz588nMzKR37944Ozvz8OFDDhw4wP379/Hy8tLn69y5M1u2bGHBggX06dMHCwsLOnXqZNDT8aTOnTsTHR3N8uXLadWqFSqVCg8PD6NVo8oqPT2d3bt3A7/3Kh08eJBbtwqXzitqlyKbN2/W98BotVoyMjL48ssvAWjbti0eHh4Vqo8QT3pQijUK7muefT2EENWg+R9g8iAI3ft72vBX4G+le0ZVdVKkd7TcKvVx0CEhIfTo0YMdO3awbt06NBoNjo6OtG/f3uAC09fXlwMHDrB9+3ZycnKwt7enXbt2zJw50+ihcE/q0qULYWFhhIaGsn79emxtbfUPU/Pz8zPKP2/ePD7//HP27dvHnj176NatG+Hh4fzzn/80mPlvZ2dHaGgoS5cuZfPmzRQUFNC+fXuWLFlCdHR0pQYRULj06LJly1i9ejUbNmxAo9Hg6urKrFmzDB42Z25uzpIlS1i8eDGxsbGo1WratGnDnDlzSE5ONgoiyto+ZWFhYUFoaKj+YXNxcXHY2dnh6enJ5MmTjSZvlSQwMJAOHToQGRnJpk2bUKvVNGzYkDZt2jB9+nSDvL6+vjRv3pyIiAgiIyPRaDQ4OTnRs2dP/XMnunbtysKFC/nyyy8JDw/HysqKXr16sXLlSgICAgyON3jwYGJiYti9ezd3797FxsaG1q1b89lnn+Hp6anPN2jQIJKSkti/fz/fffcdOp2OkJCQEoOIyZMnk5OTQ1RUFLm5uSiKwq5duyocRKSmphIeHm6QFhcXR1xcnP78Hw8ivvrqK4PPd1pamn7/IUOGSBAhKl3HP6jo4gSnbxefR36rhajFlr4PXu7wUzJ0awVDe1Z3jcQzplLKssaqEEIIUYz0PB2uK3U8Kmath/GdVKx+UyZXQ+Ew07Vr1wLg7++PpaVlNddIiBfTwn4HS513ZoLcgHucPP1HCCFEpXC2NcPHrfjtjYtfwVsIIUQNU6nDmYQQQrzY0u+bTm9kDZNelvtWQojniyzxWn7yjS6EEKLS2NYxnb53uBkt6suPtRBC1BYSRAghhKg07RuaTv8xtWrrIYQQ4tmS4UxCCCEqzQ3jZzsC0LBiC5QJIcQzIcOZyk96IoQQQlSa7IfGP8j1LMDHTX6ohRCiNpEgQgghRKUZ0c44WAj5k4p6lhJECCFEbSLDmYQQQlSa9zuruP3AjGW/6NApENhFxcxecr9KCCFqGwkihBBCVBqVSsWnr6j49BUJHIQQzz+ZE1F+8i0vhBBCCCGEKBMJIoQQQgghhBBlIsOZhBBCCCHEC0mGM5Wf9EQIIYQQQgghykSCCCGEEEIIIUSZyHAmIYQQQgjxQpLhTOUnPRFCCCGEEEKIMpGeCCGEEJXmcrbCilM68h7Bf3cw47VmcpdPCCFqIwkihBBCVIrEVB2eW3Q8LCh8H36qgK1DzXi7rXR6CyFEbSPf7EIIISrsZq7C648FEAAK8NlRXbXVSQghnkZRqUr9EoYkiBBCCFFh/zlegLrAOD37YdXXRQghxLMnQYQQQogK23/NdPp//1F+ZoQQojaSORFCCCEq7LbadPr1ezrkfpUQ4nmlyCilcpNvdiGEEBVmUcyvyZqz8HOGUrWVEUII8cxJECGEEKLChrQuftv5LAkihBCitpEgQgghRIXVtzKdrgI8mst4ASGEqG1kToQQQogKu5RlOn1oG2hZX4IIIZ6J7PtgXQfqWFZ3TWosWbq1/GpVT8ScOXPo0aNHqfKmpaXRo0cPVqxY8YxrVagsdQsMDMTb2/sZ16hkZW2fpKQkJk2axIABA6q0XYUQz4cOfzD9Q3woFXSKDGcSolKlZcGA2dBgLDTyh4U7qrtG4gUkPRGiwrRaLTNnzkSr1RIUFISdnR0vvfRSdVerysXHx5OUlMTEiRNLvc/GjRuxs7Or9KDxq6++4uDBg1y/fp179+5Rv359XF1d8fPzY8CAAZValhAAb7WC/z1inP5bPlzLgdYOVV4lIWqvieEQf7bw/3MewF83wPo42DIdOras3rqJF0at6omYNWsWiYmJ1V2NF05qaiqpqam88847jBo1isGDB7+wQcSqVavKtM+mTZuIiYmp9LqcO3eOpk2bMnr0aD755BPGjBlDfn4+M2bM4Msvv6z08oQ4lGo63VwFzjZVWxchar19J43Tfr0Jwz4D6fkrE3lidflVeU9EQUEBGo2GunXrVvqxLSwssLCQzpWq9ttvvwFgb29fqcdVFAW1Wo21tXWlHrcmCwwMBGDlypUl5vvnP/9plPbOO+8wduxYIiIi8Pf3x9zc/JnUUbx44lN0/Odn0xcuOrmeEaLytW4MyWnG6ZfS4bvTMPDlqq+TeOE80yvumJgY5s6dS1hYGGfOnCEmJoaMjAxmzZqFt7c3iqKwbds2du7cydWrVzEzM6NDhw4EBAQYzR+IjY1ly5YtpKSkoNVqcXR0pHPnzkybNo0GDRoAhfMOYmNjOX78uMG+v/zyC0uXLiUpKQkbGxs8PT0ZPnx4sfUNDw83Kj8wMJD09HSDu8aHDx8mOjqaX3/9lTt37mBpaUnHjh0ZP3487u7uldWMeidOnODLL7/k3LlzaLVaXF1dGTFiBMOGDTPId/bsWbZu3crp06e5desW5ubmuLm5MXbsWJNDWUrbPqYEBgZy4sQJAObOncvcuXMB2LVrF02bNkWtVrN69WoOHDhAZmYm9evXp3fv3kyaNAlnZ2f9cY4fP05QUBAhISGo1WqioqK4efMm7733nn540P79+9m8eTMXL16koKBAf04DBw40qtfx48fZsGEDZ8+eRa1W4+TkhLu7Ox988AEODg4AREVFER8fz5UrV7h79y729vb06tWLSZMm0bRpU4PjHTp0iIiICC5fvkx+fj4ODg506NCB4OBgXFxcDNrh8c9OSEhIsUOVivKlp6cb7FPUdpXNwsICJycnLl26hFarlSBCVIob9xTe2q4jX2t6u5M1WMm9HSEqj04HvV8yHUQAvLsUUldXbZ3EC6lKvtqXLFmCVqvFx8cHGxsbXFxcAJg9ezbffPMNnp6eeHt7o9Fo2Lt3L1OmTGHhwoX069cPgN27dzNnzhy6detGUFAQVlZW3Lp1i8TERLKysvRBhClnz55l8uTJWFtbM27cOOzs7Ni/fz8hISEVPq+YmBhycnIYPHgwjRs3JjMzk+joaCZPnkx4eDjdunWrcBlFDh48yIwZM3B0dGTMmDFYW1uzf/9+5s+fT2pqKlOmTNHnjY+P59q1awwcOBBnZ2dycnKIjY1lxowZzJ8/nzfffFOft6LtM378eF5++WXWrl2Lj4+P/pwbNGiAVqslODiYU6dO4enpyZgxY0hJSWHbtm0cOXKEiIgIGjdubHC8TZs2kZOTw7Bhw3B0dNRvX7ZsGWvWrOHVV18lKCgIMzMz4uLi+OSTT5g5cyYjR47UH2Pbtm0sWLCARo0aMXz4cJydncnIyOCHH37g1q1b+iDiq6++olOnTowaNQp7e3suX77Mzp07OXbsGJGRkfp8P//8Mx9//DFt2rTB398fW1tb7ty5w9GjR7lx4wYuLi6MHz8eRVE4efIk8+bN09elS5cuxbbdvHnzWLRoEQ4ODowfP16fXtLnuaxycnLQ6XRkZ2fz7bff8tNPP9GjRw+srIpZj1OIMtp+USk2gAD4x2tmmMkwACEqz7wtsCGh+O1pdwsnWs/0qbo61WA6+X4qtyoJIvLz89m4caPBEKa4uDj27t3Lp59+yttvv61P9/Pzw9/fn3//+994eHigUqmIj4/HxsaG5cuXGwxXCgoKemrZixYtQqfTsXr1an3wMmLECCZMmFDh85o1axb16tUzSBs+fDgjR45k7dq1lRZEFBQUsHDhQurVq8f69etxcnICYOTIkUycOJH169fj7e1Ny5aFk6kmTJhAcHCwwTH8/PwYPXo0q1evNggiKto+r7zyChYWFqxdu5YuXbowePBg/bYdO3Zw6tQpxo4dy4cffqhP7927N1OnTiU0NJR//OMfBsfLyMhg69atNGzYUJ924cIF1qxZg7+/v0Gw5Ofnx7Rp0wgLC8PLywsbGxtu3brFv/71L1xdXVmzZg12dnb6/JMmTUKn0+nfR0ZGGv39PDw8mDx5MtHR0bz77rsAJCQkoNPpCAsLM6jX+++/b9AO+/bt4+TJkwZtUJLBgwezfPlyGjZsWOp9yurtt98mJycHAHNzc/785z/zySefPJOyxIvJvoR41FwFgS/Xqql3QlS/td8/Pc+enyWIEM9clXy7+/r6Gs2B2LNnDzY2NvTv35/s7Gz9Ky8vj759+5KWlkZKSgoAtra25Ofnc+jQIZQyTBjKysri9OnT9OvXT3+BDGBpacno0aMrfF6PX4A+ePCA7OxszM3N6dSpE+fOnavw8YucP3+ejIwMhg4dqg8goPA8xo0bh06nIyHh97sSj9crPz+f7Oxs8vPz6dmzJ1evXiUvLw949u0TFxeHmZkZ/v7+Bul9+vShbdu2HDx40OCiHsDLy8vgQh1g7969qFQqvLy8DD4r2dnZeHh4cP/+fc6cOQPAt99+i0ajISAgwCCAKGJm9vtHvqiddDodeXl5ZGdn07ZtW2xtbTl79qw+n62tLQDff/89Wm0Jt1wrWdFn6vGXVqtFq9UapT948MDkMT7//HNCQ0OZPXs2vXv35uHDh9y/f7/KzuFpsrKyePjwof59Xl4eubm5+vePHj3Sz7kpkp6eXuL7jIwMg+8JKePZltHX/haNi5m2ZG9Vc86jOspo0qRJrTgPKaNqyyioU4r7vw62z/15lLUM8fypkp6Iojvkj7t27Rr379/njTfeKHa/rKwsXFxc8Pf358SJE0yfPh17e3u6d+/Oa6+9xuuvv46NTfHLfqSmFi4X4urqarStdevWZT+RJ9y8eZOwsDAOHz5s8I8DQFWJ3WNpaYXjHk3VuU2bNsDv5wqF7bZ8+XISEhLIyjJ+AlReXh62trbPvH3S0tJwcnKifv36JuudnJxMdna2QdBg6rNy9epVFEXB19e32LKKvoxu3LgBQLt27Z5av2PHjrFq1SrOnTtn8GUHGPw9R44cSUJCAgsWLOCLL77g5Zdf5tVXX2XQoEGVOvToSQsXLiQ2NtbktifngQwZMoQ5c+YY5evevbv+/4cOHcqnn37KhAkTiIqKMvl3qWpPBoxFAVuROnXq4OjoaJD2+FwaU++fvDCTMp5tGW1aOLP+rQLe3GZ8g8faouacR3WUkZGR8czLqC1tJWX8XgbT/wuCSngWk7kZfOBVoTKex7YSz58qCSJMrcSkKAoNGjRg/vz5xe5XdIHcsmVLoqKiOHr0KMeOHePEiRPMnz+fFStWsGrVKpo3b14p9Szpwr+goMDg/YMHDwgICECtVvPOO+/g5uaGjY0NKpWKdevWcezYsUqpU1kpikJwcDBXr17Fz8+PDh06YGtri5mZGTExMezbt8/o7v/zpLhVu1QqFUuXLjXoSXhc0WeltM6dO0dwcDDNmzcnODiYpk2bYmVlhUql4tNPPzVoIwcHByIiIjh58iRHjhzh5MmTLFq0iBUrVrBkyZIS5z1UxLhx43jrrbcM0hYvXgzA1KlTDdIf76EqyZAhQ9i/fz/ff/+90YR8IcqrYV0zoMAo/WYeZD7Q0chahjQJUWkmDioMFAKWG2+ztoL9s+G1P1Z9vWooBZkTUV7VtmZGixYtSElJoXPnzqVawrNOnTr06dOHPn36AIWr5UydOpWvv/6av/71ryb3KVrh5tq1a0bbrly5YpRWdGf23r17RtvS0tIM5mMcPXqU27dvM3v2bIYOHWqQd/lyE/+wK6BZs2aA6ToXpRXluXjxIsnJyQQEBBg99Gznzp0G78vaPmXVrFkzfvrpJ3Jzc42GFl25cgUbGxv95OWStGjRgh9//JEmTZrQqlWrEvMW9WQkJycbDNF60r59+ygoKGDp0qX6tgNQq9VGvUpQOJ+gR48e+lWULl68yJgxY1i9ejVLliwBytf7VNI+rVu3NuoRKmrH3r17l7ksQN/jYuozLkR59WgCTvXgttp426bzCh9W/mJ1QrzYPDqaTu/iIgGEqDLVdnvIy8sLnU5HaGioye2Pj5XLzs422t6+fXsA/aRRU4qWgU1ISOD69ev6dI1Gw8aNG43yF12AHj161CB937593L592yCtaHnMJ+doHD582GA8fWVo3749TZo0ISYmhjt37ujTtVotGzZsQKVS6VeyKrpT/2S9Ll26RHx8vEFaWdunrPr3749Op2PdunUG6YmJiSQlJeHh4VFsz8LjiiYdh4WFGfUIgeFnxdPTE0tLS1atWqWf+/G4onYp7u+3Zs0ao54aU58/V1dX6tata3AxXjTHoqTP5JPq1atX6Rf0arXa5ByJgoICoqKiAOjcuXOllilebCqVirbFjOzL08hdPiEqXdumYOom1IBOVV8X8cKqtp6IgQMH4u3tzZYtW7hw4QJ9+/bFwcGBzMxMTp8+zc2bN4mOjgZgypQp2NnZ0a1bNxo3bkxubi4xMTGoVKqnrmrz0UcfMXHiRCZMmMCIESP0S5iauhh1dXWlV69ebN++HUVRaNu2LcnJycTHx9OiRQuDSbVdu3bF0dGRxYsXk56eTqNGjUhOTmbPnj24ublx6dKlSmsrc3NzZs6cyYwZM3j33Xfx8fHB2tqaAwcOcObMGfz9/fUBUKtWrWjdujURERHk5+fj4uJCSkoK27dvx83NjfPnz5e7fcrK29ub2NhY1q9fT1paGt27d+fGjRts3boVR0dHg5WWStKxY0cCAwNZuXIlo0ePZuDAgTg5OXHnzh3Onz9PYmIihw8fBqBx48ZMmzaNzz77DD8/P7y8vHB2diYzM5OEhARmz55Nu3bt6N+/Pxs3buTDDz/Ex8cHS0tLjhw5wqVLl4x6R+bPn09mZia9e/fG2dmZhw8fcuDAAe7fv4+X1+/jTjt37syWLVtYsGABffr0wcLCgk6dOhn0dDypc+fOREdHs3z5clq1aoVKpcLDw8No1aiySElJITAwEE9PT1xcXLC3tyczM5NvvvmG69evM2TIkEpdflgIgBvGMTsAb7tVbT2EeGH4/gmifvz9vZkK3ulbffWpoeRJ1OVXrY8ACgkJoUePHuzYsYN169ah0WhwdHSkffv2BheYvr6+HDhwgO3bt5OTk4O9vT3t2rVj5syZRg+Fe1KXLl0ICwsjNDSU9evXY2trq3+Ymp+fn1H+efPm8fnnn7Nv3z727NlDt27dCA8P55///KfBSgF2dnaEhoaydOlSNm/eTEFBAe3bt2fJkiVER0dXahABhUuPLlu2jNWrV7NhwwY0Gg2urq7MmjXLYGy7ubk5S5YsYfHixcTGxqJWq2nTpg1z5swhOTnZKIgoa/uUhYWFBaGhofqHzcXFxWFnZ4enpyeTJ082mohVksDAQDp06EBkZCSbNm1CrVbTsGFD2rRpw/Tp0w3y+vr60rx5cyIiIoiMjESj0eDk5ETPnj31z53o2rUrCxcu5MsvvyQ8PBwrKyt69erFypUrCQgIMDje4MGDiYmJYffu3dy9excbGxtat27NZ599hqenpz7foEGDSEpKYv/+/Xz33XfodDpCQkJKDCImT55MTk4OUVFR5ObmoigKu3btqlAQ0bhxYwYPHswvv/xCfHw89+/fx9bWlnbt2vH+++8bLPErRGXRFnPfoZWD/EAL8UysmQINbWHHEWjaEOaMgs7FD+MVorKplLKsmSqEEEKYUO8/WvKfCCTMVaCdJo+rNkWj0bB27VoA/P39sbS0rOYaCfFi+vvgn0ud9x97ZILX4+TbXQghRIU81CpGAQRAQ9OLrQkhxHNDhjOVn6y7J4QQokKsLFSYmfgd1lR8apUQQojnlAQRQgghKszGRL929iNIy5MRs0IIURtJECGEEKJC7j1UUGtMbzucJkGEEELURjInQgghRIUcSVfQFrOt4x9kvLEQ4vklcyLKT3oihBBCVMhLDUz/CDtYQbuG8gMthBC1kQQRQgghKsTVXkXPxsbprzaVAEIIIWorCSKEEEJU2I5h5jSy/v29rSWEvCo/MUKI55uiKv1LGJI5EUIIISqsmZ2K5AnmRCUpqLUwvK2KprbyqyuEELWVBBFCCCEqhb2Vive7SOAghBAvAulrFkIIIYQQQpSJ9EQIIYQQQogXkk6WeC036YkQQgghhBBClIkEEUIIIYQQQogykeFMQgghhBDihSRPrC4/6YkQQgghhBBClIkEEUIIIYQQQogykeFMQgghhHhx7DsBi2IgLx/G9oNJb1Z3jUQ1kuFM5SdBhBBCCCFeDD9egMH/C4pS+P6nJHikhQ+HVG+9hKiBZDiTEEIIIV4Mn+34PYAo8uW31VMXIWo46YkQQghhIOehwte/KmTlg29bFe0dpbtf1AKKAgd/NU7XFlR9XYSoBSSIEEIIoXf7gUKvrwq4dq/w/dyfYOd/meHVRjquRQ2XcRey7xunN3Go8qqI54c8sbr85FdBCCGE3qrTij6AANDqYGqcrvoqJERl+UN9sKlrnH7jt6qvixC1gAQRQggh9G7mKkZpl7LhVKZxuhA1iqUFdHU1Tk+VIEKI8pAgQgghhN5QN9Nd+2vPyrhxUQu0a2qc9lALjzRVXxfxXFBUpX8JQxJECCGE0HuzlRlW5sbpJ25VfV2EqHSmOtRUgLlcDglRVs/1v5o5c+bQo0ePUuVNS0ujR48erFix4hnXqlBZ6hYYGIi3t/czrlHJyto+SUlJTJo0iQEDBlRpuwohqp+NpXFavnREiNrAwsRlj04BcxORsxCiRLI6kzCi1WqZOXMmWq2WoKAg7OzseOmll6q7WlUuPj6epKQkJk6cWOp9Nm7ciJ2dXaUGjYqisHfvXn744QfOnz/P7du3cXBwoG3btkyYMIFOnToZ7aPT6di0aRPbt28nPT2dBg0aMHDgQIKCgqhXr16l1U3UPgU6hXuPjNMbmJiPKkSNU9yQlB9+hb4dqrQqQtR0z3VPxKxZs0hMTKzuarxwUlNTSU1N5Z133mHUqFEMHjz4hQ0iVq1aVaZ9Nm3aRExMTKXW49GjR8yePZvr16/zxhtvMGPGDHx8fEhKSsLf3589e/YY7bNo0SL+85//0Lp1a2bMmIGnpyeRkZF89NFH6HSy0o4o3qbzBWhNfER6N5EBwaIWsC3mJsqpa1VaDfH8UFCV+iUMVbgnoqCgAI1GQ926lX+bysLCAgsL6Sypar/9VrhShb29faUeV1EU1Go11tbWlXrcmiwwMBCAlStXFpvH3NycFStW4O7ubpDu4+PDyJEjWbx4MW+++SZmZoX3BC5fvszmzZsZMGAAn3/+uT5/06ZN+de//sX+/ft58803n8HZiJou5Z5CwH7T27o4yQ+oqOGifoQlsaa3HUmG4MFVWx8hargyXaHHxMQwd+5cwsLCOHPmDDExMWRkZDBr1iy8vb1RFIVt27axc+dOrl69ipmZGR06dCAgIMBo/kBsbCxbtmwhJSUFrVaLo6MjnTt3Ztq0aTRo0AAonHcQGxvL8ePHDfb95ZdfWLp0KUlJSdjY2ODp6cnw4cOLrW94eLhR+YGBgaSnpxvcNT58+DDR0dH8+uuv3LlzB0tLSzp27Mj48eONLuAqw4kTJ/jyyy85d+4cWq0WV1dXRowYwbBhwwzynT17lq1bt3L69Glu3bqFubk5bm5ujB07lgEDBhgdt7TtY0pgYCAnTpwAYO7cucydOxeAXbt20bRpU9RqNatXr+bAgQNkZmZSv359evfuzaRJk3B2dtYf5/jx4wQFBRESEoJarSYqKoqbN2/y3nvv6YcH7d+/n82bN3Px4kUKCgr05zRw4ECjeh0/fpwNGzZw9uxZ1Go1Tk5OuLu788EHH+Dg4ABAVFQU8fHxXLlyhbt372Jvb0+vXr2YNGkSTZsarshx6NAhIiIiuHz5Mvn5+Tg4ONChQweCg4NxcXExaIfHPzshISHFDlUqypeenm6wT1HblZeFhYXJz5+joyPdu3cnLi6OrKws/vCHPwDwzTffoCgKo0ePNsjv4+NDaGgoe/bskSBCmPTJQV2xcx/+55AO33bPdee1EMVTP4QJoVBQzFLFsT8XPrnaQuZGCFFa5brNv2TJErRaLT4+PtjY2ODi4gLA7Nmz+eabb/D09MTb2xuNRsPevXuZMmUKCxcupF+/fgDs3r2bOXPm0K1bN4KCgrCysuLWrVskJiaSlZWlDyJMOXv2LJMnT8ba2ppx48ZhZ2fH/v37CQkJKc+pGIiJiSEnJ4fBgwfTuHFjMjMziY6OZvLkyYSHh9OtW7cKl1Hk4MGDzJgxA0dHR8aMGYO1tTX79+9n/vz5pKamMmXKFH3e+Ph4rl27xsCBA3F2diYnJ4fY2FhmzJjB/PnzDS4IK9o+48eP5+WXX2bt2rX4+Pjoz7lBgwZotVqCg4M5deoUnp6ejBkzhpSUFLZt28aRI0eIiIigcePGBsfbtGkTOTk5DBs2DEdHR/32ZcuWsWbNGl599VWCgoIwMzMjLi6OTz75hJkzZzJy5Ej9MbZt28aCBQto1KgRw4cPx9nZmYyMDH744Qdu3bqlDyK++uorOnXqxKhRo7C3t+fy5cvs3LmTY8eOERkZqc/3888/8/HHH9OmTRv8/f2xtbXlzp07HD16lBs3buDi4sL48eNRFIWTJ08yb948fV26dOlSbNvNmzePRYsW4eDgwPjx4/XpJX2eKyozMxNLS0vs7Oz0ab/++itmZmZ07NjRIK+VlRVt27bl119/fWb1ETXbwZvFPwsi+S7sulTAUDe5yBI1UPxZyM0vfnv2/cLnRbg0qro6ieeCPLG6/MoVROTn57Nx40aDIUxxcXHs3buXTz/9lLfffluf7ufnh7+/P//+97/x8PBApVIRHx+PjY0Ny5cvNxiuFBQU9NSyFy1ahE6nY/Xq1frgZcSIEUyYMKE8p2Jg1qxZRpNOhw8fzsiRI1m7dm2lBREFBQUsXLiQevXqsX79epycnAAYOXIkEydOZP369Xh7e9OyZUsAJkyYQHBwsMEx/Pz8GD16NKtXrzYIIiraPq+88goWFhasXbuWLl26MHjw7927O3bs4NSpU4wdO5YPP/xQn967d2+mTp1KaGgo//jHPwyOl5GRwdatW2nYsKE+7cKFC6xZswZ/f3+DYMnPz49p06YRFhaGl5cXNjY23Lp1i3/961+4urqyZs0ag4vlSZMmGYzvj4yMNPr7eXh4MHnyZKKjo3n33XcBSEhIQKfTERYWZlCv999/36Ad9u3bx8mTJw3aoCSDBw9m+fLlNGzYsNT7VMShQ4c4d+4cgwcPxsrKSp9eNPG6Tp06Rvs0atSI06dPo9FosLQ0sQSPeKEVPGW6zL+OKwx1q5q6CFGp9p8uebu5GTRzrJq6CFFLlKtv2tfX12gOxJ49e7CxsaF///5kZ2frX3l5efTt25e0tDRSUlIAsLW1JT8/n0OHDqEopX8KalZWFqdPn6Zfv376C2QAS0tLo6Eb5fH4BeiDBw/Izs7G3NycTp06ce7cuQofv8j58+fJyMhg6NCh+gACCs9j3Lhx6HQ6EhISTNYrPz+f7Oxs8vPz6dmzJ1evXiUvLw949u0TFxeHmZkZ/v7+Bul9+vShbdu2HDx40GjSrpeXl8GFOsDevXtRqVR4eXkZfFays7Px8PDg/v37nDlzBoBvv/0WjUZDQECAQQBRpGgeAPzeTjqdjry8PLKzs2nbti22tracPXtWn8/W1haA77//Hq1WW4EWKZuiz9TjL61Wi1arNUp/8OBBicdKSUkhJCSERo0a8dFHHxlsy8/PLzZAKAos8vNLuCNXhbKysnj48KH+fV5eHrm5ufr3jx490s/RKZKenl7i+4yMDIPvFSmjdGWcylTIeFDy9/FdtfLcn0dNKqNJkya14jxqQhkF9+5TojoWpN/OfO7P40UuQzx/ytUTUXSH/HHXrl3j/v37vPHGG8Xul5WVhYuLC/7+/pw4cYLp06djb29P9+7dee2113j99dexsbEpdv/U1FQAXF1djba1bt267CfyhJs3bxIWFsbhw4cNPuwAqkrs7kpLSwNM17lNmzbA7+cKhe22fPlyEhISyMrKMtonLy8PW1vbZ94+aWlpODk5Ub9+fZP1Tk5OJjs72yBoMPVZuXr1Koqi4OvrW2xZRV8uN27cAKBdu3ZPrd+xY8dYtWoV586dM/jyAgz+niNHjiQhIYEFCxbwxRdf8PLLL/Pqq68yaNCgZzr0aOHChcTGmp7U9+Q8kCFDhjBnzhyTeVNTU5k0aRIAS5cuNapz3bp1uXv3rsl9Hz16pM/zPHgywCwK8IrUqVMHR0fDu4OPz70x9f7JCzMpo3Rl7Lioo/j1LwuN7mD+3J9HTSojIyPjmZdRW9qqomWYj+kHa76nWB1b1IjzeJHLeFYUGc5UbuUKIkxdgCiKQoMGDZg/f36x+xVdILds2ZKoqCiOHj3KsWPHOHHiBPPnz2fFihWsWrWK5s2bl6daRkq68C8oMJw9+ODBAwICAlCr1bzzzju4ublhY2ODSqVi3bp1HDt2rFLqVFaKohAcHMzVq1fx8/OjQ4cO2NraYmZmRkxMDPv27Xuul+ws7mJVpVKxdOlSg56ExxV9Vkrr3LlzBAcH07x5c4KDg2natClWVlaoVCo+/fRTgzZycHAgIiKCkydPcuTIEU6ePMmiRYtYsWIFS5YsKXHeQ0WMGzeOt956yyBt8eLFAEydOtUg/fEeqselpaURFBSEWq1m2bJluLkZjy1xcnLi6tWrPHr0yGhIU2ZmJg4ODjKUSRhpbKPC9ON8CwV2UTGzp/zYihpqQGeY+AasKGb5sQ6Vc90hxIuk0tZPbdGiBSkpKXTu3LlUS3jWqVOHPn360KdPH6BwfPfUqVP5+uuv+etf/2pyn6IVbq5du2a07cqVK0ZpRXfM7927Z7QtLS3NYD7G0aNHuX37NrNnz2bo0KEGeZcvX/7U8ymLZs2aAabrXJRWlOfixYskJycTEBBg9NCznTt3Grwva/uUVbNmzfjpp5/Izc01Glp05coVbGxs9JOXS9KiRQt+/PFHmjRpQqtWrUrMW9STkZycbDBE60n79u2joKCApUuX6tsOQK1WG/UqQeGyqT169NCvonTx4kXGjBnD6tWrWbJkCVC+3qeS9mndurVRj1BRO/bu3fupx05LS2PixInk5eWxbNky2rdvbzJfhw4dOHz4MOfOnTOYx/Pw4UOSk5Pp3r17aU5FvGD++48q/vMzXDTRidXACla8IROqRQ1nY1X8NofiR0EIIUyrtPX6vLy80Ol0hIaGmtz++Ni37Oxso+1FF0Q5OTnFllG0DGxCQgLXr1/Xp2s0GjZu3GiUv+gC9OjRowbp+/bt4/bt2wZp5v/3yPsn52gcPnzYYDx9ZWjfvj1NmjQhJiaGO3fu6NO1Wi0bNmxApVLpV7IqulP/ZL0uXbpEfHy8QVpZ26es+vfvj06nY926dQbpiYmJJCUl4eHhUWzPwuOKJh2HhYUZ9QiB4WfF09MTS0tLVq1apZ/78biidinu77dmzRqjnhpTnz9XV1fq1q1rEHAWzbEo6TP5pHr16pkMWisqPT2doKAgcnNzCQ0N5Y9//GOxed944w1UKpXR33zHjh3k5+fL8q7CpPpWKmJ9TP/7bVW5j4wRono0KWG4av9OVVcPIWqJSuuJGDhwIN7e3mzZsoULFy7Qt29fHBwcyMzM5PTp09y8eZPo6GgApkyZgp2dHd26daNx48bk5uYSExODSqV66qo2H330ERMnTmTChAmMGDFCv4SpqYtRV1dXevXqxfbt21EUhbZt25KcnEx8fDwtWrQwmFTbtWtXHB0dWbx4Menp6TRq1Ijk5GT27NmDm5sbly5dqqymwtzcnJkzZzJjxgzeffddfHx8sLa25sCBA5w5cwZ/f399ANSqVStat25NREQE+fn5uLi4kJKSwvbt23Fzc+P8+fPlbp+y8vb2JjY2lvXr15OWlkb37t25ceMGW7duxdHR0WClpZJ07NiRwMBAVq5cyejRoxk4cCBOTk7cuXOH8+fPk5iYyOHDhwFo3Lgx06ZN47PPPsPPzw8vLy+cnZ3JzMwkISGB2bNn065dO/r378/GjRv58MMP8fHxwdLSkiNHjnDp0iWj3pH58+eTmZlJ7969cXZ25uHDhxw4cID79+/j5eWlz9e5c2e2bNnCggUL6NOnDxYWFnTq1Mmgp+NJnTt3Jjo6muXLl9OqVStUKhUeHh5Gq0aVxf379wkKCiItLY1Ro0Zx/fp1gyARCnsyisaXurm5MWLECLZs2cKMGTN47bXXuHr1KpGRkXTv3l2CCFGsOuame9JOZMIvmQpdG8lwJlGDvdLWdPqr7WDY03uDRe0kcyLKr1IfBx0SEkKPHj3YsWMH69atQ6PR4OjoSPv27Q0uMH19fTlw4ADbt28nJycHe3t72rVrx8yZM40eCvekLl26EBYWRmhoKOvXr8fW1lb/MDU/Pz+j/PPmzePzzz9n37597Nmzh27duhEeHs4///lPg5n/dnZ2hIaGsnTpUjZv3kxBQQHt27dnyZIlREdHV2oQAYVLjy5btozVq1ezYcMGNBoNrq6uzJo1y+Bhc+bm5ixZsoTFixcTGxuLWq2mTZs2zJkzh+TkZKMgoqztUxYWFhaEhobqHzYXFxeHnZ0dnp6eTJ482WhiVUkCAwPp0KEDkZGRbNq0CbVaTcOGDWnTpg3Tp083yOvr60vz5s2JiIggMjISjUaDk5MTPXv21D93omvXrixcuJAvv/yS8PBwrKys6NWrFytXriQgIMDgeIMHDyYmJobdu3dz9+5dbGxsaN26NZ999hmenp76fIMGDSIpKYn9+/fz3XffodPpCAkJKTGImDx5Mjk5OURFRZGbm4uiKOzatatCQUROTo5+0vzmzZtN5gkPDzeYpDZt2jSaNm3K9u3bOXToEA4ODowaNUr/TA4hTHG1V9GoHmSqjbftuiRBhKjhXm0HKhU8uSpk11aF6UKIMlEpZVljVQghRK11OE3hTxtN91quGWSGf2cJQCuLRqNh7dq1APj7+8tiB1UhVw31/9s4/QMvWFLxZ02JmumDEeefnun/LI0qfijxi6hSeyKEEELUXL/+Zvqe0h8bwqj2cqdW1HBfJZhO79iiaushnis6+WorN7mtJIQQAgCP5iqjJ0U41oWjY8ywtpRfWlHD7SpmqfaBz2ZZbyFqOwkihBBCAODWQEXYQDPs/u/xIi3tIOZtc2zryE+FqAUKinmmUuShqq2HELWE/DIIIYTQm9TVjPQgc5LGm3MlwJw/NZUeCFFLvD/QdPrek1VbD/FcUVSqUr+EIQkihBBCGLCpo6JtQxXmZvKjKWqRka9B/47G6a0bV31dhKgFJIgQQgghxIth5SRwqv/7e0c7+Nvb1VcfIWowWZ1JCCGEEC+Gl5pCUihs/anweRG+f4KGdtVdKyFqJAkihBBCCPHiaGALAa9Xdy3Ec0JntCadKC0ZziSEEEIIIYQoEwkihBBCCCGEEGUiw5mEEEIIIcQLSZZuLT/piRBCCCGEEEKUiQQRQgghhBBCiDKRIEIIIYQQQghRJjInQgghhBBCvJB0MiWi3KQnQgghhBBCCFEmEkQIIYQQQgghykSCCCGEEBWWr1WYEV9Am1VaXtuoZd9VXXVXSQghnkqnUpX6JQxJECGEEKLCpsbp+NdxhSs58GMaeO/Qce6OUt3VEkII8YxIECGEEKLCVp8xDBi0Ooi8IL0RQghRW8nqTEIIISrk5wwdWhPxgk46IoQQzzl5YnX5SU+EEEKICtmcZDpa6NdcfpyFEKK2kiBCCCFEhWTlm05vZle19RBCCFF1JIgQQghRId0bme5x2HBO5kSIF4iiwNVb8OBhdddEiCohQYQQQogK8e9kOog4e6eKKyJEdfnlKrT/C7SeBE3GQ+ie6q6RKCWdqvQvYUiCCCGEEBVSt5glOtLyqrYeQlSb/14MyWmF/5+rhr98CaevVWeNhHjmJIgQQghRISqVCltL4/Tb6qqvixBVLuMu/HrDOH3auiqvihBV6bkOIubMmUOPHj1KlTctLY0ePXqwYsWKZ1yrQmWpW2BgIN7e3s+4RiUra/skJSUxadIkBgwYUKXtKoSomcxMdPXLjAjxQnC0Axsr4/T4c1VfF1FmCqpSv4QheU6EMKLVapk5cyZarZagoCDs7Ox46aWXqrtaVS4+Pp6kpCQmTpxY6n02btyInZ1dpQeNZ8+eZe/evZw/f56LFy+iVqsJCQkxWc6ZM2fYsGEDycnJZGVlAdCkSRMGDhzI6NGjsbW1rdS6CVGcjDzYcVGHz0vP9f0qISrG0gI6t4TDFw3TtQWFQ5q6uFZHrYR45p7rb/ZZs2aRmJhY3dV44aSmppKamso777zDqFGjGDx48AsbRKxatapM+2zatImYmJhKr0tiYiJRUVHk5eU99W9x/fp18vPzeeutt/jwww/54IMP6NixI2vWrGHChAnk5xezHqcQ5fRAo3BfY5yuA96J1ZF5X546J2qx/Efw8xXT2y5lVG1dhKhCFe6JKCgoQKPRULdu3cqojwELCwssLKSzpKr99ttvANjb21fqcRVFQa1WY21tXanHrckCAwMBWLlyZYn5fH19GTduHPXq1ePbb7/l9OnTxeYdMmQIQ4YMMdq/VatWLF26lB9++IHXX3+94pUX4v8k3NBRUEyc8LAAEm4qjGgnQwFELXXsEmgKjNNVKujXserrI8pEJ0+sLrcyXaHHxMQwd+5cwsLCOHPmDDExMWRkZDBr1iy8vb1RFIVt27axc+dOrl69ipmZGR06dCAgIMBo/kBsbCxbtmwhJSUFrVaLo6MjnTt3Ztq0aTRo0AAonHcQGxvL8ePHDfb95ZdfWLp0KUlJSdjY2ODp6cnw4cOLrW94eLhR+YGBgaSnpxvcNT58+DDR0dH8+uuv3LlzB0tLSzp27Mj48eNxd3cvS1OVyokTJ/jyyy85d+4cWq0WV1dXRowYwbBhwwzynT17lq1bt3L69Glu3bqFubk5bm5ujB07lgEDBhgdt7TtY0pgYCAnTpwAYO7cucydOxeAXbt20bRpU9RqNatXr+bAgQNkZmZSv359evfuzaRJk3B2dtYf5/jx4wQFBRESEoJarSYqKoqbN2/y3nvv6YcH7d+/n82bN3Px4kUKCgr05zRw4ECjeh0/fpwNGzZw9uxZ1Go1Tk5OuLu788EHH+Dg4ABAVFQU8fHxXLlyhbt372Jvb0+vXr2YNGkSTZs2NTjeoUOHiIiI4PLly+Tn5+Pg4ECHDh0IDg7GxcXFoB0e/+wUN4To8Xzp6ekG+xS1XUU4OjpWaH9A//e5d+9ehY8lRJFrOQoTvim5p8HNQX6kRS227nvT6X+wLZwvIUQtVa7b/EuWLEGr1eLj44ONjQ0uLi4AzJ49m2+++QZPT0+8vb3RaDTs3buXKVOmsHDhQvr16wfA7t27mTNnDt26dSMoKAgrKytu3bpFYmIiWVlZ+iDClLNnzzJ58mSsra0ZN24cdnZ27N+/n5CQkPKcioGYmBhycnIYPHgwjRs3JjMzk+joaCZPnkx4eDjdunWrcBlFDh48yIwZM3B0dGTMmDFYW1uzf/9+5s+fT2pqKlOmTNHnjY+P59q1awwcOBBnZ2dycnKIjY1lxowZzJ8/nzfffFOft6LtM378eF5++WXWrl2Lj4+P/pwbNGiAVqslODiYU6dO4enpyZgxY0hJSWHbtm0cOXKEiIgIGjdubHC8TZs2kZOTw7Bhw3B0dNRvX7ZsGWvWrOHVV18lKCgIMzMz4uLi+OSTT5g5cyYjR47UH2Pbtm0sWLCARo0aMXz4cJydncnIyOCHH37g1q1b+iDiq6++olOnTowaNQp7e3suX77Mzp07OXbsGJGRkfp8P//8Mx9//DFt2rTB398fW1tb7ty5w9GjR7lx4wYuLi6MHz8eRVE4efIk8+bN09elS5cuxbbdvHnzWLRoEQ4ODowfP16fXtLn+VnKz8/Xv86fP88XX3yBpaUlvXv3rpb6iNrp/x3RkX6/5DwamWEtaquc+/BVgultdU1MthaiNlHKYNeuXYq7u7vi4+OjqNVqg23ff/+94u7urmzbts0gXaPRKGPGjFG8vb0VnU6nKIqiTJ8+XfHw8FA0Gk2J5YWEhCju7u4Gaf7+/krv3r2Va9eu6dMePXqkjB07VnF3d1fCw8ON6nvs2DGjYwcEBChDhgwxSHvw4IFRvjt37ih//vOflb/85S9PrVtxnixLq9UqXl5eSr9+/ZTMzEyD8/D391d69uypXL9+vcR6qdVqxcfHR/H19TVIL0v7FOfYsWOKu7u7smvXLoP07du3K+7u7srixYsN0n/44QfF3d1dmTVrltExBgwYoPz2228G+c+fP6+4u7sroaGhRmV//PHHioeHh5KXl6coiqJkZGQor7zyiuLr66vcu3fPKH9BQYH+/02105EjRxR3d3dl3bp1+rR///vfiru7u1G9nlSWv3GRIUOGKAEBAaXOHxAQUKb8iqIoBw4cMPn3edJ//vMfxd3dXf8aMWKE8tNPP5WprGftt99+U/Lz8/Xvc3NzDf7ODx8+VO7cuWOwT1paWonv09PT9d81UsazL6PXugcKn2tKfDkv0yiPtLrn+jyquoxHjx4p0dHRyooVK5RHjx7V2PN40cvI+/GsouBj+tXovRpzHjWhjGdl7JjLpX4JQ+WaWO3r62s0B2LPnj3Y2NjQv39/srOz9a+8vDz69u1LWloaKSkpANja2pKfn8+hQ4dQlNJPuMvKyuL06dP069dP3/sBYGlpyejRo8tzKgbq1aun//8HDx6QnZ2Nubk5nTp14ty5yluq7fz582RkZDB06FCcnJz06ZaWlowbNw6dTkdCwu93Nh6vV35+PtnZ2eTn59OzZ0+uXr1KXl7hE52edfvExcVhZmaGv7+/QXqfPn1o27YtBw8eRKczvOXo5eVFw4YNDdL27t2LSqXCy8vL4LOSnZ2Nh4cH9+/f58yZMwB8++23aDQaAgICsLMz7hY2M/v9I1zUTjqdjry8PLKzs2nbti22tracPXtWn69odaLvv/8erVZbgRYpm6LP1OMvrVaLVqs1Sn/w4EGFy3v77bcJCwtjwYIF/Pd//zd16tQhOzu74idSiRo2bIiV1e9362xtbQ3+znXq1DEayvX4sDlT75s0aYLqsTGuUsazLeMttzo8Tfp9+PnW830e1VFGRobhpNuaeh4vchk2PdpBw2JWvHuQX2POoyaU8azoVKpSv4Shcg1natmypVHatWvXuH//Pm+88Uax+2VlZeHi4oK/vz8nTpxg+vTp2Nvb0717d1577TVef/11bGxsit0/NTUVAFdXV6NtrVu3LvuJPOHmzZuEhYVx+PBhcnNzDbapKvHDk5ZW+FRLU3Vu06YN8Pu5QmG7LV++nISEBP2SnY/Ly8vD1tb2mbdPWloaTk5O1K9f32S9k5OTyc7ONggaTH1Wrl69iqIo+Pr6FltW0eTuGzcKH+DTrl27p9bv2LFjrFq1inPnzvHw4UODbY//PUeOHElCQgILFizgiy++4OWXX+bVV19l0KBBz3To0cKFC4mNjTW57cl5IEOGDGHOnDkVKq9ly5b69h84cCA//fQTf/nLXwAMhsAJURF/7WXG2Ts6tl0s/oaQmQqay9BwURtZWsB7A2CRiVX58h5Cnhps6xlvE6IWKFcQYWolJkVRaNCgAfPnzy92v6IL5JYtWxIVFcXRo0c5duwYJ06cYP78+axYsYJVq1bRvHnz8lTLSEkX/gUFhispPHjwgICAANRqNe+88w5ubm7Y2NigUqlYt24dx44dq5Q6lZWiKAQHB3P16lX8/Pzo0KEDtra2mJmZERMTw759+4zu/j9Pilu1S6VSsXTpUoOehMcVfVZK69y5cwQHB9O8eXOCg4Np2rQpVlZWqFQqPv30U4M2cnBwICIigpMnT3LkyBFOnjzJokWLWLFiBUuWLClx3kNFjBs3jrfeessgbfHixQBMnTrVIP3xHqrK8qc//QlHR0e2bt0qQYSoNPUsVWz9L3NcV2i5nms6z1+6qWhuJ3fxRC3VtVXx27TP7++zEBVVaeuntmjRgpSUFDp37lyqJTzr1KlDnz596NOnD1C4Ws7UqVP5+uuv+etf/2pyn6IVbq5du2a07coV4zWai+6Ym1qNJi0tzWD52KNHj3L79m1mz57N0KFDDfIuX778qedTFs2aNQNM17korSjPxYsXSU5OJiAgwOihZzt37jR4X9b2KatmzZrx008/kZubazS06MqVK9jY2OgnL5ekRYsW/PjjjzRp0oRWrUr48uX3nozk5GSDIVpP2rdvHwUFBSxdulTfdgBqtdqoVwnA3NycHj166FdRunjxImPGjGH16tUsWbIEKF/vU0n7tG7d2qhHqKgdq2qy88OHD2V1JlHptDql2AAifKCKiV3Nq7ZCQlSloT1NpzdrCA7Fj64Qzwed3N8ot0p72JyXlxc6nY7Q0FCT24uGpwAmx2W3b98egJycnGLLKFoGNiEhgevXr+vTNRoNGzduNMpfdAF69OhRg/R9+/Zx+/ZtgzRz88IfuSfnaBw+fNhgPH1laN++PU2aNCEmJoY7d+7o07VaLRs2bEClUulXsiq6U/9kvS5dukR8fLxBWlnbp6z69++PTqdj3bp1BumJiYkkJSXh4eFRbM/C4wYPHgxAWFiYUY8QGH5WPD09sbS0ZNWqVfq5H48rapfi/n5r1qwx6qkx9flzdXWlbt26BhfYRXMsSvpMPqlevXrVfpH++GfqcbGxseTl5dGpU6cqrpGo7SzMVDgUMzXipYbyCy1qOXsbsDARKHdsUfV1EaIKVVpPxMCBA/H29mbLli1cuHCBvn374uDgQGZmJqdPn+bmzZtER0cDMGXKFOzs7OjWrRuNGzcmNzeXmJgYVCqV/gKzOB999BETJ05kwoQJjBgxQr+EqamLUVdXV3r16sX27dtRFIW2bduSnJxMfHw8LVq0MJhU27VrVxwdHVm8eDHp6ek0atSI5ORk9uzZg5ubG5cuXaqspsLc3JyZM2cyY8YM3n33XXx8fLC2tubAgQOcOXMGf39/fQDUqlUrWrduTUREBPn5+bi4uJCSksL27dtxc3Pj/Pnz5W6fsvL29iY2Npb169eTlpZG9+7duXHjBlu3bsXR0dFgWdqSdOzYkcDAQFauXMno0aMZOHAgTk5O3Llzh/Pnz5OYmMjhw4cBaNy4MdOmTeOzzz7Dz88PLy8vnJ2dyczMJCEhgdmzZ9OuXTv69+/Pxo0b+fDDD/Hx8cHS0pIjR45w6dIlo96R+fPnk5mZSe/evXF2dubhw4ccOHCA+/fv4+Xlpc/XuXNntmzZwoIFC+jTpw8WFhZ06tTJoKfjSZ07dyY6Oprly5fTqlUrVCoVHh4eBpPjyyM9PZ3du3cDv/cqHTx4kFu3CmerFrULwIcffoi9vT1dunShSZMm5OXl8csvv5CQkEDjxo31D7gTorIk/aYj+5Hpbc42EkSIF0BbZ/j1pmFanz9WT12EqCKV+jjokJAQevTowY4dO1i3bh0ajQZHR0fat29vcIHp6+vLgQMH2L59Ozk5Odjb29OuXTtmzpxp9FC4J3Xp0oWwsDBCQ0NZv349tra2+oep+fn5GeWfN28en3/+Ofv27WPPnj1069aN8PBw/vnPf5Kenq7PZ2dnR2hoKEuXLmXz5s0UFBTQvn17lixZQnR0dKUGEQAeHh4sW7aM1atXs2HDBjQaDa6ursyaNcvgYXPm5uYsWbKExYsXExsbi1qtpk2bNsyZM4fk5GSjIKKs7VMWFhYWhIaG6h82FxcXh52dHZ6enkyePJkmTZqU+liBgYF06NCByMhINm3ahFqtpmHDhrRp04bp06cb5PX19aV58+ZEREQQGRmJRqPBycmJnj176p870bVrVxYuXMiXX35JeHg4VlZW9OrVi5UrVxIQEGBwvMGDBxMTE8Pu3bu5e/cuNjY2tG7dms8++wxPT099vkGDBpGUlMT+/fv57rvv0Ol0hISElBhETJ48mZycHKKiosjNzUVRFHbt2lXhICI1NZXw8HCDtLi4OOLi4vTnXxRE+Pj48P3337Nz506ys7OxsLCgefPmvPvuu4wZM6ZUQ86EKIvPj5meVN3lD/BHRwkixAvgn2PA5zPQ/d+/heaOEFj8QjNC1AYqpSxrrAohhBBP8IjU8sNN4/SGdSEl0BybOhJIPEmj0bB27VoA/P39sbS0rOYaiQo7cx22/gQNbGBsf3ladQ3h9+61UueNXO/6zOpRE1VqT4QQQogXzyvOKn64aXw/Kisfvr+h4N1GggjxAujsUvgS4gVRaROrhRBCvJim9VAV+2Pyh3oSQAghRG0kPRFCCCEqZPtFMLUafjNb+FNTCSKEEM8vRZ5EXW7SEyGEEKJCjqSbnlr3sbv8OAshRG0lQYQQQogKcW9sOli4UvpHrAghhKhhJIgQQghRIQFdVNiYWFzIoW7V10UIIcpCpyr9SxiSIEIIIUSF1LVQsXyg4c9Jw7oQ0Fl+YoQQoraSidVCCCEqbGxHM5rZweYLCg3qQtDLZrjYy607IYSorSSIEEIIUSn+3NKMP7es7loIIYSoChJECCGEEEKIF5JOlngtNxmwKoQQQgghhCgTCSKEEEIIIYQQZSLDmYQQQgghxAtJhwxnKi/piRBCCCGEEEKUiQQRQgghhBBCiDKRIEIIIYQQQghRJjInQgghRJn9mKqw96qOVvYq3mmvop6ljCsWQtQ8BfLVVW4SRAghhCiTJT/rmBqn+793Cst/gcTR5tQxl19jIYR4UchwJiGEEKWmKVCY86POIO34LdhxUammGgkhhKgOEkQIIYQoNbUWsh8apyemShAharhHGoiIg2lrYcdhUOQz/SLQqVSlfglDMpxJCCFEqW1JMn1hlV8gF1yihvuvBbDvZOH/L4qBSYNg2cTqrZMQzzHpiRBCCFFqTw5lKtKtkfyciBrscNLvAUSRFfshPat66iNEDSDf+kIIIUot475xmpU5jOkgXf2iBjuTYpymU+BObtXXRVQpnar0L2FIggghhBCl1trBOO1RAVjL4FhRkz3SmE7XFlRtPYSoQSSIEEIIUWrvtDe+HacA31yTORGiBnNtbDp9z4mqrYcQNYgEEUIIIUrtD/VMp99RV209hKhU8WdNp997ULX1EKIGqVVBxJw5c+jRo0ep8qalpdGjRw9WrFjxjGtVqCx1CwwMxNvb+xnXqGRlbZ+kpCQmTZrEgAEDqrRdhRBV6/xvptMLdNITIWqwXUdNp494tWrrIaqcDlWpX8KQjGIVFabVapk5cyZarZagoCDs7Ox46aWXqrtaVS4+Pp6kpCQmTiz9koAbN27Ezs6u0oPGs2fPsnfvXs6fP8/FixdRq9WEhIRUe3Aqar5W9qbTl/2i4N+5ausiRKXJNzEnwsEGerhVfV2EqCFqVU/ErFmzSExMrO5qvHBSU1NJTU3lnXfeYdSoUQwePPiFDSJWrVpVpn02bdpETExMpdclMTGRqKgo8vLyXsi/hXh27j0y3eNwW0Z9iJqsga1xWu4DUJt4sqIQAqiGIKKgoID8/PxncmwLCwusrKyeybFF8X77rXB8g719Mbcoy0lRFB48kCuTxwUGBhIYGPjUfL6+viQkJLBlyxZGjx5dBTUTL4oVp0ynp9+XIU2ihrqbBxfTjNMLFPD636qvj6hSBSpVqV/C0DMdzhQTE8PcuXMJCwvjzJkzxMTEkJGRwaxZs/D29kZRFLZt28bOnTu5evUqZmZmdOjQgYCAAKP5A7GxsWzZsoWUlBS0Wi2Ojo507tyZadOm0aBBA6Bw3kFsbCzHjx832PeXX35h6dKlJCUlYWNjg6enJ8OHDy+2vuHh4UblBwYGkp6ebnDX+PDhw0RHR/Prr79y584dLC0t6dixI+PHj8fd3b2ymlHvxIkTfPnll5w7dw6tVourqysjRoxg2LBhBvnOnj3L1q1bOX36NLdu3cLc3Bw3NzfGjh3LgAEDjI5b2vYxJTAwkBMnClevmDt3LnPnzgVg165dNG3aFLVazerVqzlw4ACZmZnUr1+f3r17M2nSJJydnfXHOX78OEFBQYSEhKBWq4mKiuLmzZu89957+uFB+/fvZ/PmzVy8eJGCggL9OQ0cONCoXsePH2fDhg2cPXsWtVqNk5MT7u7ufPDBBzg4OAAQFRVFfHw8V65c4e7du9jb29OrVy8mTZpE06ZNDY536NAhIiIiuHz5Mvn5+Tg4ONChQweCg4NxcXExaIfHPzslDSEqypeenm6wT1HbVYSjo2OF9hfClIt3FW4XM4H6kQ5WnSogqJuMkhU1zMYf4MEj09vizsLhZHilbdXWSYgaoEq+7ZcsWYJWq8XHxwcbGxtcXFwAmD17Nt988w2enp54e3uj0WjYu3cvU6ZMYeHChfTr1w+A3bt3M2fOHLp160ZQUBBWVlbcunWLxMREsrKy9EGEKWfPnmXy5MlYW1szbtw47Ozs2L9/PyEhIRU+r5iYGHJychg8eDCNGzcmMzOT6OhoJk+eTHh4ON26datwGUUOHjzIjBkzcHR0ZMyYMVhbW7N//37mz59PamoqU6ZM0eeNj4/n2rVrDBw4EGdnZ3JycoiNjWXGjBnMnz+fN998U5+3ou0zfvx4Xn75ZdauXYuPj4/+nBs0aIBWqyU4OJhTp07h6enJmDFjSElJYdu2bRw5coSIiAgaNzZcVm/Tpk3k5OQwbNgwHB0d9duXLVvGmjVrePXVVwkKCsLMzIy4uDg++eQTZs6cyciRI/XH2LZtGwsWLKBRo0YMHz4cZ2dnMjIy+OGHH7h165Y+iPjqq6/o1KkTo0aNwt7ensuXL7Nz506OHTtGZGSkPt/PP//Mxx9/TJs2bfD398fW1pY7d+5w9OhRbty4gYuLC+PHj0dRFE6ePMm8efP0denSpUuxbTdv3jwWLVqEg4MD48eP16eX9HkWojrduFdyT0P8DQiqvK89IarGkeSSty/eBZHTq6YuQtQgVRJE5Ofns3HjRurWratPi4uLY+/evXz66ae8/fbb+nQ/Pz/8/f3597//jYeHByqVivj4eGxsbFi+fDkWFr9XOSgo6KllL1q0CJ1Ox+rVq/XBy4gRI5gwYUKFz2vWrFnUq2e43uHw4cMZOXIka9eurbQgoqCggIULF1KvXj3Wr1+Pk5MTACNHjmTixImsX78eb29vWrZsCcCECRMIDg42OIafnx+jR49m9erVBkFERdvnlVdewcLCgrVr19KlSxcGDx6s37Zjxw5OnTrF2LFj+fDDD/XpvXv3ZurUqYSGhvKPf/zD4HgZGRls3bqVhg0b6tMuXLjAmjVr8Pf3NwiW/Pz8mDZtGmFhYXh5eWFjY8OtW7f417/+haurK2vWrMHOzk6ff9KkSeh0Ov37yMhIo7+fh4cHkydPJjo6mnfffReAhIQEdDodYWFhBvV6//33Ddph3759nDx50qANSjJ48GCWL19Ow4YNS72PENVp0wVdidtt6lRRRYSoTGZPGdl9wcRQJ1FryJOoy69K5kT4+voaBBAAe/bswcbGhv79+5Odna1/5eXl0bdvX9LS0khJKXwMva2tLfn5+Rw6dAhFKf2Y26ysLE6fPk2/fv30F8gAlpaWlTJO/PEL0AcPHpCdnY25uTmdOnXi3LlzFT5+kfPnz5ORkcHQoUP1AQQUnse4cePQ6XQkJCSYrFd+fj7Z2dnk5+fTs2dPrl69Sl5eHvDs2ycuLg4zMzP8/f0N0vv06UPbtm05ePCgwUU9gJeXl8GFOsDevXtRqVR4eXkZfFays7Px8PDg/v37nDlzBoBvv/0WjUZDQECAQQBRxOyxH4uidtLpdOTl5ZGdnU3btm2xtbXl7Nnf1wy3tS2ccPf999+j1Wor0CJlU/SZevyl1WrRarVG6TV17khWVhYPH/4+cTEvL4/c3Fz9+0ePHunn3BRJT08v8X1GRobB94SUUXll7LlS8vdv98ZmNeI8npcymjRpUivOo8aX8Vp7StSpZc04j1pehnj+VElPRNEd8sddu3aN+/fv88YbbxS7X1ZWFi4uLvj7+3PixAmmT5+Ovb093bt357XXXuP111/Hxsam2P1TU1MBcHV1NdrWunXrsp/IE27evElYWBiHDx82+McBoKrECThpaYV3QUzVuU2bNsDv5wqF7bZ8+XISEhLIysoy2icvLw9bW9tn3j5paWk4OTlRv359k/VOTk4mOzvbIGgw9Vm5evUqiqLg6+tbbFlFX0Y3btwAoF27dk+t37Fjx1i1ahXnzp0z+LIDDP6eI0eOJCEhgQULFvDFF1/w8ssv8+qrrzJo0KBnOvRo4cKFxMbGmtz25DyQIUOGMGfOnGdWl2flyYCxKGArUqdOHaP5HY/PpTH1/skLMymj8srQKsV/r/2pKfh3UmFt+fyfx/NSRkZGxjMvo7a01TMtY2w/mLoGHphYiamhLcwZVTPOo5aXIZ4/VRJEPNkLAYUr7zRo0ID58+cXu1/RBXLLli2Jiori6NGjHDt2jBMnTjB//nxWrFjBqlWraN68eaXUs6QL/4KCAoP3Dx48ICAgALVazTvvvIObmxs2NjaoVCrWrVvHsWPHKqVOZaUoCsHBwVy9ehU/Pz86dOiAra0tZmZmxMTEsG/fPqO7/88TU58VKPzbLF261KAn4XFFn5XSOnfuHMHBwTRv3pzg4GCaNm2KlZUVKpWKTz/91KCNHBwciIiI4OTJkxw5coSTJ0+yaNEiVqxYwZIlS0qc91AR48aN46233jJIW7x4MQBTp041SH+8h0qIZ+W9jioWHjPdG7FsoBnWljIuQNRAdevAXD+Ysd5427sDwE0uZoUwpdqW0WjRogUpKSl07twZa2vrp+avU6cOffr0oU+fPkDhajlTp07l66+/5q9//avJfYpWuLl27ZrRtitXrhilFd0xv3fvntG2tLQ0g/kYR48e5fbt28yePZuhQ4ca5F2+fPlTz6csmjVrBpiuc1FaUZ6LFy+SnJxMQECA0UPPdu7cafC+rO1TVs2aNeOnn34iNzfXaGjRlStXsLGx0U9eLkmLFi348ccfadKkCa1atSoxb1FPRnJyssEQrSft27ePgoICli5dqm87ALVabdSrBGBubk6PHj30qyhdvHiRMWPGsHr1apYsWQKUr/eppH1at25t1CNU1I69e/cuc1lCVNT/9jXjp7QCfkg13rb6jMIXnlVfJyEqxRsvwwwT6fb1TCSK2qRAnkRdbtX2sDkvLy90Oh2hoaEmtz8+Vi47O9toe/v2hWMYc3Jyii2jaBnYhIQErl+/rk/XaDRs3LjRKH/RBejRo0cN0vft28ft27cN0szNzQGM5mgcPnzYYDx9ZWjfvj1NmjQhJiaGO3fu6NO1Wi0bNmxApVLpV7IqulP/ZL0uXbpEfHy8QVpZ26es+vfvj06nY926dQbpiYmJJCUl4eHhUWzPwuOKJh2HhYUZ9QiB4WfF09MTS0tLVq1apZ/78biidinu77dmzRqjnhpTnz9XV1fq1q1rEHAWzbEo6TP5pHr16pkMWoV4HlmYqfhTMasPPzL+pylEzfHrDdPprz5lvoQQL7Bq64kYOHAg3t7ebNmyhQsXLtC3b18cHBzIzMzk9OnT3Lx5k+joaACmTJmCnZ0d3bp1o3HjxuTm5hITE4NKpXrqqjYfffQREydOZMKECYwYMUK/hKmpi1FXV1d69erF9u3bURSFtm3bkpycTHx8PC1atDCYVNu1a1ccHR1ZvHgx6enpNGrUiOTkZPbs2YObmxuXLl2qtLYyNzdn5syZzJgxg3fffRcfHx+sra05cOAAZ86cwd/fXx8AtWrVitatWxMREUF+fj4uLi6kpKSwfft23NzcOH/+fLnbp6y8vb2JjY1l/fr1pKWl0b17d27cuMHWrVtxdHQ0WGmpJB07diQwMJCVK1cyevRoBg4ciJOTE3fu3OH8+fMkJiZy+PBhABo3bsy0adP47LPP8PPzw8vLC2dnZzIzM0lISGD27Nm0a9eO/v37s3HjRj788EN8fHywtLTkyJEjXLp0yah3ZP78+WRmZtK7d2+cnZ15+PAhBw4c4P79+3h5eenzde7cmS1btrBgwQL69OmDhYUFnTp1MujpeFLnzp2Jjo5m+fLltGrVCpVKhYeHh9GqUWWVnp7O7t27gd97lQ4ePMitW7cA9O0iRFmdzFQBxkOaejnL3TxRg2UXszjFS/I9KURxqvWpQCEhIfTo0YMdO3awbt06NBoNjo6OtG/f3uAC09fXlwMHDrB9+3ZycnKwt7enXbt2zJw50+ihcE/q0qULYWFhhIaGsn79emxtbfUPU/Pz8zPKP2/ePD7//HP27dvHnj176NatG+Hh4fzzn/80WCnAzs6O0NBQli5dyubNmykoKKB9+/YsWbKE6OjoSg0ioHDp0WXLlrF69Wo2bNiARqPB1dWVWbNmGTxsztzcnCVLlrB48WJiY2NRq9W0adOGOXPmkJycbBRElLV9ysLCwoLQ0FD9w+bi4uKws7PD09OTyZMnG03EKklgYCAdOnQgMjKSTZs2oVaradiwIW3atGH6dMP1u319fWnevDkRERFERkai0WhwcnKiZ8+e+udOdO3alYULF/Lll18SHh6OlZUVvXr1YuXKlQQEBBgcb/DgwcTExLB7927u3r2LjY0NrVu35rPPPsPT8/fxG4MGDSIpKYn9+/fz3XffodPpCAkJKTGImDx5Mjk5OURFRZGbm4uiKOzatavCQURqairh4eEGaXFxccTFxenPX4IIUR7dGsGB68bpR9IVJnSu+voIUSmKmyuYcgdcG5veJmqFArn/UW4qpSxrpgohhHihZd7X0Xi58QXX0DYqon3Mq6FGNZNGo2Ht2rUA+Pv7Y2lpWc01esGN/g9s+sE4/Yf/hT5/rPr6iCrTN6j0S8n+EC433x5XbXMihBBC1DzFLfOap5H7UaIGu3rLOM3GCl59+nLhQryoJIgQQghRavZ1FMxMxBEpsj6AqMl6uhmnvTfg6U+zFuIFJv86hBBClNq6c6Az0elgW6fq6yJEpfn7COj22BLivV6Cee9UX31EldGpVKV+CUPVOrFaCCFEzfLzLdPDliZ3lXtSogZzsoef/wXHLoGZCnqY6JkQQhiQb30hhBCl9oqJpVzdG0NAF/k5ETWcSlXYAyEBhBClIt/6QgghSs2/kwrftr8HEu0awhZvWZVJCFEzFahUpX4JQzKcSQghRKlZmquIGmrOpbsK2Q+he2Mwkx9XIYR44UgQIYQQoszcGkjgIIQQLzIJIoQQQgghxAtJW90VqMFkToQQQgghhBCiTCSIEEIIIYQQQpSJBBFCCCGEEEKIMpE5EUIIIYQQ4oUkS7eWn/RECCGEEEIIIcpEggghhBBCCCFEmchwJiGEEEII8ULSymimcpOeCCGEEEIIIUSZSBAhhBBCCCGEKBMZziSEEEIIIV5IWmQ8U3lJT4QQQgghhBCiTCSIEEKIKnYyQ8d/RWnovErD9O+03H+kVHeVRBXLPn0Xm6/rUT/UhrP/ewbtA211V+m5k787mdsD1pPZfSW5//4JRamB/07Uj+Bvm6HzJzDkX3D0cnXXSIhKI8OZhBCiCt2+rzDgay05Dwvfn72tcOMebPaRr+MXRX6mmkOjDlInzxKAS+HJPMp8SO9lf6rmmj0/Hv54g9+GbgZdYeCgOZkBmgLsPulTzTUro0lrYf0Phf9/9iYkXIALC6FZw+qtlxCVQHoihBCiCm1P0ukDiCJbL+i497AG3mUV5XIz9ibaPMOehxvRKWjvS29EkQcRp/UBRJH7a36pnsqU10MNbPzRMC0vH6KOVk99hEkaVelfwpAEEUIIUYXqmuhwsDQDC/k2fmGY1zX+Y5vVMUNlLlcpRVQm/qGYSnuumamgjok617Ws+roI8QzIz5YQQlSht9uZ0aK+YVpgNzOsLeUC8kXRfEgL6japZ5DWepwb5nXNq6lGzx+bwO6orA0vtm2n9q6m2pSTpQVMed0wzdkBRr1SLdURorJJECGEEP8n56HCxP0FuKzQMmBzAYmpTx9i9KhA4ZODBbRepaX3V1qiL+lKzG9npeKndy2Z4q7CpT40rFs4L+KnmyXvJ2oPy/p16PCPl3nYEDR1of5rjfjjxx2rrT5pS85yokMUJzttJX3Zr8+sHPXBG9zst4lrLivInLQf3b2HxeY1b2aH1VtuqGzrYOZkjd2CP2Mzvlul1ke7+QRq98954PYPHs3Zi6ItqNTjA7BgFIx9DezqQgMbeL9/4X9N0Whh1kZo9B5Y+0GzCfDZdqiJE8prEI1KVeqXMCRBxHPo+PHj9OjRg5iYmGqrQ1JSEpMmTWLAgAH06NGDFStWVFtdhKgq7+7VsfK0QkouxN9QeCOqgLS8kn/APzmo47OjCldz4GgGvB2t43hGyfs0s1NxLQeu34OsfIi7rvBGpJZbTylL1A730x/ww99+4eGjOqgt6nDzVDaHPj1RLXXJ+PICV6f+hPp8Ng/O3eXKlEQyv75U6eVobtwj7c2t5B+8iTblHvfCT3Frwr5i8999N5r8bedR8h6hu/2AvHk/UJCWW2n1KUi4xMN3ItCduIly+Q6aufvQ/OObSju+XuRPsCERcvPh7n34x05Y+b3pvLMj4X+3wu17has6pd2FT76CJbGVXy8hKoEEEcKIVqtl5syZpKSkEBQUxLx58/jzn/9c3dWqcvHx8WUOnjZu3PhMgr+zZ8/y+eefM378ePr27VtikHnhwgUWL17Mf//3fzNgwAAGDBjAuHHjiIqKQquViZvFyX2ksOuS4UX8Ay3suFjyhf1Xvxpu1ykQeaHkXoW7aoU9T5SV9wh2JktvxIvg2oF0CvIN/9bXD6ShqYaJ1bdNBAy3v7pY6eXc334RRa01StM90Bjl1d17SP6uJIM05YEG9Y4LlVYf7dfHje7wa7/+udKOr/f1j8ZpXyUWk/eg6fSvikkXoppJEPEc6t69O4mJiQwePLhayk9NTSU1NZV33nmHUaNGMXjwYF566aVqqUt1io+PZ9WqVWXaZ9OmTc8kiEhMTCQqKoq8vLyn/i3Wr19PTEwM7du3Z8qUKQQFBWFvb89nn33G1KlTa+Za61XA0gzqmZgDWb9OyfvVtzK1T8nd3lYWha/SHEvUPpY2xn9887rmmFlU/XAJczvjSb4W9k/50JeDmZ3xMVXWFqgsjS9DVHXMUdUzrpeZfSX+A6lf17hcE2kVZmfimPbWxeStZzq9fjHpQlQzCSKeI/fv3wfAzMwMKysrzM2rZ5Ldb7/9BoC9vX2lHldRFB48eFCpx6zpAgMDCQwMfGo+X19fEhIS2LJlC6NHjy4x76hRo9izZw9///vf8fX1ZdSoUXzxxRe89dZbHD58mEOHDlVW9WuVuhYqPuhueBHXxgHefqnkC7uZPQ2/Rh3rwfjOJe9jbaki2N1wv7YNYVhb+Up+EbR6sxm2LQwvJDu+64a5VdV/5zf7uDOqx4IXVR0znD/sVOnl2I5oh0Urw98Uh6k9UFkan7OqrgU2H/QySDN3a0jdt/9YafWxDHrNKJCwnPEMetynvmm4QpOFOXz0pum8M4cZp5mpYPp/VX69hJ6mDC9hqIatl/b8iomJYe7cuYSFhfHLL78QExPDb7/9houLC/7+/gwaNMggv7e3N87Oznz88ceEhoZy5swZ7O3t2bVrF8ePHycoKIiQkBC8vb31+yiKws6dO9m5cydXrlwBoGnTpgwYMICgoCB9vkePHvHVV1+xb98+bt68SZ06dejWrRsTJ06kffv2JZ5HYGAgJ04Ujs2dO3cuc+fOBWDXrl00bdoUtVrN6tWrOXDgAJmZmdSvX5/evXszadIknJ2d9cd5/BzUajVRUVHcvHmT9957j4kTJwKwf/9+Nm/ezMWLFykoKMDNzY2xY8cycOBAo3odP36cDRs2cPbsWdRqNU5OTri7u/PBBx/g4OAAQFRUFPHx8Vy5coW7d+9ib29Pr169mDRpEk2bNjU43qFDh4iIiODy5cvk5+fj4OBAhw4dCA4OxsXFxaAdevTood/vyb/J44rypaenG+xT1HYV4ejoWOq8Xbt2NZn++uuvs3fvXi5fvkzfvn0rVJ/a6t2OKvZcUTifBc1s4ctBZtg8pVfhnT+q2H4R4m+ArSXMe1VFc7uS9/nqbAGxl3TUrwPOtjDyj2Z80NOcepW0QtO64xr+X9xDbuYoKIBrAxVzBlox6mVZWvJ5YGljQbep7Tk4+zjkq2jUpSGd/N0qfNwrC89yY3kS6BSaB7Sl9f90RvWUyaD1+znT6P123N5wCVTQeHw76v+pcYn7aG49IPWDBPIO3KCOmz1NP3sN2wHNi82fHXqCrJBEdNn5YGmG5R8dafhJb+zeKT4osPvfAWgvZfFwzyWwNKPe6I6YWRf/+VUePCLv/e1otp6FAh1m7Z2w/XoUFl1Nf/eauTlh+enraD77FtQazAd3wNynS4nnDVCwIgHd5/shMxfMVWBlidnYVzD7f8NQWZq4pOrZGsZ7FM6LUKnAvy/8uZhJ9O8OAGsr+GgNpN8tDCAsLWDFfujYAlwaPbV+QlQlCSIq2RdffIFarcbX1xcoDC7+53/+h0ePHhldfN66dYtJkyYxcOBA/vznPz/1Lv3s2bPZu3cvnTp1Yvz48djZ2XHt2jW+++47fRCh1Wr5y1/+wunTpxk8eDAjR44kLy+PHTt2MGHCBFatWkWHDh2KLWP8+PG8/PLLrF27Fh8fH7p1K1wNo0GDBmi1WoKDgzl16hSenp6MGTOGlJQUtm3bxpEjR4iIiKBxY8Mfn02bNpGTk8OwYcNwdHTUb1+2bBlr1qzh1VdfJSgoCDMzM+Li4vjkk0+YOXMmI0eO1B9j27ZtLFiwgEaNGjF8+HCcnZ3JyMjghx9+4NatW/og4quvvqJTp06MGjUKe3t7Ll++zM6dOzl27BiRkZH6fD///DMff/wxbdq0wd/fH1tbW+7cucPRo0e5ceMGLi4ujB8/HkVROHnyJPPmzdPXpUuX4n9k5s2bx6JFi3BwcGD8+PH69AYNGpT4d60qmZmZADRsKE9KNaVApzBkh47L2YXvr92D0bE6rgaosCphmMlfvtPxzbXC/39YAH/5XuFPTRW6NTa9z6EbOsbtKqBoUNm9LLibD3+wrpwA4vtLWvy35hukXbit8E5kPq0bmtGzhSwjWt1yb94n8ZNfUGkKe55un7zLwb/+zBurXi33MW+uucjFv/0+OftSyC9YNKiDy5SSbxxlLPuVW+G/zzVIX3oOmy4NaTyh+P1SRn9D3vc3AVAfy+SKVwx/vDwOS2fjVYfydiRz5y/f/Z6g06E5fZuCW/dLrNeDZcfJ33r+9+PM+wEL1wbY+Hc1mf/+R7FoNp36vZhfM8n1/BKH1L+hMvFchoKES2g++X3oacH20zz6WwxW/3m72Drpdp9GF/T1E6lqdP/aD/UsMZ9nosfgi/0Q/thE6i8OgHsreNfDdCEr9kNq1v8VqID2Eew6Btdvwy+Liq2bENVBgohKlp2dTWRkJLa2tkDhMBQ/Pz/+85//8Prrr1O37u/dp6mpqcyaNYthw4Y99bgHDhxg7969vPXWW8ydOxczs9+HPeh0v0/Q27x5Mz///DNffPEFf/rTn/TpRcNaFi9ezMqVK4st55VXXsHCwoK1a9fSpUsXg3kZO3bs4NSpU4wdO5YPP/xQn967d2+mTp1KaGgo//jHPwyOl5GRwdatWw0uXC9cuMCaNWvw9/dnypQp+nQ/Pz+mTZtGWFgYXl5e2NjYcOvWLf71r3/h6urKmjVrsLOz0+efNGmSwblHRkZSr57h2FEPDw8mT55MdHQ07777LgAJCQnodDrCwsIM6vX+++8btMO+ff+/vfsOj6L6Gjj+3d30QkJCIKGG3nsg1IACUgIKPyIgIghKpBfxtYuAqIBK70gRkY70IsUQFOkGBKQJREJIQkvvuzvvHyGbbHZTCSTI+TxPHti7M3PvzLY5c++5s4+goKA856Z069aNRYsW4eLiUmT5LNlJSEjgxx9/xMHBgXbt2hV1c4qlMxEYAoh0YfHwW6hCx0rZn+BvvGKaWL3lmp7GZcyfrG+6pCdrVsqGS3rmdTa7eL5tPG8+OVdRYPMFrQQRxcC/B8LQpxonVoccDiclLhUrh4L1FoVv+tekLGJTcK5BxP2NN8yWZRdEaO8nGgKIdEqilpgdN3F9x3QYVNyGKyZlALEbLuM8zsvscwCJGy6aLcsuiEhZe86kTHmYSOrhG1h1qWnynHZjkEmZbkMQ5BREbMw+8Vq/4bT5IGLjCfNl5oKIB7Fw6C/zFZwLhqt3oMbj9WoLUwkydWuByQDcQubn52cIIAAcHBzo3bs3MTExnDlj/AXk5OSU7dCYrPbu3QvAuHHjjAIIwOjx3r178fT0pHbt2kRFRRn+tFot3t7enDt3jqQk46uUeRUQEIBarWbw4MFG5W3atKFGjRocOXLE6KQewNfX1+TK9969e1GpVPj6+hq1MSoqCh8fH+Lj4zl//jwABw8eJDU1laFDhxoFEOb2PT2A0Ov1xMXFERUVRY0aNXBwcODChQuG5dJfn19//fWpzlaUkJBgsr9arRatVmtSXpi5Izqdjs8++4zQ0FA+/PDDQs91eRwPHz4kOTljrvi4uDhiYzOmcUxJSTHk6KQLCwvL8XF4eLhR8nhe63DNJnfR1UaVYx2lzKznoErJdj/M9TiUsi28/cipR8NSazxFZkHryOxJvR7/5TpsSpomGVvaW3A/8l6B67AqZZp0bOlinet+KI5mTgNKZASaWfdDbWcBtqaBqKZUxgWyzHVozH1AAMU54xiYO1YpDmbu6l0qI48k635Q0nzStbqUvdk6VKVMe020zsbbyFpHsn32AbiqlIPZ/UiyNxMUumb8lhnVYWuFYpdNUrtGDc52Rf7eLco6RPEjPRGFzNPT06SscuXKQFrPQ2blypXLc/J0SEgIpUqVynVs/M2bN0lOTjabV5AuKioKd3f3PNWb2Z07d3Bzc6NEiRImz1WtWpWrV68SFRVlFDRUrFjRbBsVRTEM+TIn/cslJCQEgJo1Ta8kZXXq1CmWLVvGxYsXjb68AKMvrz59+hAYGMi0adOYN28eDRs2pFWrVnTu3PmJDj2aMWMGu3aZn+876+vVvXt3Jk2a9Nh16vV6pkyZQmBgICNGjKBLl2wS+opI1gAzcwAOYGVlZfKez5x7Y+5x1vd2XutwBfrXVrH2UsYPoW8V1aNhSdnX8WkLNe8cyAieKzqCfxMbHG0zTuYz78fbjdQsPKMj/NFoDhXwaRtNoe3HO956lp5M5V68cX9HeScVY18w3kZB68jsSb0e/+U6PLuU4+yiy0RfjzM818C/BmUrGF9lzk8dnu/W4e62EHQJaRdG1NZqKv9fPZw93HLcj8qfenH+4G6U5LQbraltNVT6sEm2+6G2s6T0hCbcnXrKUGbTsBQlelQ2W4fTmCbE/HABJS5TWqqFGrePM4ZumTtWpT57kfsBq9PGCAIqO0scJmTc6Tnrfth/0Zn4NzcblVm8WAULr/Jm67Dwb0Xq4qNw99FroFJhN8nXaP2sddi91xXt+j8hMstFHo0a9cddsTCzHzaf+0HgV5Dy6IKVvTW829V8HXbWqCa8Al9swoR/JyjtjBWmOXL/tc9Hdo9F8SNBRBHKPLSpMFWrVo3x48dn+/zTHKOf3T6qVCrmzp1r0quSrmrVqvmq5+LFi4waNYry5cszatQoypYti7W1NSqVio8//tioh8TZ2ZnVq1cTFBTEiRMnCAoKYubMmSxZsoQ5c+bkmPfwOAYOHEjXrl2NymbPng2k9TBl5uZm/MNfEHq9ni+++ILdu3czdOhQozwNYd4PXdV08VQ4HqbQtIyKAXVy7+b2b6impouKn6/p8bBX8VZ9FS622a/n4aBiha+Gt/fouBMHdUtBnVKF151ewVlN0Bg7lp9K5WKEDpUKGnhoeLuZJW5mru6Kp8/CRkPjIVX5Y+JplCQ1bvWcqNm70mNts0RjV1qe6U7oD/+g6BTKDaqKQ23nXNdzbFGGRkG9uPvDNVRqFaXfrI5tjZzX8/iiBXbNyxD7y79YV3fGZUgd1FbmL4hZ1XCh4vnBRH57iuTT4VjWcqHk/zXHum6pHOuwblUBp+kdiZkUiBKdhKV3OTTuDtkvP6gpKs+SJH19GCUqCau+9bEZ0TLb5dXlnLENeh/t8uMoD+Ox6NsETQvPHNukquKGxdnP0K84ihIaBSpQOdqi7t8cVVMzr1+KFjYcT0vAtrGE5lXh+7eheg4X8aa8Bs2qwe4z8DAubTrYTg3h1YLny4icJcpopgKTIKKQBQcHm5TdvHkTSOt5KKiKFSsSGBiYNuwih96IChUqEBkZSbNmzbI9QS+ocuXKcezYMWJjY02GFt24cQN7e3tD8nJOKlSowB9//IG7u7uhlyY76T0ZV69epVKl7H9k9+3bh06nY+7cuUbHOTEx0agXIp1Go8HLy8swi9K1a9cYMGAAy5cvZ86cOQC5zmpiTk7rVKlShSpVqhiVpR9Hb2/vfNeVk/QAYufOnbz11luGGbFEzizUKt6oq+KNbCZPyU67Cira5THXIDFVYeBOHfcT0x5fuA89Nmq5OdISC3Xh/JqVc1IzsaPcdKK4ir0RS9CE09hoFUBH3JmHnBx1nHabXnis7drXKEGNL5vkvmAWdrVL4jmtee4LZuLUozJOPXL+/k5n6elE6fnZ946bk3r1AdET9oMurUctJSCYyEHbKbV/QLbrWLWrglW7Ktk+n5W6rBNWn+UvGUlV0RXNpJfztvCX29MSq9MduQwnr+ccRAD0aJb2J0QxJ5elCtnmzZuJi8vooo6Li2PLli04OjrStGnTAm83/Qr23LlzTfIOMo9D9PX15cGDB/z0U9YZJNJkHYOYH+3bt0ev17Nq1Sqj8qNHj3LlyhV8fHzyFLikJx0vWLAAnU6XYxs7dOiApaUly5YtMzqu6Qzjbh8NC8t6I7UVK1aYHK+oqCiT7Xh6emJjY0NMTIyhLD3HIjo6Otd9yrxO5m0UBUVRmDp1Kjt37mTw4MEMHz68SNsjjB29rRgCiHS3Y+HUHbkJ4PMi7MAdFK3x6333twhSY2Um+nRJu64aAoh0yQduoI9LKaIWFcDW03krE+IZJT0RhczZ2ZlBgwYZEqZ37txJeHg4n3766WMNX+rYsSOdOnVi9+7dhISE4OPjg6OjI7du3eLYsWNs3LgRgNdee40TJ04wZ84cTp06RbNmzbC3tyc8PJxTp05hZWXFkiVLCtSGHj16sGvXLn744Qfu3LlDkyZNCAkJYfPmzbi6uhrNtJSTunXr4u/vz9KlS+nfvz8dO3bEzc2N+/fvc+nSJY4ePcrx48cBKFOmDBMmTGD69On069cPX19fPDw8uHv3LoGBgUycOJGaNWvSvn171q5dy9ixY+nVqxeWlpacOHGCf/75x6R3ZOrUqdy9exdvb288PDxITk7mwIEDxMfH4+ubMSa2fv36bNy4kWnTptGmTRssLCyoV69ejj1K9evXZ/v27SxatIjKlSujUqnw8fExmTUqv8LCwti9ezeA4R4hR44cISIiAsBwXADmzJnDjh07qFGjBpUrV2bPnj1G2ypfvvwTG7IlcudhZkSGCnB3kD7154VNGdPfAktnKzQ2MnNWOo2H6UQaKhdbVDbP0GlLWWc4H5KlrHhM+S1EYXiGPo3PhtGjR3P27Fk2bdrEw4cPqVixIlOnTi2UhNYvv/ySxo0bs337dpYtW4ZGo6Fs2bJGSbkWFhbMnj2bzZs3s2fPHkPA4ObmRt26denevXuB67ewsGD+/PmGm80FBATg6OhIhw4dGDFiRL6Stf39/alTpw7r169n3bp1JCYm4uLiQtWqVXnvvfeMlvXz86N8+fKsXr2a9evXk5qaipubG82aNTPcd6JRo0bMmDGD77//nsWLF2NtbU3z5s1ZunQpQ4cONdpet27d2LlzJ7t37yYyMhJ7e3uqVKnC9OnT6dChg2G5zp07c+XKFfbv38+hQ4fQ6/V8/vnnOQYRI0aMIDo6mk2bNhEbG4uiKOzYseOxg4jQ0FAWL15sVBYQEEBAQIBh/9ODiL///htIGwI2ceJEk211795dgogiVNdNTd/aajZcyughG9xQTWVnCSKeF+W6lsepvjPR56MMZXXerYvaUgYHpLP9Xy3iGruTGhRuKCsx0QeVxTN0jD55BQIvQ9KjHiZXBxhbSHM5i0KTgnz3FpRKyTr+QxRI+h2rFy9ebHS3YiGEyEyvKLx7UMeiP/Xo9PBCJRU7XtVgKyeQz5Vrq6/y52dnUCerKFHHiTY/+GBfwXTa0eeZPiGVxJ/Oo70ZiU236li3MZ3tr9i7Fg7rjqUlVr/RGjykJ6K4UY17mOdlldlys9bMpCdCCCGeosV/6plzKqMX4mCwwozjCp+3LcJGiacq5ko0Zz/8E7U+7QpozN/RnBx9nBe2dchlzeeL2s4S+6H5TxQvVqq7w8ReRd0KIZ4IufQlhBBP0a5/9HkqE/9dYb+GQZaX/P7xe5JYLURRUOXjTxiRIEIIIZ6iSiVMf4k8i89NxMVTYF/edNiSlYs1GjN3ghZCiOJKgohC0qNHD06fPi35EEKIHL3XQkNpu4zHJazhk9Zy8vg8KdulHC7NMt3vRwX1P6qP+llKGhZCPPcksVoIIZ6yBwkKGy7pSdVBnzpqPGR61+dOcnwyaz/8CXWkmm7v+eLW6PHvUi+EyD/V+HwkVs+SxOrMJLFaCCGeMlc7FSOaSu/D80xtpSa1vhYA57rORdsYIZ5nKrmIU1DSdyqEEEIIIYTIFwkihBBCCCGEEPkiQYQQQgghhBAiXySIEEIIIYQQQuSLBBFCCCGEEEKIfJHZmYQQQgghxPNJZmcqMOmJEEIIIYQQQuSLBBFCCCGEEEKIfJEgQgghhBBCCJEvkhMhhBBCCCGeT5ISUWDSEyGEEEIIIYTIFwkihBBCCCGEEPkiw5mEEEIIIcRzSsYzFZT0RAghhBBCCCHyRXoihBDikbA4hSXn9EQkQO8aKjpWkuss4slIjkrB8qg1qigNoeXu4Olbqaib9MRog6OIX/on+pgU7PrXxbpVhaJukhCiEKgURVGKuhFCCFHU7sYrNP5Rx524jLLFndS801ACCVG4tAla9nQ9QOzNjDdb/fF1aDC+bhG26snQ3ogkwms5SmRSWoEKXDb2xs6vdtE2TIhHVP8XnedllW+cnmBLnj3y6yiEEMCqi4pRAAHw1XF90TRG/Kfd2nPbKIAAuLTsKrqU/977LW7RmYwAAkCB2Gl/FF2DhBCFRoIIIYQAIpNMO2Ujk4ugIeI/LyU61aRMG69Fn/rfCyL0mQMIQ1liEbRECFHYJIgQQgigT0016iyTdLxWS2btEIWvQpdyaKyNf37LdyyLpf1/L03Rrl8d07LX/nvDtoR4HklOhBDiP0erV1h+XiHglkJtVxWjG6twsc09IFhyVs/Eo3piU6F9Bdj8sgY7y8IPJPR6hVVndez/R091VxVjWljgZi8BS3F07+9o/t78L3qtQq2eFfBo4lIo272+PZg/PjqBKlGFW2NX2i1vg01J6wJt6+76GzzYcQur8vaUG10bmwoOhdLGrPSxKUTOP0vyuXvYtvTAaVgD1Na5Bz5xS/8kZmIgSmwyVi3K47rtVdSOOe+r/n48iXOPobt6H6uOVbEe3BSV5sld99QfvoL+h2NgY4l6mA/qhtknfyuhD2Hufgh5CN0boerfKm+VHL8CY5bD3Wh4uRnMGgwaTc7r/HkdluyHVB0MfhHamgZl4vGo3s9HTsQMyYnITIKIYuj06dMMGzaMzz//nB49ehRJG65cucLs2bO5fPkysbGxDB06lHfeeadI2iJEfr21T8eKCxlfbXVdIWigBktN9ifq4fEKDVbpuJdppMW37dRMaFb4Jy6jd6cw/4TO8Liai4rzI62xeQIBiyi4iL8i2Tb4mGGYkUoN3eY3p2Kb0o+13dS4VHZ1+oWE0Iw3W51hNWn8cYN8b+vfL84SPPFPw2MrD1u8zvfC0tXmsdqYlaIo3Gq9nqRjYYYyh55VKbf1lVzXvdtuNSlHbhke2/hWo9SuftnXlawlqsE8dFfvZ6wzvDkOC3OvqyD028+i7bUY0k+HbCyx+ON91I0rmrYtMh7qfwShkRmFE3uimtw750r+DoH640Cf6ZSrfT0ImJL9OievQdtPIEWb9lithp0fQbemedsxkScSRBScDGcSJrRaLe+//z63bt1i2LBhTJkyhRdffLGom/XUHT58mCVLluRrnbVr17Jz585Cb8uFCxf45ptvGDJkCG3btsXLyyvbehISEli6dCnjx4+nW7dueHl54e/vX+htKq7uJSj8cNH42sjFB7AvOOfrJT9cUIwCCIBvTxf+GPXYZIWlp3VGZf88VNh+WZfNGqKonF8XbJSnoOjhrzU3H3u7t/bcNgogAK788A+65Py9BxRF4fbMC0ZlKWGJ3F1747HbmFXiH3eMAgiAuG3XSbkeleN6KSdDjQIIgKTd/5B6+X42a0DKzstGAQRA0vdn0Eeb5lcUBt3MgxkBBEBSKvr5h80vvP6YcQABMPsXFF0u3xUfrzEOIAAOX4Do+OzXmbcnI4AA0OthVuH/vghRUBJEFENNmjTh6NGjdOvWrUjqDw0NJTQ0lNdee42+ffvSrVs3qlevXiRtKUqHDx9m2bJl+Vpn3bp1TySIOHr0KJs2bSIuLi7X1yIqKoqlS5fy999/U716dTS5dZf/xyTrQGcmXog3zWXN8rzpSrmtUxApOjCXP/sk6hKPR5uoNSlLNVOW7+0mmAYL+hQ9irk3bk70CroE0/bonsCbSclmm/pc6sru+ey2l/Zcimlhqg6SH//YmxVvZgYFc2XZlSempJ3g5yQum+0l53D84s0ETdm1SzwGVT7+RGYSRBQj8fFpVyTUajXW1tZFdvL34MEDAJycCrfbTlEUEhISCnWbzzp/f/889RL4+fkRGBjIxo0b6d+/f47LlipVit27d/PLL78wZ84crKysCqu5z4TyjipeqGD8Ze9qC75Vcv4BeK22Gsss34gD6xT+j4arnQrf6sYVOdnAK7Wer2DvWVCjR3mTsppmyvKrQpdyWNgZv94VupbDwi5/idUqjZoyA6oalaltNLj1qfzYbczKrn0FLCo4GpVZN3LDpoFbjutZt62IprKzUZlFPTcsm7hnu45Vj1qonI2HY1l2rYG69JPJ9VAPbGmmrIX5hf2ag22W79R+LVBZ5vLavd/TtKyqO5R2zn6dge3zViZEEZEgopDs3LkTLy8vTpw4wZIlS+jevTstW7akX79+/PLLLybL9+jRA39/fy5fvsyoUaNo164dr732GpCWE2FuuIqiKGzdupVBgwbRtm1b2rZtS9++fVm8eLHRcikpKaxYsYI+ffrQqlUr2rdvz/jx47l8+XKu+5H5pHby5Ml4eXnh5eXFnTt3AEhMTGT+/Pm88sortGzZks6dOzNx4kTCwoy7uTPvw8aNG3n11Vdp1aoVP/74o2GZ/fv389Zbb+Hj40Pr1q0ZNGgQBw8eNNuu06dPM3bsWDp06ECrVq145ZVXmDJlClFRUYZlNm3axMiRI+natSstWrSgc+fOfPbZZ4a2Z/b777/j7+9Phw4daN26Nb6+vvzf//0f//77r+E47Nq1C8BwDHIaQpS+XFhYGH/++afROubqzy9XV1dsbW3ztKyVlRVlypR57DqfZd+0U1HHFewsoH4pOPiqGkernAOC2q4qVndTU84B7C2hQ0WY1vbJXHma72tJ07Iq7CzT8iF29LfC1U6uchU3VTp40PSd6lg7WWJpb0GtXhWo4/f4d5a2c7fF+5smYK8FjZ4yTV3wnlawce5V57Wg5EtlUdtbYFXWjurft8a2Sok8rZtw7j7Bbx7i+it7eLj+Wo7Lqqw0OI9siMrREjQqLKo64fFj19wr0aiwf6sRag8HVCWssOlRnVJ7+qFSZf9+V7vY4fjz66iruoCdJRbNy+GwrGeO1Sj340j+cCfxDb8hvvbXJL25Ft3FsBzXAdD9dALdwUuomntCtdKovCqhWTMEdbf6ZpdXebrBt/2gTAmwtYRyJSE+GSXg75wreqkRdG8K6ftdtiQc+yrndXp6ww+joUZZcLKDRp5Q5fn+bhfFy39vPrkiNm/ePBITE/Hz8wPSgotPPvmElJQUkyTpiIgIhg8fTseOHXnxxRdzvUo/ceJE9u7dS7169RgyZAiOjo4EBwdz6NAhhg0bBqTlM4wePZq//vqLbt260adPH+Li4ti6dStvvfUWy5Yto06d7Gd3GDJkCA0bNmTlypX06tWLxo0bA1CyZEm0Wi2jRo3i3LlzdOjQgQEDBnDr1i22bNnCiRMnWL16tcnJ67p164iOjqZnz564uroanl+4cCErVqygVatWDBs2DLVaTUBAAB9++CHvv/8+ffr0MWxjy5YtTJs2jdKlS9O7d288PDwIDw/nt99+IyIiAmdnZwDWrFlDvXr16Nu3L05OTly/fp1t27Zx6tQp1q9fb1juzJkzvPvuu1StWpXBgwfj4ODA/fv3OXnyJCEhIVSqVIkhQ4agKApBQUFMmZKR+NagQfaJj1OmTGHmzJk4OzszZMgQQ3nJkiVzfF1F4XqYqNDtZz13H32czt+H1RcVGuWSC5uYqvDRET2hj+4BdugWjPpVYVUezpPyq++mFM7cSRu68s9DhYm/ajk8RHoiipv7l6M5u/K64SZwl7eG4NHEhVqvZD9zT16kRqVwdfwZSkToAT2JB8O5+sVf1PvGK9/bCvnyHJH70y5UpMRruT7mBC4dymLlbpfjekmXI7na6mf0j4ZDRe8IRns/idKjzJ88R879k/sf/m54rL0eTej/dlD50ps5zpoU80kAsV9n3Fwu5Y/bqKxyfq8rej3x43ajv/4wra6TocT5b8Np9yDzy+v0JL6wEP2FjKBBe/ku2p//wu6v91F7mp9RSzfzALoJm9O2AeBgjcW+MaiqZt+7ovx2BcasgfQciNBI+Pk0bDuD8sv7qDrWM7/iRz/CrjMZj+9EwpRNMG9otnUBUKEU/BOeNlzqbDB0+QJ2fATd8/9eEaKwSRBRyKKioli/fj0ODmndrn5+fvTr149Zs2bRqVMnbGwyumhDQ0P59NNP6dmzZ67bPXDgAHv37qVr165MnjwZtTrjS1ufaSzmhg0bOHPmDPPmzaNly4wuWj8/P/r27cvs2bNZunRptvW0aNECCwsLVq5cSYMGDYzyMrZu3cq5c+d44403GDt2rKHc29ubcePGMX/+fL744guj7YWHh7N582ZcXDK+xC9fvsyKFSsYPHgwI0eONJT369ePCRMmsGDBAnx9fbG3tyciIoJvv/0WT09PVqxYgaNjRnf68OHDjfZ9/fr1JlfrfXx8GDFiBNu3b2fQoLQfoMDAQPR6PQsWLDBq19tvv210HPbt20dQUFCec1O6devGokWLcHFxKbJ8FgHrLyuGACLd4nMK032UHGdn2nFdITjGuGzN3woz2yt5mh42r06E6Dlx23jse2Cwnr/C9TRwl87h4uTiplsmd5E+/9PNxw4i7my9RXKE8Xj3f1f9Q+0vGqOxyXswqSgKofMvGZVpHyYTsfYGFd7N5mT2kfvLLxkCiHT35v6VbRDxcOafJmWp16JIOHwb+w6msxilty9u/mmjMv2DRBLWXsRxvHe2bUs9fBPdX+HGZXuuorv+AE1VV5PldQHXjAIIg9hkUledxHpSF7P16OYGGBfEJaNbcRSLL3tm2zYWHswIIDLTKzD/AGQXRMzfa1q27CDMfTujd8KcBXuN8y0UJS3hWoKIwiOdwAUmv1iFzM/PzxBAADg4ONC7d29iYmI4c+aM0bJOTk55nsJ17960L6Bx48YZBRCA0eO9e/fi6elJ7dq1iYqKMvxptVq8vb05d+4cSUkFm+EiICAAtVrN4MGDjcrbtGlDjRo1OHLkiNFJPYCvr6/RiXp6G1UqFb6+vkZtjIqKwsfHh/j4eM6fPw/AwYMHSU1NZejQoUYBhLl9Tw8g9Ho9cXFxREVFUaNGDRwcHLhwIWMGk/TX59dff0WrfUKJemYkJCSY7K9Wq0Wr1ZqUPy+5Iw8fPiQ5OSNRMC4ujtjYWMPjlJQUQ45OuqxD57I+fhCdJRIAdHrFMDFKdnWYS3bWK2lJ2lnrCA8PJ/Ps2PnZj9SsM7Sk78dd49loHqcOwzZzOVZSR8516LWmbwrdowT8x6lDMbNdRasnPCz/+2HuLtdKSkbidnbHSjG3Xqo++/0w0+b0urJ9PRTM1pMcm5Dzscrmzt2Zt2X0mud0p+9Hx8Lc66FPziaB21wdpL0e+hwSofXJqdm/r8wFHjpdru9dbaJpInVqvPHMXv/lz6Ao3qQnopB5enqalFWunJbkFhoaalRerly5PCdPh4SEUKpUKVxdTa/CZHbz5k2Sk5Pp2LFjtstERUXh7p59Ult27ty5g5ubGyVKmI63rVq1KlevXiUqKsooaKhY0fQK1c2bN1EUxTDky5z0L5eQkBAAatasmWv7Tp06xbJly7h48aLRlxdg9OXVp08fAgMDmTZtGvPmzaNhw4a0atWKzp07P9GhRzNmzDDkWWSV9fXq3r07kyZNemJtKS6yBpiZA3BIy+/I+p738PDI8fHbXk58+5eOmEznBwPqqLG2UOVYx8sOCm62GE3z+ko1FW52KrAzriPr5yc/+9Gqgprabiou3cv4wW3soaJzA+PxVo9TR7rcjpXUkUsdPa25sj0EJdP5X53eFR67Do+eFbk06SzamIwT0nKvelKucrl87Ye1tTUeQ2pwZ0FGb4Ta3oLSr2UkW2d3rFwH1eTeggtGwYHr27Wz3Q/lnQY8mPiH0XMWHvbYd6iIQ5bhSYbXQwX2gxsSvyjjAprK3hLnN5tgkemiUNZjZfliFdSVS6K/mTGVqkXrSljUyhhmlPk113SojsrTBSX4oVE7sLbAcqCX2ToALIb6oP9id6adtTBKqDb3vlKGvgBbjS8IplP7v5j9++qNdrD0gPEKfdvgnuX1yfqaW7zTGfYEGZVZjjAeY/mf/gyKYk2CiCKUeWhTYapWrRrjx4/P9vmnOUY/u31UqVTMnTvXpFclXdWqVc2WZ+fixYuMGjWK8uXLM2rUKMqWLYu1tTUqlYqPP/7YqIfE2dmZ1atXExQUxIkTJwgKCmLmzJksWbKEOXPm5Jj38DgGDhxI167GX/6zZ88G0nqYMnNzy3nGE5E9DwcVh/tqmHpcz78xCr5VVHzsnXunawlrFQdfVTNgj54b0VDZCT5vVfj93Gq1igODrJkUkMqZO3qal1Mz+UXLQq9HPD6Pxi50ndecv9bcIDVBR43u5ajX1/Oxt2vtZkOdxc05+n/HUCWpKNPYjbrfNivQtqrO8saqjG3aHavL2VHx44bYVMp9FiO7xm5U/6U7Ed+cRRuZjEu/ariNyf67z/UTb1RqiJx3Fn2CFtuWHrgv6ZhrfoPTrE7oQmJIPvwvqhJWOH31AhYVc575T2WpwSngLRIm/Yr2XBiWrSthN6lD9stbWWAbMJLkiXvRH7oKWj3qRuWw+rQT6lrZJyJrJnVH5WSLfuNpcHVA80Fn1PXKZbs8gKprQ5T1I+GjjRAeBZYaqFUW3u2KqlcOQ4wW+oOFBtb+ljYk6dVWaWW5ebk5bHwPFu4DrQ78O0F/n9zXE/kg45kKSoKIQhYcHGxSdvNm2s2JypXL+cspJxUrViQwMJAHDx7k2BtRoUIFIiMjadasWbYn6AVVrlw5jh07RmxsrMnQohs3bmBvb29IXs5JhQoV+OOPP3B3dzf00mQnvSfj6tWrVKqU/awo+/btQ6fTMXfuXKPjnJiYaNQLkU6j0RhmTwK4du0aAwYMYPny5cyZMwcgx9lDspPTOlWqVKFKlSpGZenH0ds7+/HBIv8al1Gx5ZX8Jyp/e1rh/KNRRRfuQ+fNeq6+pcLJunB/ZMqVULHsledr6t1nVaW2panU9vHuUJ1VcmQyJz89h5JggQKEnXnIn1PP0WJG/se5qy3VVPqsEZU+a5TvdR1fLI/ji3mbslalVuH6SQtcP8lm6tNsxM04RtKutJmflLgUoobvxapFeSxr5tyrrqlUEseVudwFOhO1pwu2q1/PV9tUajWaCZ3QTOiUr/XYcw5u3kv7f2IqBN+HzuZzSQw0Gljgn/aXX6+2SvsTopiRnIhCtnnzZuLi4gyP4+Li2LJlC46OjjRtWvBb1adfwZ47d65J3kHmcYi+vr48ePCAn376yex2so5BzI/27duj1+tZtWqVUfnRo0e5cuUKPj4+eQpc0pOOFyxYgE5netOlzG3s0KEDlpaWLFu2zOi4pkvf9/RhYZmPBcCKFStMjlfmaWHTeXp6YmNjQ0xMxnj69ByL6OjoXPcp8zqZtyGeHTHJCmsvGb9/7ibAz1fzeQMwIXLx767bpEQaj8e/uSUYbdJ/767lcYuNE7KVRC0JP5wrotY8PiU2EdYeMy68G5M2Q5MQzxnpiShkzs7ODBo0yJAwvXPnTsLDw/n0008fa/hSx44d6dSpE7t37yYkJAQfHx8cHR25desWx44dY+PGjQC89tprnDhxgjlz5nDq1CmaNWuGvb094eHhnDp1CisrK5YsWVKgNvTo0YNdu3bxww8/cOfOHZo0aUJISAibN2/G1dXVaKalnNStWxd/f3+WLl1K//796dixI25ubty/f59Lly5x9OhRjh8/DkCZMmWYMGEC06dPp1+/fvj6+uLh4cHdu3cJDAxk4sSJ1KxZk/bt27N27VrGjh1Lr169sLS05MSJE/zzzz8mvSNTp07l7t27eHt74+HhQXJyMgcOHCA+Ph5fX1/DcvXr12fjxo1MmzaNNm3aYGFhQb169XLsUapfvz7bt29n0aJFVK5cGZVKhY+PT57v8ZCdsLAwdu9OG7t748YNAI4cOUJERASA4bik27Bhg6EHRqvVEh4ezvfffw9AjRo18PGR7vCsVKpHk6QopuVCFCaz76n/6BvtudnX/+I+PS/kpSswCSIK2ejRozl79iybNm3i4cOHVKxYkalTp9Kli/kp5vLjyy+/pHHjxmzfvp1ly5ah0WgoW7asUVKuhYUFs2fPZvPmzezZs8cQMLi5uVG3bl26d+9e4PotLCyYP38+y5cv58CBAwQEBODo6EiHDh0YMWJEvpK1/f39qVOnDuvXr2fdunUkJibi4uJC1apVee+994yW9fPzo3z58qxevZr169eTmpqKm5sbzZo1M9x3olGjRsyYMYPvv/+exYsXY21tTfPmzVm6dClDhxrPw92tWzd27tzJ7t27iYyMxN7enipVqjB9+nQ6dMgYd9u5c2euXLnC/v37OXToEHq9ns8//zzHIGLEiBFER0ezadMmYmNjURSFHTt2PHYQERoaanJTwYCAAAICAgz7nzmIWLNmjdHMFnfu3DGs3717dwkizHC0UvF6bRU/XMyIIsrYQa/q8gsjCldF3/Kc+/YCyQ8zeiOq+HlikY/pXZ8V9sObEvPpYcNjla0Fdm82LLoGPSaVoy3KgFaw6reMwjJO8D+ZclU8f1RK1vEfokB27tzJ5MmTWbx4sWGcvRDi2XIsVM9bv+i5FQvVneEnXzV1SsmoT1H4Hl6NZMeE3aij1DTu24i679RCbfnfe68pikL8siASN/6N2s0Ox/daYtX02Z51R0nRwsy9sO8vqFYGPuyBqprcSfpZpfrQNG8yO8o006nmn2fSEyGEEMDtWIVOm/XEP5p18+w9mHVGYVnnom2X+G9yrOxASo+0+8HUGlz9PxlAQNpkEw7+TXDwb1LUTSk0KisL+LBH2p8Qz7H/5reWEELk04bLiiGASPfj3wqpOumsFUKI/yxVPv6EEQkihBACsDYzHN1SDWr54RBCCCFMSBBRSHr06MHp06clH0KIZ1S/WipK2xmXjWysQiNRhBBCCGFCciKEEAIoZafieH8NM8/ouRUDPaqqeKu+BBBCCPHfJt/zBSVBhBBCPFLZWcW8Dv+9aTaFEEKIwibDmYQQQgghhBD5IkGEEEIIIYQQIl9kOJMQQgghhHg+SUpEgUlPhBBCCCGEECJfJIgQQgghhBBC5IsMZxJCCCGEEM8nlYxnKijpiRBCCCGEEELkiwQRQgghhBBCiHyRIEIIIYQQQgiRLxJECCGEEEIIIfJFggghhBBCCCFEvkgQIYQQQgghhMgXmeJVCCGEEEI8n2SG1wKTngghhBBCCCFEvkgQIYR4pv1+W2HVBT23YpSibooQ+WJ9VYX9MQ1JtxOKuik5SjoVRszK86RciyzqphSd5FTYego2HIe4pKJujRDFggxnEkI8kxRFoc9OPZuvpgUPGhX80FXN63Xk2ogo3hS9wl9+R3DfZQ3AsXU7afBjG9xf9Szahplxd8QBYhadTXugglKzX8R5TNMibdNTFx4Fbb+AfyLSHpdxgsBPoGbZIm2WKCwynqmg5NdWCPFMOnRLMQQQADoF3j2sJ1UnPRKieLu3J5T7u0INj5VUPZcnnEbRF6/3bvJfdzMCCAAFHnz0G7ro5CJrU5H4bk9GAAEQEQ2Tfi669ghRTEgQIYR4Jl1+YFp2NwEeykgDUczFX4k2KUsOTUAbk1oErcleyqWHJmVKQiraWzFF0JoidOlO3sqEeM5IECGEeCa1r2DaBV3HFcrYS9e0KN5c2rublDk2dsHS2aoIWpM927blwcL4NEHjYY9VLZcialERebFO3srEs0mVjz9hRIIIIcQzqZ6bitkvqLB7lNlV0RHWdNM8sfqCI/XMP6Hl5791MmTqGRB/P5nzm29xdV8Y2mRdntZJuJvIpbU3uL4zBG1S3tYpCKemrlT9siFqCx2Wig47Tzvqr2r9xOoDSAi6x705Z4n9NQRFydv716KsA6Vm+KB69CHTlHfAfV0PVJbZf850d+OJX3KGhDV/oY9PyXP7FJ2elF2XSJr3B7qr9/K8nu6366TOOYzuRHDe67oSjm7uIfS7/kLR6XNf4a320LoGqB6dRXZtCJP+l7fK7kbBkl/gp0BIyOMwsIu3YO5u2Pcn6PPQPiGKiCRWCyGeWSfDIUGb9v9bsfBLsELjMoV/uWj7ZR2vbkwh9dF5ZbNyKgIHW2NrKZemiqPQoEh2jD5jCARKetrjt7w5Nk7ZX+kPP32fXwYfRZuYto5TFQe6b2iHTUnrQm+fotWTeCAEu5RHb97gKBL/vIdjvZKFXhdAxNenCf/4mOGx8+s1qbTmpVzXi9t+jfsfHIHUtBNZC3cHrJub9qKkSzkVyv0OP6LEpgUPmsrOuB0bgqaMQ471KFodsV1Woj10Pa1ArcJ+pR/WA5vkuF7yyE1oF/5ueGz5YUesvu6R4zr6VX+ge+sHeJR/oupYG82+sag02VxTvR8LrSbDtfC0x7ZW8OkrUMIux3oAOHkNOk6C2MS0x1XWw7GvobRz9uss3Asjl2U87uEF2z/KCGCEKEakJ6IYOn36NF5eXuzcubPI2nDlyhWGDx/OCy+8gJeXF0uWLCmytghhzqkwhbWXjK+oTjmmJyqp8HsJ3t+fagggAE6FKqz968ldqRaP5/jCa0Y9CZHB8Vz4+XaO65z57m9DAAEQfSOOy+tuPpH2Pdx1i5hfwzIK9ArB75/M21XxfNJGJhEx5aRRWdRPV0g4czfXdR+8H2gIIACST4cTt/ZStsvHfB5oCCAAdDejiJt7Mtvl06XuupwRQADoFRI+2Jfj8dBfvWsUQACkfvMr+jum+SbpFK0O3ftbDAEEgHLwEsruv7Jv3KKDGQEEQGIKfLIp++Uzm7guI4AAuBEBc/dkv3xSCnz8k3HZztPw6/m81SfEUyY9EcKEVqvl/fffR6vVMmzYMBwdHalevXpRN+upO3z4MFeuXOGdd97J8zpr167F0dGRHj1yvhqWXxcuXGDv3r1cunSJa9eukZiYyOeff55tPSkpKaxYsYI9e/Zw7949SpcuTY8ePXjzzTexsPhvfOyvR5sGC4lauBMHzjaFXFekaV3mykTxEB1iet8Fc2WZxdyKM1MWX2htyizpumlicmpEIro4LRY59JYUhPZOPIqZoVnJ/0Rh17R0juumXo/KU5mhrn9ME7F1ZspMlrluJoE7PBYlLgWVk/kPs/6GmZkVdHqU4IdQ1sl8RbFJcC/WtK7rOQyfum4m2DJXZnbdCDNl4aZl6e7HQLSZ9+n1cOjQIG91ivyTTp4Ck56IYqhJkyYcPXqUbt26FUn9oaGhhIaG8tprr9G3b1+6dev23AYRy5Yty33BTNatW/dEepCOHj3Kpk2biIuLy9Nr8dFHH/H999/j5eXFBx98QNOmTVm8eDFTp04t9LYVlfYVVFhlGZpdqQTUci38ujpXNf2q7FxNvj6Lq4otS5mWtTIty6x82zJ5KisMzp3KmZy4OLYoXegBBIB1rZJYVnQ0KlNZa3B4oXyu69p1rmxa1sW0LJ1Nl2qm9Zspy8qyUzWT4TqaFhVQZxNAAGhaVQaHLEPN3BxQN62Q7TqqkvaomnlmKVShfqlu9o3rXN+0rEseT+g7NzKzbuPsly9fCupmab9aDR0lgBDFk/wKFiPx8WlXvdRqNdbW1mg0Ty5JNCcPHqRd4XFyyuZqTgEpikJCQvG+M+vT5u/vj7+/f67L+fn5ERgYyMaNG+nfv3+Oy/7+++8EBgby+uuvM3HiRHr27MnEiRN5/fXX2bVrF+fOnSus5hcpd3sVa33VlH40NLmsPazppkb9BMYOL+lhRatHs0FZa+CD1hraeRbN51Pkrs24GpRt7AyA2kJF4zc8qd4x+7H8AM0/rE+FF9xBBSoLFRU7euDZ+cncTMy+gSsVZ3mTbK0iBQ1WtZ2pvrr9E6lLpVHjubkrluXT8hJUthrcp7XEsnTuY/pdp/lgUc05bT0HS1xntMPWJ/uT9BJTX8CmVy1Qq8BCjXXHytj41c69kSk6LHvUAntLADRe5XBY3Sfn/Sphg/WmwagqPsojcbXH4vWmkJBzMrdmzVvQ8FEAZW2BqmMtlH8fZJ9s3q8lvN89LRcCoKYHtK+dt4Tnr16Hns3TAkYLDfzPGwa2z3md9e9mBBIONvDdIKiS83tXiKIiQUQh2blzJ15eXpw4cYIlS5bQvXt3WrZsSb9+/fjll19Mlu/Rowf+/v5cvnyZUaNG0a5dO1577TUg+5wIRVHYunUrgwYNom3btrRt25a+ffuyePFio+XSh7L06dOHVq1a0b59e8aPH8/ly5dz3Y/MJ7WTJ0/Gy8sLLy8v7txJmxM7MTGR+fPn88orr9CyZUs6d+7MxIkTCQsLM9pO5n3YuHEjr776Kq1ateLHH380LLN//37eeustfHx8aN26NYMGDeLgwYNm23X69GnGjh1Lhw4daNWqFa+88gpTpkwhKirKsMymTZsYOXIkXbt2pUWLFnTu3JnPPvvM0PbMfv/9d/z9/enQoQOtW7fG19eX//u//+Pff/81HIddu3YBGI5BbnkqXl5ehIWF8eeffxqtY67+/HJ1dcXW1jZPy6a/39LfT+nSH+/du/ex21NcaPVw71Fceicehh/UE5dS+MOMLNRw+9EIlGQdzD6hI+Cm5EQUV7eOPyDsXBQAeq3CreP3SU3U5riOtbMVpRu7gAKKVuHWwTAO+B/L80xG+aFP1XN7421SU61IUVvw8Eoi9w/lMMzlMUVtuErq7bThWkqijrB3fyd66/Uc10kNjuZOp41o/4lKK1DAtl32AQSAuoQ1doMbpp00a/UkH7zJfa/v0UcmZrtO0oJjxDRbQOqOSxCfiqZ5eUocG46mes49RwAWXWpjteYNsLGAB/FoZweSWH8a+ttROTRSBaGPnk/Wohy4hM53HrrBq8wvr1LB9H7g/0La4yth8PpC6L8w1/ZRwi7tTwG0Ovj5BIxdnvM6jrbw4NGQq7gk+HQdHL+Se13iMcgcrwX13xgcXYzMmzePxMRE/Pz8gLTg4pNPPiElJcVk/HpERATDhw+nY8eOvPjii7lepZ84cSJ79+6lXr16DBkyBEdHR4KDgzl06BDDhg0D0vIZRo8ezV9//UW3bt3o06cPcXFxbN26lbfeeotly5ZRp07281sPGTKEhg0bsnLlSnr16kXjxmldryVLlkSr1TJq1CjOnTtHhw4dGDBgALdu3WLLli2cOHGC1atXU6aMcff/unXriI6OpmfPnri6uhqeX7hwIStWrKBVq1YMGzYMtVpNQEAAH374Ie+//z59+mRchdqyZQvTpk2jdOnS9O7dGw8PD8LDw/ntt9+IiIjA2dkZgDVr1lCvXj369u2Lk5MT169fZ9u2bZw6dYr169cbljtz5gzvvvsuVatWZfDgwTg4OHD//n1OnjxJSEgIlSpVYsiQISiKQlBQEFOmTDG0pUGD7LuVp0yZwsyZM3F2dmbIkCGG8pIln8yMK9m5ePEipUuXxt3d+OqVu7s7bm5u/P3330+1PU/Sx7/pyXyKd+E+rPlbYVijwv2yX3hKy61MORjJWvg8QMsLlaU3ojg6tuAaSqYLxQ+uxXFlXxj1emV/EpwSl8rZhcYna7ePRBB2/D5lW7oVavvubrtFzPH7RmXXPj9Lubero7Yo3Gt72vuJ3JudpfdRgdB3f8epV9Vs14uadRpdRMZvkhKfysMvjlF2Z85Tm8Z8ejjt9vHp9V99QPyKszhOaGmyrJKqI3HiAaMy3cnbpO64hNX/6uVYT7rUKfsgKSNAVEKj0c47gtX0l80ur/92P9w3zX9RfjiG8kEXVLU9TFcKj4L5xu1kw3H4sAc0qpR94y7egtWHjcsW7IP/6wkVsgmSZu9Kqy9dfBJ8sQl2f5p9PUIUEQkiCllUVBTr16/HwSGt69jPz49+/foxa9YsOnXqhI1NxhjP0NBQPv30U3r27Jnrdg8cOMDevXvp2rUrkydPRq3O+KHRZ+pW3bBhA2fOnGHevHm0bJnxpe3n50ffvn2ZPXs2S5cuzbaeFi1aYGFhwcqVK2nQoIFRXsbWrVs5d+4cb7zxBmPHjjWUe3t7M27cOObPn88XX3xhtL3w8HA2b96Mi0vGzYkuX77MihUrGDx4MCNHjjSU9+vXjwkTJrBgwQJ8fX2xt7cnIiKCb7/9Fk9PT1asWIGjY8bY3uHDhxvt+/r1602u1vv4+DBixAi2b9/OoEGDAAgMDESv17NgwQKjdr399ttGx2Hfvn0EBQXlOTelW7duLFq0CBcXlyLLZwG4f/8+lSubH7fs5ubG3bt5TAp8Ch4+fIi9vT3W1mljm+Pi4lAUxfA6p6SkEBsbi6trRqJDWFgYHh5pP/QhpjmS/B0Wh9LQEdWjYU2PWwfAlbAEwHi8+q2ojPdeYdSR9XF4eDhlypQp1P14XuqIDTe98v3g34xkZnN1hFy5jc5MAnJ8WEKh70fSbdMLRqn3kwm7eYey1coV7rG68K/RSX06bXh8jnVozXy4tP9Gm68j02PdLdPZkeKvRGCVnGxSh73OAuWh6WulvxWV59dcuRVluv6/D7M9Vk4h2Sd6Pzj7D6Vqm3lf3YkEMzNFJV65jbaqS/avR8h9k3XQ6yH0gSGIyPq+SvnnDlkzY3Q3I0i/XPGsfAafRB2i+JHhTIXMz8/PEEAAODg40Lt3b2JiYjhz5ozRsk5OTnmexSd9CMq4ceOMAgjA6PHevXvx9PSkdu3aREVFGf60Wi3e3t6cO3eOpKSkAu1bQEAAarWawYMHG5W3adOGGjVqcOTIEaOTegBfX1+jE/X0NqpUKnx9fY3aGBUVhY+PD/Hx8Zw/nzal3cGDB0lNTWXo0KFGAYS5fU8PIPR6PXFxcURFRVGjRg0cHBy4cOGCYbn01+fXX39Fq815iENhSkhIMNlfrVaLVqs1KX+c3JGkpCSsrMwnaFpbWxf49X8SXFxcDD8ykPbaZH6draysjH5kAKMfle5VTXsc+jXICCAKow6APo1N57nvXjOjF6Iw6sj62N3dvdD343mpw7Ot6axDNTuWy7GOqk0r41y9hFGZ2lJNuTalC30/SnUpmzasJpOSPmUoV718oR+r8j41sfCwJyvHrpVyrMO+u2kvhX2PambryPzYpkcNk/WcX61vtg61sy0WrbNcydeosexWM8+vuaaHaVK0RY962R4rVfdsepNL2uH6cnOzddCgIlTIMmODow22XRrn/Hq0qQ3OWY69R0lomnFss76vrHq3Mmma5hXv7OugeH4Gn0QdoviRnohC5unpaVKWflU4NDTUqLxcuXJ5Tp4OCQmhVKlSJh+6rG7evElycjIdO3bMdpmoqCiToS55cefOHdzc3ChRooTJc1WrVuXq1atERUUZBQ0VK1Y020ZFUQxDvsxJT+4OCQkBoGbNmrm279SpUyxbtoyLFy+SnGx8Z9DY2Iyran369CEwMJBp06Yxb948GjZsSKtWrejcufMTHXo0Y8YMQ55FVllfr+7duzNp0qQC1WNjY0NKivnkwuTkZKPesGfdp94q/r6vcCUSXG3gizZqWpUr/HGrveto+OJFC779Q0t8CvSpq2FaR8tCr0cUjhc/qcMhnULw0XvYlrSixTvVcK/nnOt6HRZ4c2jEcaL+icW6pCWtJjXCrnTecpHyw6G2MzUXNePv8SfQJKiwb1yS+j88mTtWq9Qqqux7mZvdd5IakjaMx66lOxWWvZjjeo6D65F87i7Ri8+CVsHulWqU/Mx0SFJWznM6o8SnkLTtCuqSNjh+0habTtkPm7L/qS/xgzejDbiBurwTtjO6oKmR9+FjVlO6wb04tOv+BFtLLMe1w+J1r2yXV3Wvj2pdNZQ/bmT0LtT2QLP4dVT22dxY0EIDs1+HUashLAqqloYlQ8Apl+R0B1vY9iEMXwKXbkNDT1g2HCxzOPUa9AJcC0u7Y3WKFga0g89zTjIXj0lSHQpMgogi9KRO5qpVq8b48eOzff5pjtHPbh9VKhVz58416VVJV7Vq9j865ly8eJFRo0ZRvnx5Ro0aRdmyZbG2tkalUvHxxx8b9ZA4OzuzevVqgoKCOHHiBEFBQcycOZMlS5YwZ86cHPMeHsfAgQPp2rWrUdns2bOBtB6mzNzcCj4Gu1SpUty7Z37e8/R7RvwXXLin8MJGPTGP4qVELXg9gbtVp/u0nSUftbVApwcrC/nVKc7sXKzpMbsJuhQ9agsVKnXeXq+QX8OJ+iftgkNyZCrnFl+lUseyaKwLN/dFl6Tj6rqbxNtZgR3E3I4nZM9tagyrVaj1pLNtUIo6twajS0hFZaFGnXVuZDO0t2KIW38ZUtK+OxN2XScxMAR7M9O+ZqYuaYvrlj4oKTqwUOd67DWVSlLi16EoyVqw0hhdzc4LlZ0V1j8MwOr710Ctyv7O04ByLQKd99cQ+ain19oC9c5RaDplnycIwJHL0H8RJKemPY5MgEq5J34D0K4u/D037UZyNnmYwlelgi9fhyn90m6Kl1PAIUQRk3dnIQsODjYpu3kz7a6n5cqVM3kurypWrEhgYCAPHjzIsTeiQoUKREZG0qxZs2xP0AuqXLlyHDt2jNjYWJOhRTdu3MDe3t6QvJyTChUq8Mcff+Du7p7t2P106T0ZV69epVKl7BPY9u3bh06nY+7cuUbHOTEx0agXIp1GozHMngRw7do1BgwYwPLly5kzZw5Avn/MclunSpUqVKlSxags/Th6e3ubW6VA6taty969ewkPDzfqcQoPD+fevXv4+PgUWl1F6dvTGQEEQIIWpp/Us/mVJ5fsrFGryOEcRRQzGqu8v1j6VD1nFxrPYPfwUjTBB+5QtXvOsxLlV+je20RfjDa6N8Lfsy5S7a0aqC2f3BtMY5f33rPoBUHo7mYaVpmqJ3LqsVyDiHSqPAQqRstbP97piMoy9/r0sw9lBBCQNjvTdwcgtyDiy+0ZAQTAwziY/QvMH5T3BuYlgMhMo4En91UmRKGQn8NCtnnzZuLiMmZ+iIuLY8uWLTg6OtK0adMCbzf9CvbcuXNN8g4yT0Ho6+vLgwcP+Omnn8xuJ32YUEG0b98evV7PqlWrjMqPHj3KlStX8PHxyVPgkp50vGDBAnQ600TGzG3s0KEDlpaWLFu2zOi4pkvf9/RhYVmnY1yxYoXJ8co8LWw6T09PbGxsiInJSL5Mz7GIjjZNFMyOra2t0TaKQufOnYG0mbEyS3+ctTfkWRVu5mbCYfFyF2lRMNokHSkxqSbliXcLP4coycw2U6NT0SUXn2mDdWY+YObKniVKuOl3ubkyE+aWCYt6/AYJ8YyTnohC5uzszKBBgwwJ0zt37iQ8PJxPP/30sYYvdezYkU6dOrF7925CQkLw8fHB0dGRW7ducezYMTZu3Aik3QvgxIkTzJkzh1OnTtGsWTPs7e0JDw/n1KlTWFlZsWTJkgK1oUePHuzatYsffviBO3fu0KRJE0JCQti8eTOurq5GMy3lpG7duvj7+7N06VL69+9Px44dcXNz4/79+1y6dImjR49y/PhxAMqUKcOECROYPn06/fr1w9fXFw8PD+7evUtgYCATJ06kZs2atG/fnrVr1zJ27Fh69eqFpaUlJ06c4J9//jHpHZk6dSp3797F29sbDw8PkpOTOXDgAPHx8fj6+hqWq1+/Phs3bmTatGm0adMGCwsL6tWrl2OPUv369dm+fTuLFi2icuXKqFQqfHx88nyPh+yEhYWxe/duIK3XB+DIkSNEREQAGI4LpCW6t23blp9++om4uDjq16/P+fPn2b59O127dqVRo0aP1Zbi4n/VVfwSrGQpk+siomCsHC0p27o0d45mzF6mslBRsUPhJ3eWfaksf31xFkWb8f4t064Mlg7FJ8/G/n81iP3xb5OyZ5n6f03Q/RxkUpar/3nBX7eMy3o3K8SWCfFskiCikI0ePZqzZ8+yadMmHj58SMWKFZk6dSpdunR57G1/+eWXNG7cmO3bt7Ns2TI0Gg1ly5Y1Ssq1sLBg9uzZbN68mT179hgCBjc3N+rWrUv37t0LXL+FhQXz589n+fLlHDhwgICAABwdHenQoQMjRozIV7K2v78/derUYf369axbt47ExERcXFyoWrUq7733ntGyfn5+lC9fntWrV7N+/XpSU1Nxc3OjWbNmhvtONGrUiBkzZvD999+zePFirK2tad68OUuXLmXo0KFG2+vWrRs7d+5k9+7dREZGYm9vT5UqVZg+fTodOnQwLNe5c2euXLnC/v37OXToEHq9ns8//zzHIGLEiBFER0ezadMmYmNjURSFHTt2PHYQERoaanJTwYCAAAICAgz7n3kmi2nTprF8+XL27t3Lnj17KF26NMOGDePNN998rHYUJ0MbqAiNUzHvT4VELdR3gxdM8/iFyLN233px9LMgbgdG4FjRnmbv1aVEJdOZuR6XQ2VHmi3y5thHR1FHqvHoUJZm3zbPfcWnyKFndUrNfIHIb06ij03B8Y26uEx+MsnfT4v6dW+UWw/Rzz4ISamoh7RG/VEefps/fhmiEmBFINhYwrgu0N90FiUhnjcq5UncjvM5tHPnTiZPnszixYsN4+yFEE/W+XsKLdfqiH80CsVSDb/4qXmhovRIiOItNTWVlStXAjB48GAsLYtPL4QQzxPVpOzvqJ6VMqnwZ2t7lskvrRDimTX7jN4QQACk6mHGSbkuIoQQQjxpEkQIIZ5ZD83kvD5IkiBCCCGEeNIkiBBCPLP61jJzx+pa8rUmhBBCPGmSWF1IevToYZiRSQjxdPSrpeZuAsz9U0+KDt6qr2ZcU7kRnBBCiDwqwD2hRBoJIoQQz7QxTdSMaSK9D0IIIcTTJL+8QgghhBBCiHyRIEIIIYQQQgiRLxJECCGEEEIIIfJFggghhBBCCCFEvkhitRBCCCGEeD7J5EwFJj0RQgghhBBCiHyRIEIIIYQQQgiRLxJECCGEEEIIIfJFciKEEEIIIcRzSpIiCkp6IoQQQgghhBD5IkGEEEIIIYQQIl9kOJMQQgghhHg+yWimApOeCCGEEEIIIUS+SBAhhBBCCCGEyBcJIoQQQuTLrSg94bHKU60zIUlPSLgWvf7p1iuEEMI8yYkQQgiRJ5GJCq9uSOHQDT0qFfStp+GHXpZYWTzZQcVbDsaxYkcsSckK7q4aPvMvSS1PqydapxBCiJxJT4QQQog8mfhrKodu6AFQFFh/Xsf8E9onWufN0FQWboohKTmtByL8gY5pK6JQFOmREEKIoiRBhBBCiDwJDNablB02U1aY/rqWYlIWEqHlYcyTrVcIIUTOJIgQQgiRJ3XcTH8yzJUVpkoepqNunR3VODnIz5cQohCo8vEnjMi3sBBCPEPuxCmcCVfQ5THBWK8o/BmhcDuXRGhFUTgbric4KvvlprxogYdDxuNapVRMaG16kh+brHAyREdscu5tjErQ8+e/WhJSzC/bqKY1HZrbGh6r1fCGrwMWmsf7RU+I03Hrn0RSkqVH43EkX3pAypWHOS6juxdPyqk7KMmFM/RN0evRBd1GfyuycLZ3Pxbl1A2U5NScF7zzELb8ARdu5b7RB7Fw6hokmfakCfFfIYnVQgjxjBj3q475QQo6BSo6wvZeGhqVzv5k+vIDhe5bdVyPSruI9nYDFYs7qVGrjNe5GaXguyGVS/fTlutfT82qHhos1MbLxaVA+qpqFXSppsbN3niZn4JSGfZzInEp4GAFC3vZ8EYT80nQy35LYuL2eBJTwclWxaLXHehW33TZj98qSfN61izcGE10nMKCDTHcCtcyup8TKlX+g4nf9jxgx48RpKYo2NqreX10eeo1c8z3dp5nuqgkQl/eTuJvoQDYvViBsltfRlPC2mi5mKm/ETPlN0jVo3azw2Xj/7Bp71ngevX/3CPRdxnK1XugUmEx0Avr5f1QaQp2TVT5agdM3gopWnBzRNkwCtULdUwXHLkUFu2D9Fi3cRX4dTI425su++02+HQdJKeCqyOsHQ8vNSpQ+4QozqQnohg6ffo0Xl5e7Ny5s8jacOXKFYYPH84LL7yAl5cXS5YsKbK2CCHgl5t65vyZFkAA3IoF//26HNcZcVDP9ai0/yvAsr8Utl4zveI//oCWS/czlvvpgp4fz5teoX97ewp3YtP+r1dg9nEdv97IaENkgsLQLWkBBKQFHe/8nMTDBNM6b0fq+PDntAACIDpRYeTaOBKz6ZHYERhPdJxiqHv74QSOn0/Ocf/NeXg3hZ9XhpP6qJ7EeD3rFoSSmiI9EvnxYOoJQwABkPBrCA+nnzJaJuWvCGI+C4TUtGOrv5dA5Js7UR5jmt7k0T+nBRAAioL2h1NoNwQVaFvKhRD4ZFNaAAFwLxbeXIqiy/Je2H8WFmYKIACCbsCXm003eiUU3v8xLYCAtB6JN+dB6pOdgECIoiBBhDCh1Wp5//33uXXrFsOGDWPKlCm8+OKLRd2sp+7w4cP5Dp7Wrl37RIK/Cxcu8M033zBkyBDatm2bpyAzIiKCL7/8El9fX1q2bEnnzp0ZM2YMN27cKPT2iSfv2B3TE69T4aDN4YTsWJjpc3+Emim7bVp2LEtZUqpCkLnt3co44TobpjMEBekSUyHojmmwc+ZfLVnP1SITFK7dNV1WURT+vmE61OTvG/kfKnLrn0SULPXGx+q4e0eGneRH4h93ci1L+eO2yTK6f6PRpUeiBaA7FmxSpv/DtCxP/rhmWnbrAYRmGZ517Ir59X+/ZFp2/Gra1GWZhUVC8N2CtVGIYkyCiGKoSZMmHD16lG7duhVJ/aGhoYSGhvLaa6/Rt29funXrRvXq1YukLUXp8OHDLFu2LF/rrFu37okEEUePHmXTpk3ExcXl6bW4fPky/fv35/jx47z88st8+OGHDBgwAHt7eyIjC2ccsXi6GpoZtlTXFZMhR0bruJmWmRv+1KhM7mU2lipqljJdrrFHxs9IndJqLDXGz1tqoG4Z05+aemUtyDoSycEaKpfSmCyrUqmoWt509G21CpYmZbnxqGRjUmZtq6ZUmfxv63lm06i0aVlj4zLLRmVMllG7O6ApY2YIUB6pG5YzLWtsWpYnjSqZlpVxAg9n47KGnubXb1LFtMzcsq6OUKFUPhsnRPEnQUQxEh8fD4Barcba2hqNxvTH9Gl48OABAE5OToW6XUVRSEhIKNRtPuv8/f3x9/fPdTk/Pz8CAwPZuHEj/fv3z3HZ5ORkPvroI8qUKcO6det45513eOWVV3jjjTf4+uuvadq0aWE1XzxFL1dV8WqNjLNuJ2tY0DHn74g5L2pwzchJpoUHmDn349sOGlwynVt7l1VRw8W0l2Nhd0scMw1571dPTdfqGT8jZRzVTO9qTfrwdLUKPnvRCndH05+aqqU1vPeSrWHCE0sNfP0/exxtzAdF/bs6YJOp7jaNbGjTyDQgyE2Zcta85FcqI7dDA/8b4o61bdF83z6rXD/1xqqWi+GxZR0XXD5sbrSMdYvy2I/I9H1jo6Hkgi6oskaaj+gfJpBy6Dr6iLhs67We9Qq4ZQQhmpdqYjHAy+yyiqKgP3kT/cmbZp9XNa8KozplFFiq4Z0XMoY3pXu5WdpfZmVd4FM/0402qgzje2RqsCXMexts5OaI4r9HEqsLyc6dO5k8eTILFizg7Nmz7Ny5kwcPHlCpUiUGDx5M586djZbv0aMHHh4evPvuu8yfP5/z58/j5OTEjh07OH36NMOGDePzzz+nR4+MLyNFUdi2bRvbtm0zDEkpW7YsL7zwAsOGDTMsl5KSwpo1a9i3bx+3b9/GysqKxo0b884771CrVq0c98Pf358///wTgMmTJzN58mQAduzYQdmyZUlMTGT58uUcOHCAu3fvUqJECby9vRk+fDgeHh6G7WTeh8TERDZt2sTt27d58803eeeddwDYv38/GzZs4Nq1a+h0OqpVq8Ybb7xBx44dTdp1+vRpfvzxRy5cuEBiYiJubm40bdqUMWPG4OzsDMCmTZs4fPgwN27cIDIyEicnJ5o3b87w4cMpW7as0fZ+//13Vq9ezfXr10lKSsLZ2Zk6deowatQoKlWqZHQcvLwyfqCyviaZpS8XFhZmtE76sXscrq6ueV72wIEDhISEMHPmTBwcHEhJSRumYWUlP2LPsuAY+PNuxkm9Vxlo7p7zOt4eKv4dqmHFBT1fHFM4HgYNftDTp6bCT75qLNQqHiYqDNyh42FSxnon7ih0WqfD00nHL69ZUsM17Yy7eTk1Dcuo+P1WWjvOhiuExipUcMo48R/f1proJIWpv6ag08NXASlUcFbzppfx+09RFO7G6A3DzB2soHpp8yeXSzZHs/lgPHoFbKxUvP0/R3q94GB22byo3diR3/Y9JDFOj14HN68k0PwF5wIlaT+vNKVssazuTMrltKE/SrwW3YNELErbGS1nUckJLNSg1YNKhZJkPjcgaXUQce9sgyQtWGqwn94Z2/GtTRe0tgCrTKcu9lZp0WoWyv04tF3moJxJm0lJ1bQiFvvGoiqV5X3zRW/47Qqcu5WWuzFlG8z+BWXzaFSd6qcto1ZD+3qw+wyGMXhhkfDTEXivp/H2Qh/AL2czHjeqDL5y4aZYk899gUkQUcjmzZtHYmIifn5pVyh27tzJJ598QkpKisnJZ0REBMOHD6djx468+OKLuV6lnzhxInv37qVevXoMGTIER0dHgoODOXTokCGI0Gq1jB49mr/++otu3brRp08f4uLi2Lp1K2+99RbLli2jTh0zM088MmTIEBo2bMjKlSvp1asXjRs3BqBkyZJotVpGjRrFuXPn6NChAwMGDODWrVts2bKFEydOsHr1asqUMe6+XrduHdHR0fTs2RNXV1fD8wsXLmTFihW0atWKYcOGoVarCQgI4MMPP+T999+nT58+hm1s2bKFadOmUbp0aXr37o2Hhwfh4eH89ttvREREGIKINWvWUK9ePfr27YuTkxPXr19n27ZtnDp1ivXr1xuWO3PmDO+++y5Vq1Zl8ODBODg4cP/+fU6ePElISAiVKlViyJAhKIpCUFAQU6ZMMbSlQYMG2R67KVOmMHPmTJydnRkyZIihvGTJkjm+roXt6NGjADg6OjJ06FDOnj2LoijUqFGD0aNH07Jly6faHlE43g/MSJIGOHQLlp1XGNMk5x9AeysVm68q3EvMKNt4ReGVagr9a6uY9oeOc3fN51UER8OEg1p29k0b6jP3uNYQQABcvq/wyUEtq3tnBAih0Xq+fBRAQNo54chtSfSqa4mTbUZbf72cyg/HMhKjIxNh/IZ4jn3kbNSGyzdT2Hgg3vA4KUVh4y/xvNzOHk0OQ7lysnHJHRLjMhIjjh+MooF3Ceo0kRma8ir6h4vE78zIr9L+G8O9dwMpv/d/GWXBUUR/FJCWCQ+QqCVy+F5sXqmB2j7jPaOPSSJuxI60NwtAqo74/9uH1av10JQ37hFPGb8NQqMNj3Vbz6NdcxrLwd5Gy+m+2mMIIACUM7fQfbUHi5l9jJbj2z1pAURmMYngvwLl+neo1GoIuQ//9wNGSTyKkpZA/WorqJSpe++zdfB3SMbjE1dhzi74LEu9QvwHSBBRyKKioli/fj0ODmlXO/z8/OjXrx+zZs2iU6dO2NhkdL+Hhoby6aef0rNnz1y3e+DAAfbu3UvXrl2ZPHkyanXG8AC9PuOLbcOGDZw5c4Z58+YZnSz6+fnRt29fZs+ezdKlS7Otp0WLFlhYWLBy5UoaNGhglJexdetWzp07xxtvvMHYsWMN5d7e3owbN4758+fzxRdfGG0vPDyczZs34+KS0e19+fJlVqxYweDBgxk5cqShvF+/fkyYMIEFCxbg6+uLvb09ERERfPvtt3h6erJixQocHTN+5IcPH2607+vXr8fWNtPYDcDHx4cRI0awfft2Bg0aBEBgYCB6vZ4FCxYYtevtt982Og779u0jKCgoz7kp3bp1Y9GiRbi4uBRZPgvAv//+C8D7779PvXr1+Oqrr4iOjmblypWMHTuWefPm4e3tnctWno6HDx9ib2+PtXXaOJW4uDgURTG8zikpKcTGxhr1xISFhRn1emV9HB4eTpkyZQxXlf8rdZy4oyPrCNQ/QlIY08Qm1zpOhZse+1PhCi+WDOfUnZx7uU7eyfiMnbhtehX5+K0UIOOE8NCF+2j1xsOMElLh77s6WlayMByrP2+ZJlBfCtcRHZ+MNinOsB+Xg00Tqu9G6oiM0VPKOa3nIj+vR2qKnrBbprM6/X32nlEQ8TRec3d3d8LDw59oHU9qP1SnIkyOYdLpCKM6Us6EZQQQjygxycScvY2mgZuhjqS/7kB8lsR2nR7tn3cMQUT6fuhOhZCV7lQIsa9UN9oP7fEbJuO1U45dNzrpCQsLw/2U+aFOBN/n3sXruNWrhiroBiazAAAoColHL2L7KIhISUlBffyK6YnVqX+M6izq75JntQ5R/EhORCHz8/MzBBAADg4O9O7dm5iYGM6cOWO0rJOTU7ZDY7Lau3cvAOPGjTMKIACjx3v37sXT05PatWsTFRVl+NNqtXh7e3Pu3DmSkpIoiICAANRqNYMHDzYqb9OmDTVq1ODIkSNGJ/UAvr6+Rifq6W1UqVT4+voatTEqKgofHx/i4+M5f/48AAcPHiQ1NZWhQ4caBRDm9j09gNDr9cTFxREVFUWNGjVwcHDgwoULhuXSX59ff/0VrfbpTbuXkJBgsr9arRatVmtS/ji5I+nrenp6MnPmTDp16oSfnx+LFi1CpVKxcOHCwtqlx+bi4mL4kYG01ybz62xlZWUylCvrj0rWx+7u7kbDUv4rdbQoazrUp1WFjJP3nOowN+ypubsKd3d3mpfL+Wq+d7mMz1iLCqbXnVpWMh6m1KFeKSyy/LLYW0GdR0OV0o9V00qm26rjocHJ3tpoP2pVNk14Ll1SQ8kSGZXk5/WwtFLjUdH4XgYAdRsbZ6E/jdc8cwDxpOp4UvthY+ZNZdOsjFEdVk09TIYaqZysKdGovFEdNg3KonLIMtxSo8aiScYw0PT90DSvaFKvpnlFk/2waFnVZDmrVtVM9oPmZpKjATxL4Va3atqxalIFzN2HQq3Ctk29jO1bWWHR0syQ4WYZ9RaH75JntY4nRu5YXWDSE1HIPD09TcoqV64MpPU8ZFauXLk8J0+HhIRQqlSpXMfG37x5k+TkZLN5BemioqJwd89lMLUZd+7cwc3NjRIlSpg8V7VqVa5evUpUVJRR0FCxoukX/s2bN1EUxTDky5z05O6QkLSrTjVr1sy1fadOnWLZsmVcvHiR5GTjK42xsRlTCvbp04fAwECmTZvGvHnzaNiwIa1ataJz585PdOjRjBkz2LVrl9nnsr5e3bt3Z9KkSQWqJ/2L29fX1+hLvWLFijRs2JCgoCASExNNem1E8TajnZpz93T8E5X2uIunCv8GeftVm9tBQ7ctOkIf5av2q6WiT820dT9oqWH/DYWzEaZDmio7w3cdM34mxrSw4Oe/dZx+NN1sbTcVX3YwPskv56Tmu+7W/N/uZFJ0YGsJC3raGA1lAnihpiWDW1mz6lgyigKu9ipm9TWdtaeWpxV9X3Jg4/44FMDWBiYMdCrwUCaAPsPKsnzaLeJidKhU0KJjSWo1KniOxfPIaWAd4nfdIG77dQAsPUvgNrO90TIWns44TX+R6I8D0vINbCwoubib0VAmAHUJG+wXvUKc/7a0OYEtNdjP6GwylAnAenYvErssQXl0t2pN7wZYvG6ac6D5uCvKkWsop9N6ZlVeldB83NV0R97rBocuwrGM3gKcbGHZW2lDmQDKl4JvB8F7mYY0adQwYyBUzDIF2pR+aUOYLj7qMfGpA+PydrFQiGeNBBFFKPPQpsJUrVo1xo8fn+3zT3OMfnb7qFKpmDt3rkmvSrqqVU2vIuXk4sWLjBo1ivLlyzNq1CjKli2LtbU1KpWKjz/+2KiHxNnZmdWrVxMUFMSJEycICgpi5syZLFmyhDlz5uSY9/A4Bg4cSNeuxj9is2fPBtJ6mDJzczMzN2celSlThuvXr5sNOF1dXVEUhbi4OAkinjFVnFVcHqLhRBiUsIJ6bnk/iW7gpuLmUA3Hw6C0HdR0yXTF0FZF0NuWnLqj56+7Cs08VGjUEJUELcqpDCfrWp3C65tTDAGEvRUs7mFBeSfTdoxpbU2/hpZcjNDT0EODi53pMiqVill9HRjbwZbbUXq8KllgY2l+n1TpVwEVSE2FB9GPd2O4yjXt+HxJDf69loizqyWl3GXSgfxSWWkot+0Vkv9+gC4yCVtvD1RZu6AA605VUE37A+VBIiRpiV/yJ7av1EBlaxx82gxohJVvTbRnw7CoUxp1GfNBnbp2Geyuf4L++L+oXO1R1zadRhZA5eqA5amP0Z8OTlvPy9P8ck528MfnKH8GQ8gDKGEL3lVR2WXprRrXA15rmxYgADSvDu5mfkvLucL52WnL2VilJVYL8R8lQUQhCw4ONim7eTNtzGW5cgWcy5q0q8iBgYE8ePAgx96IChUqEBkZSbNmzbI9QS+ocuXKcezYMWJjY02GFt24cQN7e3tD8nJOKlSowB9//IG7u7uhlyY76T0ZV69epVIlM3N6P7Jv3z50Oh1z5841Os6JiYlGvRDpNBoNXl5ehlmUrl27xoABA1i+fDlz5swBKNBMLTmtU6VKFapUMe46Tz+OhZmjULduXf744w8iIkzHLN+9exeNRmO2N0kUfxq1ilYF/Bqx1KhoWz7755uVVdMsh0nEtvytY/vljJP3+BQYu0dL0AjzPyOlHdSUdsj9O8izlAZPM/eGSBd8J5X1v2RM+anVwYIN0bRraoONVcG/4yyt1FSrW/D7FYg01nVy7h2PnnAgLYB4JPnwv8SvOIfDSNNpWdUlbbF6IZvhRZmoLDRo2uS+HGQfPJhss4knNMll2TLO8HLznJeBtKi3Re6950I86yQnopBt3ryZuLiMH7y4uDi2bNmCo6PjY83Pn34Fe+7cuSZ5B0qmu2P6+vry4MEDfvrpJ7PbSR8mVBDt27dHr9ezatUqo/KjR49y5coVfHx88hS4pCcdL1iwAJ3ONLkycxs7dOiApaUly5YtMzqu6dL3PX1YmJLlTqErVqwwOV5RUVEm2/H09MTGxoaYmBhDWfqV+ujoaJPls2Nra2u0jaLQuXNnNBoN27dvN8r5uHr1KufPn8fLy8torKoQeXEu3HS40zkzQ6AK243bponV8YkK4fdNvztE8ZP6l+mdmlPPmV7gEEI8e6QnopA5OzszaNAgQ8L0zp07CQ8P59NPP32s4UsdO3akU6dO7N69m5CQEHx8fHB0dOTWrVscO3aMjRs3AvDaa69x4sQJ5syZw6lTp2jWrBn29vaEh4dz6tQprKysWLJkSYHa0KNHD3bt2sUPP/zAnTt3aNKkCSEhIWzevBlXV1ejmZZyUrduXfz9/Vm6dCn9+/enY8eOuLm5cf/+fS5dusTRo0c5fvw4kDY0Z8KECUyfPp1+/frh6+uLh4cHd+/eJTAwkIkTJ1KzZk3at2/P2rVrGTt2LL169cLS0pITJ07wzz//mPSOTJ06lbt37+Lt7Y2HhwfJyckcOHCA+Ph4fH19DcvVr1+fjRs3Mm3aNNq0aYOFhQX16tXLsUepfv36bN++nUWLFlG5cmVUKhU+Pj6PPXQoLCyM3bt3AxjuEXLkyBFDb0P6cYG0gGjgwIGsXLkSf39/XnrpJWJiYtiwYQM2NjYmQ6eEyItWFU0vELSq8OSvQ9WuYoVaZTzJj7OjmnKl5efrWWDVqjxJ268al7XOoUtMCPHMkG/hQjZ69GjOnj3Lpk2bePjwIRUrVmTq1Kl06dLlsbf95Zdf0rhxY7Zv386yZcvQaDSULVvWKCnXwsKC2bNns3nzZvbs2WMIGNzc3Khbty7du3cvcP0WFhbMnz/fcLO5gIAAHB0d6dChAyNGjMhXsra/vz916tRh/fr1rFu3jsTERFxcXKhatSrvvfee0bJ+fn6UL1+e1atXs379elJTU3Fzc6NZs2aG+040atSIGTNm8P3337N48WKsra1p3rw5S5cuZejQoUbb69atGzt37mT37t1ERkZib29PlSpVmD59Oh06dDAs17lzZ65cucL+/fs5dOgQer2ezz//PMcgYsSIEURHR7Np0yZiY2NRFIUdO3Y8dhARGhrK4sWLjcoCAgIICAgw7H/mmSxGjhyJh4cHmzZtYu7cuVhbW+Pl5cWwYcPynW8iBIBvDTWjvDUsOqVDp4cqJVUs7mE6c1Jh8yhlwfA+JVi2JYYULdhaqxg/wAlLC5kq5VngPKsT9/+JRHvxHqjAbkB97AbUL+pmCSEKgUrJOv5DFEj6HasXL15sdLdiIYT4LwmLVQiPU2hYRoX6MWZIyo97kTrGzrhPxMO0IUylS2qY9Z4r7qWe3etgqamprFy5EoDBgwdjafnkA7KioigKqefvona2waKi6YxLQhQl1dcpuS/0iPKRTMKQmeRECCGEyDMPRxWNPdRPLYAAWLcv1hBAQNrN5tbsMc2REsWTSqXCqkEZCSCE+I+RIEIIIUSx9m+Y6U0h/w0zTbgWQgjx9EgQIYQQolhrWMN0NrFGNWWGMSFEYZBbVhfUszugtJjp0aOHYUYmIYQQhafvSw5cD0nl6LkkFAVa1Lemfxe5w7QQQhQlCSKEEEIUa9ZWKiYPd+FBtA69HtxKZn9zOiGEEE+HBBFCCCGeCa5OEjwIIURxIUGEEEIIIYR4PkmqQ4FJYrUQQgghhBAiXySIEEIIIYQQQuSLBBFCCCGEEEKIfJEgQgghhBBCCJEvEkQIIYQQQggh8kVmZxJCCCGEEM8nmZ2pwKQnQgghhBBCCJEvEkQIIYQQQggh8kWCCCGEEEIIIUS+SBAhhBBCCCGEyBcJIoQQQgghhBD5IkGEEEIIIYQQIl9kilchhBBCCPF8kileC0x6IoQQQgghhBD5IkGEEEIIIYQQIl8kiBBCCCGEEELkiwQRQgghhBBCiHyRIEIIIYQQQgiRLxJECCGEEEIIIfJFpngVQgghhBDPJ5XM8VpQ0hMhhBBCCCFEAU2aNAkHB4eibsZTJ0GEEEIIIYQQIl9kOJMQQgghhHg+yWimApOeCCGEEEIIIZ6Q8+fP07lzZ+zt7XFycsLPz49bt24Znn/rrbdo27at4fH9+/dRq9U0a9bMUBYXF4elpSWbNm16qm3PiQQRQgghhBBCPAEhISH4+Pjw4MED1qxZw+LFi/nzzz9p164dsbGxAPj4+HDq1CmSkpIAOHLkCNbW1gQFBRmW+eOPP9Bqtfj4+BTZvmQlw5mEEEVCURTDl6MQz5vU1FQSExMBiImJwdLSsohbJETx5ejoiOoZnUVp1qxZpKamsn//flxcXABo3LgxderUYdWqVYwePRofHx+Sk5M5ceIE7dq148iRI/Tq1Yv9+/dz9OhRunTpwpEjR6hRowZlypQp4j3KIEGEEKJIxMbG4uTkVNTNEKLIjRs3rqibIESxFh0dTYkSJZ7ItpX3nuyp8G+//caLL75oCCAAatWqRcOGDfn9998ZPXo0lStXpnz58hw5csQQRAwbNozExEQCAwMNQURx6oUACSKEEEXE0dGR6Ojoom7GUxMXF4evry+7d+9+LqcCzEyORRo5DhnkWKSR45Ah87FwdHQs6uYUWGRkJI0aNTIpL1OmDA8fPjQ8Tg8eYmJiOHfuHD4+PsTHx7N582aSk5M5efIkQ4cOfYotz50EEUKIIqFSqZ7YlaXiSK1Wo9FoKFGixHN/ciDHIo0chwxyLNLIcciQ+Vg8q0OZAFxcXLh7965JeUREBDVq1DA89vHx4d133+Xw4cOUKlWKWrVqER8fzwcffEBAQADJyclGydfFgSRWCyGEEEII8QS0adOGQ4cOERkZaSi7cuUKf/31F23atDGUpfc8zJw50zBsqVGjRtja2jJt2jQqVKiAp6fn025+jqQnQgghhBBCiMeg0+nYvHmzSfnYsWNZuXIlL730Ep988glJSUl8+umnVKxYkTfffNOwXK1atShdujSBgYHMnTsXAI1GQ+vWrdm7dy+vv/7609qVPJMgQgghngIrKyuGDh2KlZVVUTelyMmxSCPHIYMcizRyHDI8a8ciKSmJV1991aT8xx9/JDAwkPfee4/XX38djUZDp06dmDlzpkmuh4+PD5s3bzZKoG7Xrh179+4tdknVACpFUZSiboQQQgghhBDi2SE5EUIIIYQQQoh8kSBCCCGEEEIIkS8SRAghhBBCCCHyRRKrhRCiiF26dIlBgwZhbW3Nb7/9VtTNefpetuMAAB26SURBVGp0Oh1r1qzh999/58aNGyiKQvXq1Rk2bBiNGzcu6uY9McHBwcyYMYO//voLe3t7unXrxogRI7C0tCzqpj1VBw8eZM+ePVy+fJmYmBgqVqxI3759efnll5/p+wI8roSEBPz8/Lh79y6rV6+mTp06Rd2kp27Xrl2sXbuW4OBgbG1tqVu3LjNmzMDGxqaomyYykSBCCCGKkKIozJgxg5IlS5KQkFDUzXmqkpOTWbVqFd27d2fQoEGo1Wq2bt3KsGHDmD9/Ps2aNSvqJha6mJgYhg0bRsWKFfnmm2+4e/cus2bNIikpiQ8++KCom/dU/fTTT3h4eDBu3DhKlizJiRMn+PLLL4mIiMDf37+om1dkvv/+e3Q6XVE3o8gsX76c1atXM3jwYOrXr09UVBSnTp1Cr9cXddNEFhJECCFEEdqxYwdRUVG8/PLLrF+/vqib81RZW1uzfft2ozuXe3t707dvX9auXfufDCK2bNlCfHw833zzDU5OTkBaj8z06dMZMmQIbm5uRdzCp2fWrFk4OzsbHjdr1ozo6Gh++ukn3n77bdTq52/EdXBwMJs2bWLcuHF8/fXXRd2cpy44OJilS5cyc+ZMWrdubSjv0KFDEbZKZOf5+4QKIUQxERsby/z583n33XexsHj+ruloNBqjACK9rHr16ty7d6+IWvVk/fHHHzRv3twQQAB06tQJvV7P8ePHi7BlT1/mACJdzZo1iY+PJzEx8ek3qBiYMWMGvXv3plKlSkXdlCKxc+dOypUrZxRAiOJLggghhCgiCxcupHbt2rRt27aom1JsaLVazp8/T+XKlYu6KU9EcHAwnp6eRmWOjo6UKlWK4ODgImlTcXL27FlKly6Nvb19UTflqTt48CDXr1/n7bffLuqmFJnz589TtWpVvv/+ezp16kSLFi0YMmQIFy5cKOqmCTMkiBBCiCJw5coVduzYwbvvvlvUTSlWVq9ezb179+jfv39RN+WJiImJMblLLaQFEjExMUXQouLj7Nmz7N+/nwEDBhR1U566pKQkZs2axYgRI3BwcCjq5hSZBw8ecOLECfbs2cMHH3zAt99+i0qlYuTIkTx8+LComyeyeP76z4UQ4gmIi4vj/v37uS5Xrlw5LCwsmD59On5+fiZXpZ91+TkOWWcjOn78OEuWLOHtt9+mdu3aT6qJohiKiIjgo48+wsvLi379+hV1c5665cuX4+rqyssvv1zUTSlSiqKQkJDA9OnTqV69OgD169fn5ZdfZuPGjQwbNqyIWygykyBCCCEKwcGDB5k6dWquy23evJkrV64QHBzMl19+SWxsLAApKSlAWp6ElZUV1tbWT7S9T0p+jkPmAOry5ct88MEHdOnShaFDhz7BFhatEiVKEBcXZ1IeGxtrkh/yvIiNjWXMmDE4OTkxY8aM5y6hOiwsjDVr1vDNN98Y3hvpOSEJCQkkJCRgZ2dXlE18ahwdHXFycjIEEABOTk7UrFmT69evF2HLhDkSRAghRCHo2bMnPXv2zNOyv/zyCzExMfTo0cPkuRdeeIFBgwYxevToQm7h05Gf45AuJCSEMWPG0KBBAz777LMn07BiwtPT0yT3Ib335r/WK5UXSUlJjBs3jri4OFauXPlcDuUJDQ0lNTWVcePGmTw3bNgw6tWrx6pVq556u4pClSpVuH37ttnn0i+0iOJDggghhHjKevToQdOmTY3Kdu3axYEDB5gzZw7u7u5F1LKn7/79+4waNQp3d3emT5/+n5+lqlWrVqxcuZLY2FhDbsTBgwdRq9W0aNGiiFv3dGm1Wj766COCg4NZtmwZpUuXLuomFYmaNWuyePFio7KrV68yc+ZMPvroI+rWrVtELXv62rZty86dO7ly5Qo1a9YEICoqisuXL/9n86SeZf/tb2shhCiGypYtS9myZY3Kzpw5g1qtxsvLq4ha9fQlJSUxZswYoqKimDBhgtFwBUtLS2rVqlWErXsyevfuzYYNG5gwYQJDhgzh7t27zJkzh//973/P1T0iAKZPn85vv/3GuHHjiI+P5/z584bnatasiZWVVRG27ulxdHTM9nNfu3bt/+TnIDvt27enTp06fPDBB4wYMQJra2tWrVqFpaUlfn5+Rd08kYUEEUIIIYrEw4cPuXr1KoDJLFUeHh7s3LmzKJr1RJUoUYJFixbxzTffMGHCBOzt7enZsycjRowo6qY9den3xZg9e7bJczt27DAJtMV/n1qtZu7cuXz33Xd89dVXpKam0rhxY5YtW0apUqWKunkiC5WiKEpRN0IIIYQQQgjx7Hi+pkAQQgghhBBCPDYJIoQQQgghhBD5IkGEEEIIIYQQIl8kiBBCCCGEEELkiwQRQgghhBBCiHyRIEIIIYQQQgiRLxJECCGEEEIIIfJFggghhBBmvfnmm6hUqqJuBgAXLlzAwsKCAwcOGMoOHz6MSqVi1apVRdcwUSysWrUKlUrF4cOHC7S+vJfS/Pnnn4wfP54uXbrg5eXFypUrUavVBAYGPpH6lixZgpeXl9Ff7969n0hdovBJECGEeK7cuHEDf39/atWqhZ2dHSVLlqR27doMGjSIgIAAo2U9PT2pV69etttKP8m+f/++2ecvXbqESqVCpVLx22+/Zbud9GXS/2xsbKhevTrvvvsuDx8+LNiO/se8++67tG7dmk6dOhV1U56K4OBgJk2axNmzZ4u6KeIpiYqKYtKkSQUOhAoq83stMTGR6tWr88EHHwBQuXJlevbsyYQJE3hS9yauUqUK+/btM/wtX778idQjCp9FUTdACCGeltOnT9OuXTssLS0ZOHAgdevWJTExkWvXrrF//34cHR154YUXCq2+5cuX4+joiK2tLStWrKBt27bZLtuoUSMmTJgAwMOHD9mzZw+zZs3iwIEDnDlzBisrq0Jr17Pm2LFjHDhwgG3bthmV+/j4kJiYiKWlZdE07AkKDg5m8uTJeHp60qhRo6JujngKoqKimDx5MgDt27d/avVmfq+9+eabtG7d2uj5cePG0a5dO/bs2UOnTp1YuHAhv/zyC7GxsVStWpXRo0fj5eVV4PotLCwoVarU4+6GKAISRAghnhuTJ08mISGBs2fP0rBhQ5Pnw8PDC62u1NRUfvzxR1599VWcnJxYunQpc+fOxdHR0ezy5cqVY8CAAYbHY8aMoUePHuzatYvt27fz6quvFlrbnjULFy6kVKlSdOvWzahcrVZjY2NTRK0S4vnQtm1bPD09Wbx4MUFBQdy4cYOvvvoKNzc3AgICGDNmDOvXr6dixYoF2v6tW7fo0qUL1tbW1K9fn1GjRuHu7l7IeyGeBBnOJIR4bly7dg1XV1ezAQRQqD9cO3fu5O7duwwaNIg333yT+Ph4NmzYkK9tdO7cGYB//vkn22UWLVqESqVix44dJs/p9XrKly9vdCV7//799O3blypVqmBra4uzszMvvfRSnsc8t2/fHk9PT5Py4OBgVCoVkyZNMipXFIVFixbRtGlT7OzscHBw4IUXXjAZOpYdrVbLtm3b6Nixo0mPg7lx7JnLFi5cSM2aNbGxsaF+/frs2rULgPPnz9OlSxdKlCiBq6srY8aMITU11ex+3rhxg1deeQUnJydKlChBr169uHHjhtGyer2eL7/8Eh8fH9zd3bGysqJixYoMHz6cBw8emN2vLVu20L59e5ydnbGzs6NmzZqMGTOGlJQUVq1aZegRGzx4sGGYW16uTgcHB/PGG29QpkwZrK2tqVq1Kh9//DEJCQlGy02aNAmVSsWVK1f4+OOPKV++PNbW1jRs2JA9e/bkWg9k5CEcOnSIKVOmUKlSJWxtbfH29ub48eMABAYG0qZNG+zt7fHw8OCLL74wu61t27bRunVr7O3tcXBwoHXr1mzfvt3sssuWLaNWrVpYW1tTrVo1Zs+ene1Qm+joaD744AOqVauGtbU1bm5uvPbaayavYX7l9TjnlFekUql48803gbT3beXKlYG0ix3pr3n6Zy3z52vdunU0aNAAGxsbKlasyKRJk9BqtUbbzuvnNC/vNZVKRefOnTl06BA7duxg+vTpNG7cmPLly/PGG2/QqFEjdu7cmc8jmKZevXpMmjSJefPm8eGHH3Lnzh3efvtt4uPjC7Q98XRJT4QQ4rlRtWpVrly5ws8//8z//ve/PK2j0+myzXlITk7Odr3ly5dTuXJl2rZti0qlonHjxqxYsYK33347z+29du0aQI5d/f369WP8+PGsXr2al19+2ei5Q4cOERoaahgmBWknDQ8fPmTgwIGUL1+e0NBQvv/+ezp06EBAQECOQ64K4o033mDdunX4+fkxePBgkpOT+emnn+jUqRM///yzSZuzOnPmDHFxcTRv3jxf9S5YsIDIyEjefvttbGxsmDt3Lr169WLTpk0MHTqU1157jZ49e7J//37mzZtH6dKl+fTTT422ER8fT/v27fH29ubrr7/m2rVrLFy4kOPHjxMUFGQIOlNSUvjmm2/o3bs3r7zyCvb29pw6dYrly5fz+++/mwxH++STT/jqq6+oU6cO48ePx8PDg+vXr7NlyxamTJmCj48PH3/8MV999RX+/v6G16RMmTI57vO///5L8+bNiY6OZsSIEVSvXp3Dhw/z9ddfc/ToUQ4dOoSFhfHP/qBBg7C0tOS9994jJSWF2bNn07NnT65evWr2JNScDz/8EJ1Ox9ixY0lJSeG7777jpZdeYvXq1bz11lv4+/vz+uuvs3HjRiZOnEjlypWNet0WLlzIyJEjqVWrFhMnTgTS3qc9e/ZkyZIl+Pv7G5adPXs248ePp2HDhnz11VckJCTw7bffUrp0aZN2RUdH06pVK27dusWQIUOoW7cuYWFhLFy4EG9vb06fPk2lSpXytI+Pe5xzU7t2bWbNmsX48ePp1auX4fvJwcHBaLkdO3Zw48YNRo4cibu7Ozt27GDy5Mn8+++/rFy5Mt/7ktN77aOPPjIs17JlS9atW4derzf57kxJScHJyQlIC1L8/PxyrHPQoEGMHj0awGjoVPXq1alXrx7du3fnwIED9OzZM9/7I54yRQghnhN//PGHYmlpqQBK9erVlcGDBysLFy5U/v77b7PLV6pUSQFy/bt3757ReqGhoYpGo1E+//xzQ9ns2bMVwGxdgPLSSy8p9+7dU+7du6dcvXpVmTlzpmJpaak4OTkpEREROe6Xn5+fYm1trTx8+NCofMCAAYqFhYXR+nFxcSbrh4eHK66urkrXrl2NygcNGqRk/Zlo166dUqlSJZNt3Lx5UwGM9vnnn39WAGXJkiVGy6ampipNmzZVPD09Fb1en+O+rVixQgGU7du3mzwXEBCgAMrKlStNysqWLatERUUZys+dO6cAikqlUrZs2WK0nSZNmiju7u4m+wkoY8eONSpP36d33nnHUKbX65WEhAST9n3//fcKoGzYsMFQduLECQVQXnjhBSUxMdFoeb1ebzge5vYtN/3791cAZffu3Ubl7733ngIo33//vaHs888/VwDF19fX6DU4efKkAigffvhhrvWtXLlSAZTGjRsrycnJhvLt27crgGJhYaGcOnXKUJ6cnKy4u7srLVq0MJQ9fPhQsbe3V6pWrapER0cbyqOjo5UqVaooDg4OSmRkpKIoihIZGanY2dkptWvXVuLj4w3LhoSEKPb29gqgBAQEGMrHjBmj2NjYKGfPnjVqd3BwsOLo6KgMGjTIUJaf452f42zuM5QOMGqDuc9Q1ufUarVy5swZQ7ler1d69uypAMqxY8cM5fn5nGa3702bNjUcz99++00pWbKk4uXlpdy8eVO5deuW0V/6d2BKSopy8+bNHP+yfk9l9cYbbyjz5s3LcRlRPMhwJiHEc6Nly5acOXOGQYMGER0dzcqVKxkxYgR16tTBx8fH7BAHT09PDhw4YPbvpZdeMlvPqlWr0Ov1DBw40FD2+uuvY2lpyYoVK8yus3//ftzc3HBzc6NGjRq8++671KlTh/3795u9yprZoEGDSE5ONhouFRcXx9atW+nSpYvR+vb29kbLPHjwAI1Gg7e3NydOnMixnvxas2YNjo6O9OzZk/v37xv+oqKi6NGjB8HBwYbeluzcu3cPABcXl3zV/eabbxqujgI0aNCAEiVKULZsWZMrqW3atCE8PJy4uDiT7Xz44YdGj3v16kXNmjWNkrxVKhW2trZAWs9VVFQU9+/f58UXXwQwOq4//fQTAF9//bVJPkf6UJKC0Ov17Nixg8aNG5vkjnz00Ueo1Wq2bt1qst7YsWON6mzWrBkODg65vi6ZDR8+3KinJf1qtre3t1HCrZWVFc2bNzfa9oEDB4iPj2fMmDGUKFHCUF6iRAnGjBlDXFwcBw8eBNI+IwkJCYwcORI7OzvDsuXLl+f11183apOiKPz000/4+PhQrlw5o/efvb09LVq0YP/+/Xnex3QFPc6FpVOnTjRp0sTwWKVS8f777wM80XpdXV1JSEhAURQiIyOpUKGC0V96b6mlpSWenp45/pUsWTLbehISErh9+7YkWj8jZDiTEOK5Ur9+fcMY+n///ZfAwEC+//57fvvtN1555RWToSf29vZ07NjR7LbWrFljUqYoCitWrKBBgwbo9XqjfIbWrVvz448/8vXXX5sMd/D29mbq1KkAWFtbU6lSpTwnKqYHCqtXr2bYsGFA2pj7+Ph4o0AG4Pr163zyySf88ssvREVFGT1X2PeEuHTpErGxsTkOw4mIiKBGjRrZPp/eJiWf00tWqVLFpKxkyZJUqFDBbDnAgwcPjIaPODs7m82TqV27Ntu2bSM+Pt4QlG3cuJHvvvuOoKAgk/yKyMhIw/+vXbuGSqXKNi+noO7du0dcXBx169Y1ec7FxQUPDw+zQbK54+Tq6pptLoc5WbeRfjzTx/hnfS7ztm/evAlgtt3pZentTv+3Vq1aJsvWqVPH6PG9e/d48OCBITg3R63O/3XUgh7nwlK7dm2TsvR9L4x6ExISCAkJMTwODQ3lypUr3Lt3j+TkZNzd3fn8888ZN24cNWvWJDIyklOnTlG9enXatGmT7/pmz55N27Zt8fDw4N69eyxZsgS1Wm3IBxPFmwQRQojnVqVKlRg4cCBvvPEGbdu25ejRo5w8ebJAP4bpAgMDuX79OpA2xtecXbt2mYz3LVWqVLbBSm4sLCzo378/s2fP5p9//qFatWqsXr2akiVLGuUcxMXF4ePjQ3x8POPGjaN+/fo4OjqiVqv5+uuv+fXXX3OtK7tAI2tiJ6Sd+Lu5ubF27dpst5fTfTgAwwlgfu+XodFo8lUO+Q9U0v3888/07duX5s2bM2fOHCpUqICNjQ06nY4uXbqg1+uNln+cHofClt3xyM+xKMixftLS29+xY0fDPQ+KQn4+L8Wh3r///ttwIQJg1qxZQFoPFUC7du0oUaIEs2fP5u7duzg7O1O/fv0C51JFRETwySefEB0dTcmSJWnYsCGrVq3KsbdCFB8SRAghnnsqlQpvb2+OHj1KaGjoY21rxYoVWFtbs3r1arNXOt955x2WL19e6EmDgwYNYvbs2axevZqhQ4dy+PBh/P39sba2Nixz6NAh7ty5w4oVKxg8eLDR+lmTirPj4uLCmTNnTMrNXQWtXr06V69epUWLFiYJonmVHmTkZ3hNYYmKiiI8PNykN+LSpUuULl3a0Avx448/YmNjQ0BAgNEwm8uXL5tss0aNGuzdu5dz587lmCye3yDDzc0NR0dHLl68aPJcZGQkYWFhxfJ+E+m9GBcvXqRDhw5Gz/39999Gy6T/e/ny5WyXTefm5oazszMxMTEFDs7Nye9xTh+G9/DhQ6MheeY+L3l5zS9dumRSlvU4pdeb189p5nq9vLw4ffq0yTKrVq1i8eLFNGjQgM6dO/POO+/k2ta8+PrrrwtlO6JoSE6EEOK5ceDAAbNX4hITEw3jo7MOi8iP6OhoNm/ezEsvvUSfPn3w8/Mz+Xv55ZfZu3cvYWFhBa7HnEaNGtGgQQPWrFnDjz/+iF6vZ9CgQUbLpF8ZznqVef/+/XnOh6hRowaxsbGcPHnSUKbX6w1XLDMbOHAger3eaJaXzCIiInKtr3HjxpQoUcIwZejTNm3aNKPHW7du5cqVK0ZBoEajQaVSGfU4KIpiGJ6WWf/+/QH4+OOPSUlJMXk+/bVJD7ry2gOjVqvp0aMHQUFB7Nu3z2Qf9Ho9vXr1ytO2nqZOnTphb2/PvHnziI2NNZTHxsYyb948HBwcDHcp79SpE7a2tixYsMBoKtXbt2+b9Hap1Wpef/11Tp48yebNm83Wfffu3Xy3N7/HOX2oXnpeR7rvvvvOZNt5ec0PHDjAn3/+aXisKAozZswAMHpP5udzmpd6jx8/joWFhcmN6MTzTXoihBDPjfHjx/PgwQNefvll6tevj52dHSEhIaxdu5arV68ycOBA6tevX+Dtr1u3jsTERHr37p3tMr1792bVqlX88MMPJkm7j2vQoEFMmDCB6dOnU6NGDVq0aGH0fJs2bXB3d2fChAkEBwdTvnx5zp49y48//kj9+vU5f/58rnX4+/vz3Xff0atXL8aOHYuVlRWbN282G5ylT+s6f/58/vzzT7p3706pUqW4ffs2x44d459//sl1HLdGo+F///sf27ZtIzk52ahn5UkrVaoUP//8M3fu3KF9+/aGKV7LlCljdD8MPz8/tmzZwosvvsjAgQNJTU1l27ZtJvcMAGjevDkffPAB06dPp0mTJvTt2xd3d3du3rzJ5s2bOXnyJM7OztSpUwdHR0cWLlyInZ0dzs7OlC5d2pCsbc5XX31lmBpzxIgRVKtWjSNHjrBhwwZ8fHxMgsriwNnZmRkzZjBy5Ei8vb0N901YtWoV//zzD0uWLDEkyJcsWZIvvviC9957j1atWjFw4EASEhJYvHgx1atXJygoyGjbX375JUePHqVPnz706dOHFi1aYGVlxb///suePXto2rSp0T1G8io/x/m1117j448/xt/fn8uXL+Pi4sK+ffvMThvt6upKtWrVWL9+PVWrVqVMmTLY29vTo0cPwzINGzbkxRdfZOTIkXh4eLB9+3YOHjzIG2+8QcuWLQ3L5edzmtt7TVEU9u3bR5cuXQrcoyj+o4pkTighhCgCv/zyizJixAilQYMGiqurq6LRaBQXFxelffv2yvLlyxWdTme0fKVKlZS6detmu7306RvTpzf08vJSLCwscpzCMCkpSXF0dFRq1KhhKOPRVJuPKzw8XLGwsFAAZerUqWaXOXfunNK5c2fF2dlZcXBwUNq1a6ccOXLE7FSU2U1PuXv3bqVhw4aKlZWV4uHhobz//vvK5cuXs52ecvXq1UqbNm0UR0dHxdraWqlUqZLSq1cvZf369Xnar/RpUTdv3mxUntMUr+am6qxUqZLSrl07k/L06U5v3rxpKEufIvP69evKyy+/rDg6OioODg7Kyy+/rFy7ds1kG0uXLlVq166tWFtbK+7u7srQoUOVBw8emEzjmW7t2rVKq1atFAcHB8XOzk6pWbOmMnbsWKOpUnfv3q00btxYsba2VgCzbc/qxo0byoABAxQ3NzfF0tJSqVy5svLRRx8ZTYma3T7ndpyySp/iNfO0qumy2+/s3lM///yz0rJlS8XOzk6xs7NTWrZsqWzdutVsvYsXL1Zq1KihWFlZKVWrVlVmzZplmAo4a1vi4+OVKVOmKPXq1VNsbGwUBwcHpVatWsrbb7+tHD9+3LBcfqfUzetxVhRFOX78uNKqVSvF2tpacXV1VYYOHapERkaaPUYnTpxQWrVqpdjZ2SmAYZrWzFOzrl27Vqlfv75iZWWllC9fXvnss8+UlJQUk3rz8znN6b12+PBhBVB27dqVp2Mjnh8qRSlgJpkQQgjxlHTp0oX4+Hh+++23p1Jf+/btCQ4OJjg4+KnUJ0ROgoODqVy5Mp9//rnJXeGftF69ehESEsKpU6eKzYQAoniQnAghhBDF3nfffcexY8cKNLe/EKJggoKC2L59O999950EEMKE5EQIIYQo9urWrfvEp8UUQhhr3LixyRTFQqSTngghhBBCCCFEvkhOhBBCCCGEECJfpCdCCCGEEEIIkS8SRAghhBBCCCHyRYIIIYQQQgghRL5IECGEEEIIIYTIFwkihBBCCCGEEPkiQYQQQgghhBAiXySIEEIIIYQQQuSLBBFCCCGEEEKIfJEgQgghhBBCCJEv/w/KtPKSlBAEHgAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x950 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "No data for colormapping provided via 'c'. Parameters 'vmin', 'vmax' will be ignored\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxEAAAO8CAYAAAA25TlWAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOzdeVxU9f748dewiGyCEipu4G5uqbh0TVHD8iZhkqjkVQsNRKWyXFq+XkGzm1p51cA193LDDcEltQDTcrtaLim4IQoIIkKgoAxzfn/4Y3KcARl29f18PObxcD7nM+e8z5kjc97nsxyVoigKQgghhBBCCFFMJpUdgBBCCCGEEOLJIkmEEEIIIYQQwiiSRAghhBBCCCGMIkmEEEIIIYQQwiiSRAghhBBCCCGMIkmEEEIIIYQQwiiSRAghhBBCCCGMIkmEEEIIIYQQwiiSRAghhBBCCCGMIkmEEEKIQr3zzju4uLhUyLZSUlLw9vbGwcEBlUrFvHnzKmS74vFWrVqFSqUiPj6+skMpNZVKRXBwcGWHUSUdO3aM7t27Y21tjUql4vfffyc4OBiVSlXZoYkqSJIIIUSVd/r0aby9vXF2dqZ69erUr1+fV155hW+//bayQ3ti9e7dG5VKpX3VqlWLLl26sGLFCjQaTZls4z//+Q/bt28vdv0PP/yQH3/8kU8//ZS1a9fyz3/+s0ziKMqdO3f4/PPPad++PVZWVtjZ2dGzZ0/WrFmDoiglXu+uXbsq7EL17t27BAcHEx0dXaz60dHROt+9hYUFderUoXfv3vznP//h5s2b5RvwMyo5OZlPPvmEPn36YGtri0qlKvZ3VhHy8vIYPHgw6enp/Pe//2Xt2rU4OztXdliiCjOr7ACEEKIov/76K3369KFRo0b4+flRt25drl27xuHDh5k/fz7vvfdeZYf4xGrQoAFffvklADdv3mTNmjWMHj2auLg4Zs2aVer1/+c//8Hb25uBAwcWq/7PP//MG2+8waRJk0q97eJISUnB3d2dc+fO4ePjQ2BgILm5uWzZsoW3336bXbt28cMPP2Bqamr0unft2kVoaGiFJBJ3795l+vTpwIPksLjef/99unTpQn5+Pjdv3uTXX38lKCiIuXPnsmnTJl5++WVt3REjRuDj44OFhUVZh1/hcnJyMDOr+Muf2NhYZs+eTfPmzWnXrh2//fZbhcdQlEuXLnH16lWWLVvGu+++W9nhiCeAJBFCiCrtiy++wM7OjmPHjmFvb6+zLDU1tXKCqkSKopCbm4ulpWWp12VnZ8fw4cO178eMGUPLli0JCQnh888/x9zcvNTbMEZqaqred1waubm5VKtWDRMTw43ub7/9NufOnWPbtm0MGDBAW/7+++8zefJkvv76azp27MjHH39cZjFVJT179sTb21un7I8//uDVV19l0KBB/Pnnnzg5OQFgampaomSqKqpevXqlbNfV1ZVbt25Rq1YtNm/ezODBgysljsIU/D0ty/+D4ukm3ZmEEFXapUuXaNOmjcEfttq1a2v/HR8fj0qlYtWqVXr1Hu0DXdDHNy4ujuHDh2NnZ4ejoyP//ve/URSFa9eu8cYbb1CjRg3q1q3LN998o7O+gu4gmzZtYvr06dSvXx9bW1u8vb3JzMzk3r17TJgwgdq1a2NjY4Ovry/37t3TWcfKlSt5+eWXqV27NhYWFrRu3ZpFixbpxe7i4sLrr7/Ojz/+SOfOnbG0tGTJkiX06tWLF154weAxa9myJf369SviqBpmZWXFiy++yJ07d4rs0nLnzh0mTpxIw4YNsbCwoGXLlnz99dc63X9UKhV37txh9erV2m4z77zzjsH1FfS3VxSF0NBQbf0Cly9fZvDgwdSqVUsb486dO3XWUfCdbNiwgalTp1K/fn2srKz466+/DG7z8OHD/Pjjj7zzzjs6CUSBL7/8kubNmzN79mxycnJ0tvFoF5RHz7133nmH0NBQ7XF4eH8K6n799df897//xdnZGUtLS3r16sWZM2d01tu7d2+DLQsPj1OJj4/H0dERgOnTp2u3VdIWkBdeeIF58+aRkZFBSEiIttzQmIiCczM6Olp7brZr1057fLZu3Uq7du2oXr06rq6unDx5Um9758+fx9vbm1q1alG9enU6d+7Mjh07dOoUbPvQoUN89NFHODo6Ym1tjZeXl955evz4cfr168dzzz2HpaUljRs3ZtSoUTp1DB2fkydP8tprr1GjRg1sbGxwd3fn8OHDJY7DEFtbW2rVqvXYesYoiOnAgQOMGTMGBwcHatSowciRI7l9+3ax1/POO+/Qq1cvAAYPHoxKpXpsq9b333+Pq6srlpaW1KpVCx8fH65du6ZdvnLlSlQqFStWrND53H/+8x9UKhW7du0q/o6KKklaIoQQVZqzszO//fYbZ86coW3btmW67qFDh/L8888za9Ysdu7cycyZM6lVqxZLlizh5ZdfZvbs2fzwww9MmjSJLl264ObmpvP5L7/8EktLSz755BMuXrzIt99+i7m5OSYmJty+fZvg4GAOHz7MqlWraNy4MdOmTdN+dtGiRbRp04YBAwZgZmZGREQE48aNQ6PRMH78eJ3txMbG8tZbbzFmzBj8/Pxo2bIlNjY2+Pn56R2XY8eOERcXx9SpU0t0TC5fvoypqWmhdyMVRWHAgAFERUUxevRoOnTowI8//sjkyZNJTEzkv//9LwBr167l3XffpWvXrvj7+wPQtGlTg+t0c3Nj7dq1jBgxgldeeYWRI0dql6WkpNC9e3fu3r3L+++/j4ODA6tXr2bAgAFs3rwZLy8vnXV9/vnnVKtWjUmTJnHv3j2qVatmcJsREREAOtt6mJmZGcOGDWP69OkcOnSIvn37Fn7QHjFmzBiSkpLYt28fa9euNVhnzZo1ZGVlMX78eHJzc5k/fz4vv/wyp0+fpk6dOsXelqOjI4sWLWLs2LF4eXnx5ptvAtC+fftir+NR3t7ejB49mr179/LFF18UWffixYsMGzaMMWPGMHz4cL7++ms8PT1ZvHgxn332GePGjQMe/F8ZMmQIsbGx2pahs2fP8tJLL1G/fn0++eQTrK2t2bRpEwMHDmTLli163+17771HzZo1CQoKIj4+nnnz5hEYGMjGjRuBB3fSX331VRwdHfnkk0+wt7cnPj6erVu3FrkPZ8+epWfPntSoUYMpU6Zgbm7OkiVL6N27NzExMXTr1s2oOCpDYGAg9vb2BAcHExsby6JFi7h69ao28X2cMWPGUL9+ff7zn/9ou7kVdR5+8cUX/Pvf/2bIkCG8++673Lx5k2+//RY3NzdOnjyJvb09vr6+bN26lY8++ohXXnmFhg0bcvr0aaZPn87o0aPp379/WR4CURkUIYSowvbu3auYmpoqpqamyj/+8Q9lypQpyo8//qjcv39fp96VK1cUQFm5cqXeOgAlKChI+z4oKEgBFH9/f22ZWq1WGjRooKhUKmXWrFna8tu3byuWlpbK22+/rS2LiopSAKVt27Y6cbz11luKSqVSXnvtNZ3t/+Mf/1CcnZ11yu7evasXZ79+/ZQmTZrolDk7OyuAsmfPHp3yjIwMpXr16srHH3+sU/7+++8r1tbWSnZ2tt76H9arVy+lVatWys2bN5WbN28q586dU95//30FUDw9PbX13n77bZ3Yt2/frgDKzJkzddbn7e2tqFQq5eLFi9oya2trneP2OIAyfvx4nbIJEyYogPLLL79oy7KyspTGjRsrLi4uSn5+vqIof38nTZo0MXhsHzVw4EAFUG7fvl1ona1btyqAsmDBAp1tREVF6dQzdO6NHz9eMfQTW1DX0tJSuX79urb8yJEjCqB8+OGH2rJevXopvXr10lvHo9/JzZs39c7xohTsR1hYWKF1XnjhBaVmzZra9ytXrlQA5cqVK9qygnPz119/1Zb9+OOP2v27evWqtnzJkiV6x87d3V1p166dkpubqy3TaDRK9+7dlebNm+ttu2/fvopGo9GWf/jhh4qpqamSkZGhKIqibNu2TQGUY8eOFbn/jx6rgQMHKtWqVVMuXbqkLUtKSlJsbW0VNzc3o+MojrCwMIPnkrEKYnJ1ddX5WzRnzhwFUMLDw4u9rsLOi4K/lwXi4+MVU1NT5YsvvtCpd/r0acXMzEynPDk5WalVq5byyiuvKPfu3VM6duyoNGrUSMnMzDR2V0UVJN2ZhBBV2iuvvMJvv/3GgAED+OOPP5gzZw79+vWjfv36et0ejPXw4EFTU1M6d+6MoiiMHj1aW25vb0/Lli25fPmy3udHjhypM26gW7duKIqi132iW7duXLt2DbVarS17eExDZmYmaWlp9OrVi8uXL5OZmanz+caNG+t1T7Kzs+ONN95g/fr12m5E+fn5bNy4kYEDB2Jtbf3Y/T9//jyOjo44Ojry/PPP8+233+Lh4aHX/eBhu3btwtTUlPfff1+nfOLEiSiKwu7dux+7XWPs2rWLrl270qNHD22ZjY0N/v7+xMfH8+eff+rUf/vtt4s1XiQrKwt40MWkMAXLCusSVRoDBw6kfv362vddu3alW7duVaaLh42NjfYYFaV169b84x//0L4vuGv/8ssv06hRI73ygv9H6enp/PzzzwwZMoSsrCzS0tJIS0vj1q1b9OvXjwsXLpCYmKizLX9/f5276j179iQ/P5+rV68Cf/flj4yMJC8vr1j7mZ+fz969exk4cCBNmjTRljs5OTFs2DAOHjyo9/0/Lo7K4O/vr/O3aOzYsZiZmZXL+bR161Y0Gg1DhgzRfm9paWnUrVuX5s2bExUVpa1bt25dQkND2bdvHz179uT3339nxYoV1KhRo8zjEhVPkgghRJXXpUsXtm7dyu3btzl69CiffvopWVlZeHt7611EGuPhixx4cGFevXp1nnvuOb1yQ/2LDX0eoGHDhnrlGo1GJzko6CJjbW2Nvb09jo6OfPbZZwAGkwhDRo4cSUJCAr/88gsA+/fvJyUlhREjRhS6zw9zcXFh37597N+/n4MHD3Ljxg0iIyP19v9hV69epV69enoX388//7x2eVm6evUqLVu21CsvbHuFHatHFcRf1IVycRKNkmrevLleWYsWLarMcxiys7OLtd/G/B8AtP+PLl68iKIo/Pvf/9YmsgWvoKAgQH/ihEe3VbNmTZ119urVi0GDBjF9+nSee+453njjDVauXKk3HulhN2/e5O7du4WeYxqNRqeff3HiqAyPnk82NjY4OTmVy/l04cIFFEWhefPmet/duXPn9L43Hx8fPDw8OHr0KH5+fri7u5d5TKJyyJgIIcQTo1q1anTp0oUuXbrQokULfH19CQsLIygoqNB+v/n5+YWuz9BsM4XNQKMYeGZAYXUft45Lly7h7u5Oq1atmDt3Lg0bNqRatWrs2rWL//73v3rPaSjsznq/fv2oU6cO33//PW5ubnz//ffUrVu32P33ra2tjerr/yQo7qxVzz//PNu3b+fUqVN6Y10KnDp1Cnhwtx0o0TlWGgWDzStqewXy8vKIi4sr1hikkv4fKDjHJ02aVOgkAM2aNTNqnSqVis2bN3P48GEiIiL48ccfGTVqFN988w2HDx/GxsbmsftTHMb8jXgaaTQaVCoVu3fvNngsHj3Ot27d4vjx4wD8+eefaDSaQmdME08WSSKEEE+kzp07Aw8e4AR/3w3MyMjQqVeZXQwKExERwb1799ixY4fOXc2HuwEUh6mpKcOGDWPVqlXMnj2b7du34+fnV65TcTo7O7N//36ysrJ07lSfP39eu7xAWTzl1tnZmdjYWL1yQ9szxuuvv86XX37JmjVrDCYR+fn5rFu3jpo1a/LSSy8Bxp1jj9v3Cxcu6JXFxcXpPB28Zs2aBrvRPbq9sn6a8ObNm8nJySnRDF/FVdB1yNzcvMwT2RdffJEXX3yRL774gnXr1vGvf/2LDRs2GHz2gaOjI1ZWVoWeYyYmJnqtKlXRhQsX6NOnj/Z9dnY2ycnJ5TJ4uWnTpiiKQuPGjWnRosVj648fP56srCy+/PJLPv30U+bNm8dHH31U5nGJiiepoBCiSouKijJ4h6+gr29BN4QaNWrw3HPPceDAAZ16CxcuLP8gjVRwkf/wfmVmZrJy5Uqj1zVixAhu377NmDFjyM7O1nnuQ3no378/+fn5OtN/Avz3v/9FpVLx2muvacusra31LrhLsr2jR4/qPJjrzp07LF26FBcXF20rgbG6d+9O3759WblyJZGRkXrL/+///o+4uDimTJmibd1wdnbG1NS0WOdYwZiUwvZ/+/btOn3+jx49ypEjR3SOX9OmTTl//rzO9KF//PEHhw4d0lmXlZVVkdsyxh9//MGECROoWbOm3ixhZal27dr07t2bJUuWaG8EPKwkT82+ffu23t+KDh06ABTapcnU1JRXX32V8PBwna4/KSkprFu3jh49ejwR/feXLl2qMw5k0aJFqNVqnfOprLz55puYmpoyffp0veOtKAq3bt3Svt+8eTMbN25k1qxZfPLJJ/j4+DB16lTi4uLKPC5R8aQlQghRpb333nvcvXsXLy8vWrVqxf379/n111/ZuHEjLi4u+Pr6auu+++67zJo1i3fffZfOnTtz4MCBKvlj9eqrr1KtWjU8PT21F//Lli2jdu3aBi+oitKxY0fatm1LWFgYzz//PJ06dSqnqB/w9PSkT58+/N///R/x8fG88MIL7N27l/DwcCZMmKAzjaurqyv79+9n7ty51KtXj8aNG+tNl/k4n3zyCevXr+e1117j/fffp1atWqxevZorV66wZcuWUnWLWLNmDe7u7rzxxhsMGzaMnj17cu/ePbZu3Up0dDRDhw5l8uTJ2vp2dnYMHjyYb7/9FpVKRdOmTYmMjDT40ENXV1fgwYPr+vXrh6mpKT4+PtrlzZo1o0ePHowdO5Z79+4xb948HBwcmDJlirbOqFGjmDt3Lv369WP06NGkpqayePFi2rRpozPY19LSktatW7Nx40ZatGhBrVq1aNu27WO7I/3yyy/k5uaSn5/PrVu3OHToEDt27MDOzo5t27ZRt27dEh/b4ggNDaVHjx60a9cOPz8/mjRpQkpKCr/99hvXr1/njz/+MGp9q1evZuHChXh5edG0aVOysrJYtmwZNWrUKPKO/MyZM9m3bx89evRg3LhxmJmZsWTJEu7du8ecOXNKu5t624IH08rCg6mQDx48CKAzLXNwcDDTp08nKiqqWE8hv3//Pu7u7tppdBcuXEiPHj0MPgOltJo2bcrMmTP59NNPiY+PZ+DAgdja2nLlyhW2bduGv78/kyZNIjU1lbFjx9KnTx8CAwMBCAkJISoqinfeeYeDBw9Kt6YnXUVPByWEEMbYvXu3MmrUKKVVq1aKjY2NUq1aNaVZs2bKe++9p6SkpOjUvXv3rjJ69GjFzs5OsbW1VYYMGaKkpqYWOsXrzZs3dT7/9ttvK9bW1nox9OrVS2nTpo32fWFTIRZMt/joFJOGtrdjxw6lffv2SvXq1RUXFxdl9uzZyooVKwxOo+nh4VHkMSqYzvE///lPkfWK2qfCPDqdqKI8mGL1ww8/VOrVq6eYm5srzZs3V7766iudaS8VRVHOnz+vuLm5KZaWlgrw2OleMTDFq6IoyqVLlxRvb2/F3t5eqV69utK1a1clMjJSp05xpi01JCsrSwkODlbatGmjWFpaKra2tspLL72krFq1Sm9/FOXBdKqDBg1SrKyslJo1aypjxoxRzpw5ozfFq1qtVt577z3F0dFRUalU2ikyC6Z4/eqrr5RvvvlGadiwoWJhYaH07NlT+eOPP/S29/333ytNmjRRqlWrpnTo0EH58ccfDX4nv/76q+Lq6qpUq1btsdO9Fhyrgpe5ubni6OiouLm5KV988YWSmpqq95nCpng1dG4a+h4f3u+HXbp0SRk5cqRSt25dxdzcXKlfv77y+uuvK5s3b9bb9qP/rx6dcvfEiRPKW2+9pTRq1EixsLBQateurbz++uvK8ePH9eJ79PicOHFC6devn2JjY6NYWVkpffr00Zm61pg4ivLwcX/09bCJEycqKpVKOXfuXJHrK4gpJiZG8ff3V2rWrKnY2Ngo//rXv5Rbt249Nh5D+/G4KV4LbNmyRenRo4dibW2tWFtbK61atVLGjx+vxMbGKoqiKG+++aZia2urxMfH63wuPDxcAZTZs2cbFZ+oelSK8oyMBBJCiKfU/Pnz+fDDD4mPj9ebOUZULfHx8TRu3JivvvqKSZMmVXY4oorq2rUrzs7OhIWFFVlv1apV+Pr6cuzYMe04MSEqinRnEkKIJ5iiKCxfvpxevXpJAiHEU+Cvv/7ijz/+YPXq1ZUdihBFks5oQgjxBLpz5w7r169nzJgxnD59mg8//LCyQxJClIEaNWpw79497bNQSis7O5sbN24U+SrvaYOfdsHBwYVOIfzwsvj4eO1UxMYo6efKm7RECCHEE+jmzZsMGzYMe3t7Pvvss3IZQCmEePJ9/fXXTJ8+vcg6V65c0ZleWJQPJycnfvvtt2JNjfskkCRCCCGeQC4uLs/Mw62eJvK9ibL0zjvv8M477xRZZ+TIkfTo0aPIOuU9E5d4wMLCghdffLGywygzkkQIIYQQQjylmjRpon24n6hcBRMrhIWF4e3tDTyYnnfSpEl8//33aDQahg4dSq9evfjXv/6l10KUm5tLYGAgP/zwA9WrV+df//oXs2bNwsysci7nZUyEEEIIIYQQpaRWq/VeGo2myM988sknLFmyhI8//piNGzei0Wj45JNPDNb9v//7P0xMTNi0aRMBAQF88803fPfdd+WxK8UiLRFCCCGEEEKUwp07dzA3Nze4rOAJ9o9KT09n0aJFTJ06lY8//hiAfv360bdvX65du6ZXv1u3bixYsACAV155haioKDZv3kxAQEAZ7YVxJIkQQgghKkleXh4rV64EwNfXt9CLECFEOVG9Wfy6ytZCF1laWnLgwAG98qVLl7Ju3TqDnzl9+jS5ubl6E2O88cYb/PTTT3r1X331VZ33rVu35ueffy5O5OVCkgghhBBCCCFKwcTExOAD/yIjIwv9THJyMgCOjo465bVr1zZY397eXud9tWrVyM3NNTLSsiNjIoQQQgghhKhgTk5OwIMpux+WmppaGeEYTZIIIYQQQgjxjFIZ8Spbbdu2pXr16oSHh+uUb9++vcy3VR6kO5MQQgghhBAVzMHBgbFjx/LFF19QvXp1OnToQFhYGHFxccCDLlJVWdWOTgghhBBCiKfUrFmz8Pf358svv2Tw4MHk5eVpp3i1s7Or5OiKplLk0ZlCCCFEpZDZmYSoZKpBxa+rbCm/OB4yYsQIDh48yJUrVypkeyUl3ZmEEEIIIcQzquzHOhgjJiaGQ4cO4erqikajITIykh9++IG5c+dWalzFIUmEEEIIIYQQlcDGxobIyEhmz55NTk4OjRs3Zu7cuUyYMKGyQ3ssSSKEEEIIIYSoBK6urvz666+VHUaJSBIhhBBCCCGeUZXbnelJJrMzCSGEEEIIIYwiSYQQQgghhBDCKJJECCGEEEIIIYwiYyKEEEIIIcQzSsZElJS0RAghhBBCCCGMIkmEEEIIIYQQwiiSRAghhBBCCCGMIkmEEEIIIYQQwiiSRAghhBBCCCGMIrMzCSGEEEKIZ5TMzlRS0hIhhBBCCCGEMIokEUIIIYQQQgijSBIhhBBCCCGEMIqMiRBCCCGEqGo0GtAoYGZa2ZE85WRMRElJS4QQQgghRFUyays89w5Y+sCw/0JWTmVHJIQeaYkQQgghhKgqth2GT7//+/36X8DeChaOqbyYhDBAWiKEEKISXc1U2Byr4VKGUtmhCCGqgs9+0C/bcazi43hmqIx4iYdJS4QQQlSS+f/T8FG0Bo3y4OdpxksmTP2H3NsR4pmVeQdik/TLrSwqPhYhHkN+rYQQohKk3VWYHPMggQBQgGmHNCRkaio1LiFEJbqSCoqBVsmX21V8LEI8hiQRQghRCWJvQ94j+YICfHNcujUJ8cxKSjdcnpFdsXE8U6Q7U0lJEiGEEJWgvaPh8jO3JIkQ4pnVpZnha9UTVyo8FCEeR5IIIYSoBAl/GS43lZtdQjy7/rr7oEnyUdVkCKuoeiSJEEKISpB5z3B5ViHlQohnQPBGw+X9OlRoGEIUhyQRQghRCbo5QXUDD6I9X0iXaCHEM2D3ScPln7xZsXE8U2RMRElV6SQiODiYzp07F6tuUlISnTt3ZsmSJeUc1QPGxObv74+np2c5R1Q0Y49PbGwsY8eOpU+fPhV6XIV4VpiaqGhrYFxE5v2Kj0UIUQUoCty+o19uooK/5InVouqRTnZCj1qtZsqUKajVagICArC1taV58+aVHVaFi46OJjY2ljFjiv+U0HXr1mFra1vmSeOZM2fYvXs3586d48KFC+Tk5BAUFFTkdlJSUvjuu+/49ddfSU9Pp0aNGrRs2ZIJEybQpEmTMo1PlEx3Jzh+Q7dMAX5PVehQW+56CfFMUangOVtIzdQt1ygQsgv+O6py4hKiEFW6JWLq1KkcOnSossN45iQmJpKYmMhbb73F0KFD6d+//zObRCxbtsyoz6xfv56IiIgyj+XQoUOEhYWRnZ1drO/i/PnzDBs2jMOHDzNgwAA++eQThg8fjrW1Nbdv3y7z+ITx7uYpRF83vCwtR2ZoEuKZNG2I4fL9pyo2jmeKdGcqqVK3ROTn55OXl0f16tXLIh4dZmZmmJlJY0lFu3XrFgB2dnZlul5FUcjJycHKyqpM1/sk8/f3B2Dp0qVF1vP29mbkyJFYWlqyf/9+Tp0q/Afl3r17fPrpp9SpU4elS5diY2NTpjGL0tMoCp7b8jl10/DynvXlx0qIZ1JhA6jPJMCaKBjZp0LDEaIoRl2hR0REMH36dEJDQzl9+jQRERHcuHGDqVOn4unpiaIobNmyhe3bt3PlyhVMTExo3bo1fn5+euMHIiMj2bRpEwkJCajVahwcHGjXrh0TJ06kZs2awINxB5GRkRw/flzns7///jsLFiwgNjYWa2tr3N3dGTRoUKHxLl68WG/7/v7+JCcn69w1Pnz4MOHh4fz555+kpaVhbm5OmzZtGDVqFK6ursYcqmI5ceIE3333HWfPnkWtVuPi4sLgwYMZOHCgTr0zZ86wefNmTp06RUpKCqampjRr1owRI0bQp4/+H5TiHh9D/P39OXHiBADTp09n+vTpAOzYsYN69eqRk5PD8uXL2bdvH6mpqdSoUYNu3boxduxYnJyctOs5fvw4AQEBBAUFkZOTQ1hYGNevX+edd97Rdg/au3cvGzdu5MKFC+Tn52v3qW/fvnpxHT9+nLVr13LmzBlycnJwdHTE1dWV999/H3t7ewDCwsKIjo7m8uXL3L59Gzs7O7p27crYsWOpV6+ezvoOHjzImjVruHTpErm5udjb29O6dWsCAwNxdnbWOQ4PnztFdSEqqJecnKzzmYJjVxoODg7Frrtv3z6uXbvG3LlzsbGx4f79B53sq1WrVqoYRNl590cNPycYXtbUHizMJIkQ4pm07kDhy0aHQptG4Nq04uIRogglus0/f/581Go1Xl5eWFtb4+zsDMC0adP48ccfcXd3x9PTk7y8PHbv3s348eOZM2cOvXr1AmDnzp0EBwfTsWNHAgICsLCwICUlhUOHDpGenq5NIgw5c+YM48aNw8rKipEjR2Jra8vevXsJCgoqya7oiIiIIDMzk/79+1OnTh1SU1MJDw9n3LhxLF68mI4dO5Z6GwUOHDjA5MmTcXBwYPjw4VhZWbF3715mzpxJYmIi48eP19aNjo4mPj6evn374uTkRGZmJpGRkUyePJmZM2fyz3/+U1u3tMdn1KhRvPDCC6xcuRIvLy/tPtesWRO1Wk1gYCB//PEH7u7uDB8+nISEBLZs2cKRI0dYs2YNderU0Vnf+vXryczMZODAgTg4OGiXL1y4kBUrVtC9e3cCAgIwMTEhKiqKTz75hClTpjBkyN9Nulu2bGHWrFnUrl2bQYMG4eTkxI0bN/jll19ISUnRJhHff/89bdu2ZejQodjZ2XHp0iW2b9/OsWPH2LBhg7be//73Pz766COaNm2Kr68vNjY2pKWlcfToUa5du4azszOjRo1CURROnjzJjBkztLG0b9++0GM3Y8YM5s6di729PaNG/d13tajzuTwUdAG0tbXFz8+P33//HUVRaNGiBe+99x7/+Mc/KjQeoetKhsKqM4V3VxrYTBIIIZ5ZP50ufJlaA7O3waZJFRePEEVRjLBjxw7F1dVV8fLyUnJycnSW/fzzz4qrq6uyZcsWnfK8vDxl+PDhiqenp6LRaBRFUZRJkyYpbm5uSl5eXpHbCwoKUlxdXXXKfH19lW7duinx8fHasvv37ysjRoxQXF1dlcWLF+vFe+zYMb11+/n5Ka+//rpO2d27d/XqpaWlKS+//LLy3nvvPTa2wjy6LbVarXh4eCi9evVSUlNTdfbD19dX6dKli3L16tUi48rJyVG8vLwUb29vnXJjjk9hjh07pri6uio7duzQKd+6davi6uqqzJs3T6f8l19+UVxdXZWpU6fqraNPnz7KrVu3dOqfO3dOcXV1VUJCQvS2/dFHHylubm5Kdna2oiiKcuPGDeXFF19UvL29lb/++kuvfn5+vvbfho7TkSNHFFdXV2XVqlXasm+++UZxdXXVi+tRxnzHBV5//XXFz8+v2PX9/PyMqq8oirJv3z6D30+Bt956S3F1dVX69u2rTJgwQdm7d68SFham9O/fX+nSpYty+PBho7ZXnm7duqXk5uZq32dlZel8z/fu3VPS0tJ0PpOUlFTk++TkZO3fmqq4jd8SNQpf5RX6sp2Xp9xXa6r8fsg2ymYb9+/fV5YsWaIsWbJEuX79+hO7H7KNstlGXqvxioJXoa/8lz55IvajPLZRXjQML/ZL6CrRwGpvb2+9MRC7du3C2tqa3r17k5GRoX1lZ2fTs2dPkpKSSEh40H5vY2NDbm4uBw8eRFGKP4AwPT2dU6dO0atXL23rB4C5uTnDhg0rya7osLS01P777t27ZGRkYGpqStu2bTl79myp11/g3Llz3LhxgwEDBuDo+Pccj+bm5owcORKNRkNMTIzBuHJzc8nIyCA3N5cuXbpw5coVsrOzgfI/PlFRUZiYmODr66tT3qNHD1q0aMGBAwfQaDQ6yzw8PKhVq5ZO2e7du1GpVHh4eOicKxkZGbi5uXHnzh1On35wN2b//v3k5eXh5+eHra2tXkwmJn+fwgXHSaPRkJ2dTUZGBi1atMDGxoYzZ85o6xWMEfj5559Rq9WlOCLGKTinHn6p1WrUarVe+d27d0u1HQAXFxfmzp3LK6+8gre3N4sWLUKlUrFw4cKy2qVSq1WrFhYWFtr3NjY2Ot9ztWrV9LpyPdxtztD7unXrolL9fTe/qm2jc11oqH8qa2XlwReHNVV+P2QbZb+N2rVrPxX7Idso+TbM6thTFJNB3Z+I/SiPbYiqp0TdmRo1aqRXFh8fz507d3j11VcL/Vx6ejrOzs74+vpy4sQJJk2ahJ2dHZ06deKll17ilVdewdrautDPJyYmAg8ujh5VFlNWXr9+ndDQUA4fPkxWVpbOsof/c5RWUlISYDjmpk0f9HUs2Fd4cNwWLVpETEwM6en6T6LKzs7Gxsam3I9PUlISjo6O1KhRw2DccXFxZGRk6CQNhs6VK1euoCgK3t7ehW6rYHD3tWvXAGjZsuVj4zt27BjLli3j7Nmz3Lun+9jfh7/PIUOGEBMTw6xZs/j222954YUX6N69O/369SvXrkdz5swhMjLS4LJHx4G8/vrrBAcHl2g7BX+4PTw8dM7bRo0a8cILL3Dy5ElycnJ0klNRccxMVES+acq4/fn8mvhgStdH7b6iEPxShYcmhKhsfdpCzJ/65aYmMOkNeL9/xcckRCFKlEQYmolJURRq1qzJzJkzC/1cwQVyo0aNCAsL4+jRoxw7dowTJ04wc+ZMlixZwrJly2jQoEFJwtJT1IV/fn6+zvu7d+/i5+dHTk4Ob731Fs2aNcPa2hqVSsWqVas4duxYmcRkLEVRCAwM5MqVK/j4+NC6dWtsbGwwMTEhIiKCPXv26N39r0oKm7VLpVKxYMECnZaEhxWcK8V19uxZAgMDadCgAYGBgdSrVw8LCwtUKhWfffaZzjGyt7dnzZo1nDx5kiNHjnDy5Enmzp3LkiVLmD9/fpHjHkpj5MiRvPbaazpl8+bNA2DChAk65Q+3UBmrTp06XLp0yeBgbAcHBxRFITs7W5KIStTeUcXBt8wYFJ7P1gv6aYS1uYyLEOKZdDXNcHmr+jBrRMXGIsRjlNn8qQ0bNiQhIYF27doVawrPatWq0aNHD3r06AE8mC1nwoQJ/PDDD3z88ccGP1Mww018fLzessuXL+uVFdwx/+uvv/SWJSUl6Uwfe/ToUW7evMm0adMYMGCATt1FixY9dn+MUb9+fcBwzAVlBXUuXLhAXFwcfn5+eg892759u857Y4+PserXr89vv/1GVlaWXteiy5cvY21trR28XJSGDRvy66+/UrduXRo3blxk3YKWjLi4OJ0uWo/as2cP+fn5LFiwQHvsAHJycvRalQBMTU3p3LmzdhalCxcuMHz4cJYvX878+fOBkrU+FfWZJk2a6LUIFRzHbt26Gb2twrRp04Zff/2VlJQUvWWpqamYmpoabE0SFe9ihuHunO91kiRCiGdSon5vAwAuJEN6FtQqoi+kEBWszB425+HhgUajISQkxODygu4pABkZGXrLW7VqBUBmZqbesgIF08DGxMRw9epVbXleXh7r1q3Tq19wAXr06FGd8j179nDzpu4E7aampgB6YzQOHz6s05++LLRq1Yq6desSERFBWtrfdx3UajVr165FpVJpZ7IquFP/aFwXL14kOjpap8zY42Os3r17o9FoWLVqlU75oUOHiI2Nxc3NrdCWhYf17/+gOTY0NFSvRQh0zxV3d3fMzc1ZtmyZduzHwwqOS2Hf34oVK/Raagydfy4uLlSvXl0n4Sy4U1/UOfkoS0tLg0lrRerXrx+mpqaEh4frjPmIi4vj9OnTdO7cWaevqqg81oXcxmn3nCQRQjyTXmxhuPy+Gg7HVWwsQjxGmbVE9O3bF09PTzZt2sT58+fp2bMn9vb2pKamcurUKa5fv054eDgA48ePx9bWlo4dO1KnTh2ysrKIiIhApVJpLzAL8+GHHzJmzBhGjx7N4MGDtVOYGroYdXFxoWvXrmzdulU7xWVcXBzR0dE0bNhQ5wKrQ4cOODg4MG/ePJKTk6lduzZxcXHs2rWLZs2acfHixbI6VJiamjJlyhQmT57M22+/jZeXF1ZWVuzbt4/Tp0/j6+urTYAaN25MkyZNWLNmDbm5uTg7O5OQkMDWrVtp1qwZ586dK/HxMZanpyeRkZGsXr2apKQkOnXqxLVr19i8eTMODg4609IWpU2bNvj7+7N06VKGDRtG3759cXR0JC0tjXPnznHo0CEOHz4MPOiaM3HiRGbPno2Pjw8eHh44OTmRmppKTEwM06ZNo2XLlvTu3Zt169bxwQcf4OXlhbm5OUeOHOHixYt6rSMzZ84kNTWVbt264eTkxL1799i3bx937tzBw8NDW69du3Zs2rSJWbNm0aNHD8zMzGjbtq1OS8ej2rVrR3h4OIsWLaJx48aoVCrc3NxK3XUoOTmZnTt3An+3Kh04cEDb2lBwXODBeT9y5EhWrlyJv78/r776Kn/99RcbN26kevXqel2nROXJuq9fZgLUk+cDCvFsKqx7skoFLQv/7RGlITdtSqpMHwcdFBRE586d2bZtG6tWrSIvLw8HBwdatWqlc4Hp7e3Nvn372Lp1K5mZmdjZ2dGyZUumTJmi91C4R7Vv357Q0FBCQkJYvXo1NjY22oep+fj46NWfMWMGX331FXv27GHXrl107NiRxYsX8+WXX5KcnKytZ2trS0hICAsWLGDjxo3k5+fTqlUr5s+fT3h4eJkmEQBubm4sXLiQ5cuXs3btWvLy8nBxcWHq1Kk6D5szNTVl/vz5zJs3j8jISHJycmjatCnBwcHExcXpJRHGHh9jmJmZERISon3YXFRUFLa2tri7uzNu3Djq1q1b7HX5+/vTunVrNmzYwPr168nJyaFWrVo0bdqUSZN058D29vamQYMGrFmzhg0bNpCXl4ejoyNdunTRPneiQ4cOzJkzh++++47FixdjYWFB165dWbp0KX5+fjrr69+/PxEREezcuZPbt29jbW1NkyZNmD17Nu7u7tp6/fr1IzY2lr179/LTTz+h0WgICgoqMokYN24cmZmZhIWFkZWVhaIo7Nixo9RJRGJiIosXL9Ypi4qKIioqSrv/D89kMX78eJycnAgLC2PBggVYWFjQuXNnAgICjB5vIspH1n2F8wZ6LjhagZWMiRDi2XQu0XB53/bQtPi/sUJUBJVizByrQgghysRHUfn893/6f34HNIVwrzK9vyOqsLy8PFauXAmAr68v5ubmlRyRqFQfroB5BmbxU6ng1FxoW/jYQFEyimpkseuqlDXlGMmTp8zGRAghhCi+H+MN3795v5P8WRbimTW0kLmdFQX2/lGxsQjxGPJrJYQQlaCZvX6XJbcG4O4sf5aFeGa1K6Klobk8fK08KKiK/RK65NdKCCEqwfSXTLB/aJIs5xqw4XXTygtICFH5Em4aLm/uBP07VWwsQjyGdLwVQohK0KG2igujTdl+UcHSDAY2U2FdTe50CfFMO3XVcPmckWAqNxlE1SJJhBBCVJLnrFS8214SByHE/5eu/zwkAJrJzEzlR/4Gl5R0ZxJCCCGEqApaGZhC3MIMXGpXfCxCPIYkEUIIIYQQVUHvtvpjH4J9wKZ0zxoSojxIdyYhhBBCiKpApYIdn0LEcTh3Hfq0hRdbVnZUTznpzlRSkkQIIYQQQlQVpqYwsNuDlxBVmHRnEkIIIYQQQhhFkgghhBBCCCGEUaQ7kxBCCCGEeCbJk6hLTloihBBCCCGEEEaRJEIIIYQQQghhFOnOJIQQQgghnlHSnamkpCVCCCGEEEIIYRRpiRBCiCok+75CyEmF/6UovOikYlwHFZbmcqdMCCFE1SJJhBBCVCH9t+bzy/UH/94cp7D/qord3qaVG5QQomxdSAILc2jkWNmRCFFi0p1JCCGqiGPJijaBKLAnXuHcLaVyAhJClK1bWdDz/6BFIDiPgTdnQ+79yo7qmaYY8RK6JIkQQogq4lau4Z+phL/k50uIp8K/18HBc3+/33YEvt1VefEIUQqSRAghRBVhY244WbiXX8GBCCHKx89n9MtW/VzxcQhRBmRMhBBCVBGpdw0nEbbVKjgQIUT5MDRHwrW0Cg9DPEwmrigpaYkQQogqYsclw+V1rORHToingqmBy658TcXHIUQZkCRCCCGqgPQchY3n9cvNTaD1c5JECPFUuPmXflkt24qPQ4gyIN2ZhBCiCtgUq5BrYOxDpzoVH4sQopzcvadf5lij4uMQWop0ZyoxaYkQQogqIL+QCZhkXiYhnnJZOZUdgRAlUqWTiODgYDp37lysuklJSXTu3JklS5aUc1QPGBObv78/np6e5RxR0Yw9PrGxsYwdO5Y+ffpU6HEV4lk1uIXK4P2wP2XMpRBPh7S/IMfAMyFy8io+FiHKgHRnEnrUajVTpkxBrVYTEBCAra0tzZs3r+ywKlx0dDSxsbGMGTOm2J9Zt24dtra2ZZ40njlzht27d3Pu3DkuXLhATk4OQUFBBreTlJTEgAEDDK6nSZMmbNq0qUxjE2Uj+Y7hVoem9hUdiRCiXIT9angQtY1FxcciRBmo0knE1KlT+fTTTys7jGdOYmIiiYmJTJgwgaFDh1Z2OJUmOjqayMhIo5KI9evX4+TkVOZJxKFDhwgLC8PFxYXmzZtz6tSpx36mT58+9OnTR6fM1lYG8FVVkZcNz9BibV7BgQghykd8quHy2CTY+zu82qEioxFaMiaipEqdROTn55OXl0f16tXLIh4dZmZmmJlV6TznqXTr1i0A7OzsynS9iqKQk5ODlZVVma73Sebv7w/A0qVLi6zn7e3NyJEjsbS0ZP/+/cVKIpo1a0b//v3LJE5Rvlad0TD1oOHRD78mwbpzGoY9X6V7nwohinIlpegnU/vMhcRlYCmtEuLJYdQVekREBNOnTyc0NJTTp08TERHBjRs3mDp1Kp6eniiKwpYtW9i+fTtXrlzBxMSE1q1b4+fnpzd+IDIykk2bNpGQkIBarcbBwYF27doxceJEatasCTwYdxAZGcnx48d1Pvv777+zYMECYmNjsba2xt3dnUGDBhUa7+LFi/W27+/vT3JyMhEREdqyw4cPEx4ezp9//klaWhrm5ua0adOGUaNG4erqasyhKpYTJ07w3XffcfbsWdRqNS4uLgwePJiBAwfq1Dtz5gybN2/m1KlTpKSkYGpqSrNmzRgxYoTenWYo/vExxN/fnxMnTgAwffp0pk+fDsCOHTuoV68eOTk5LF++nH379pGamkqNGjXo1q0bY8eOxcnJSbue48ePExAQQFBQEDk5OYSFhXH9+nXeeecd7Z39vXv3snHjRi5cuEB+fr52n/r27asX1/Hjx1m7di1nzpwhJycHR0dHXF1def/997G3twcgLCyM6OhoLl++zO3bt7Gzs6Nr166MHTuWevXq6azv4MGDrFmzhkuXLpGbm4u9vT2tW7cmMDAQZ2dnnePw8LlTWBeih+slJyfrfKbg2JWGg4NDiT537949FEUplyRflJ1lp4qeJ37ZKYVhz1dQMEKIsrfuF8PjIQrczobdJ+HNFysuJiFKqUS3+efPn49arcbLywtra2ucnZ0BmDZtGj/++CPu7u54enqSl5fH7t27GT9+PHPmzKFXr14A7Ny5k+DgYDp27EhAQAAWFhakpKRw6NAh0tPTtUmEIWfOnGHcuHFYWVkxcuRIbG1t2bt3L0FBQSXZFR0RERFkZmbSv39/6tSpQ2pqKuHh4YwbN47FixfTsWPHUm+jwIEDB5g8eTIODg4MHz4cKysr9u7dy8yZM0lMTGT8+PHautHR0cTHx9O3b1+cnJzIzMwkMjKSyZMnM3PmTP75z39q65b2+IwaNYoXXniBlStX4uXlpd3nmjVrolarCQwM5I8//sDd3Z3hw4eTkJDAli1bOHLkCGvWrKFOHd35KNevX09mZiYDBw7EwcFBu3zhwoWsWLGC7t27ExAQgImJCVFRUXzyySdMmTKFIUOGaNexZcsWZs2aRe3atRk0aBBOTk7cuHGDX375hZSUFG0S8f3339O2bVuGDh2KnZ0dly5dYvv27Rw7dowNGzZo6/3vf//jo48+omnTpvj6+mJjY0NaWhpHjx7l2rVrODs7M2rUKBRF4eTJk8yYMUMbS/v27Qs9djNmzGDu3LnY29szatQobXlR53N5+uGHH/juu+9QFIU6derg6enJqFGjqFZNHn9c1Rh6/tTDzKQRQogn2+P+k4P8R68kMsVrKShG2LFjh+Lq6qp4eXkpOTk5Ost+/vlnxdXVVdmyZYtOeV5enjJ8+HDF09NT0Wg0iqIoyqRJkxQ3NzclLy+vyO0FBQUprq6uOmW+vr5Kt27dlPj4eG3Z/fv3lREjRiiurq7K4sWL9eI9duyY3rr9/PyU119/Xafs7t27evXS0tKUl19+WXnvvfceG1thHt2WWq1WPDw8lF69eimpqak6++Hr66t06dJFuXr1apFx5eTkKF5eXoq3t7dOuTHHpzDHjh1TXF1dlR07duiUb926VXF1dVXmzZunU/7LL78orq6uytSpU/XW0adPH+XWrVs69c+dO6e4uroqISEhetv+6KOPFDc3NyU7O1tRFEW5ceOG8uKLLyre3t7KX3/9pVc/Pz9f+29Dx+nIkSOKq6ursmrVKm3ZN998o7i6uurF9ShjvuMCr7/+uuLn51fs+n5+fkbVVxRF2bdvn8Hvp0BycrISEBCgrF+/XomOjla2bdumjB8/XnF1dVXGjh2rqNVqo7ZXnm7duqXk5uZq32dlZel8z/fu3VPS0tJ0PpOUlFTk++TkZO3fmidlGxvP5St8lVfoa1tc/hOxH7IN47dx//59ZcmSJcqSJUuU69evP7H7Idt4zDaupymK/XBFwcvwq+ZwRbl3v+rvRyVuo7zcw7/YL6GrRGmvt7e3XveIXbt2YW1tTe/evcnIyNC+srOz6dmzJ0lJSSQkJABgY2NDbm4uBw8eRFGKPwt6eno6p06dolevXtrWDwBzc3OGDRtWkl3RYWlpqf333bt3ycjIwNTUlLZt23L27NlSr7/AuXPnuHHjBgMGDMDR0VFbbm5uzsiRI9FoNMTExBiMKzc3l4yMDHJzc+nSpQtXrlwhOzsbKP/jExUVhYmJCb6+vjrlPXr0oEWLFhw4cACNRrdbhoeHB7Vq1dIp2717NyqVCg8PD51zJSMjAzc3N+7cucPp06cB2L9/P3l5efj5+RkcFGxi8vcpXHCcNBoN2dnZZGRk0KJFC2xsbDhz5oy2no2NDQA///wzarW6FEfEOAXn1MMvtVqNWq3WK797926Jt1O3bl0WLVqEj48PvXr1YuDAgYSEhODl5cXRo0fZu3dvGe5V6dSqVQsLi7/7ANvY2Oh8z9WqVdPryvVwtzlD7+vWrYtK9fedpSdhG0NamdC7IQbVt4GBzU2eiP2QbZRuG7Vr134q9kO2YWCd9R3g1y/B3BSDvF+EauZVfz8qcRui6ilRd6ZGjRrplcXHx3Pnzh1effXVQj+Xnp6Os7Mzvr6+nDhxgkmTJmFnZ0enTp146aWXeOWVV7C2ti7084mJiQC4uLjoLWvSpInxO/KI69evExoayuHDh8nKytJZ9vB/jtJKSkoCDMfctGlT4O99hQfHbdGiRcTExJCenq73mezsbGxsbMr9+CQlJeHo6EiNGvpP12zatClxcXFkZGToJA2GzpUrV66gKAre3t6FbqtgcPe1a9cAaNmy5WPjO3bsGMuWLePs2bPcu6f7VNCHv88hQ4YQExPDrFmz+Pbbb3nhhRfo3r07/fr1K9euR3PmzCEyMtLgskfHgbz++usEBweX6fZHjRrFtm3bOHjwIK+99lqZrluU3vf9TWiwRH9shJXMLSHE0+H5BlDNDPIMPJq+uwx6Ek+eEv08GRqkqSgKNWvWZObMmYV+ruACuVGjRoSFhXH06FGOHTvGiRMnmDlzJkuWLGHZsmU0aNCgJGHpKerCPz9f9z/x3bt38fPzIycnh7feeotmzZphbW2NSqVi1apVHDt2rExiMpaiKAQGBnLlyhV8fHxo3bo1NjY2mJiYEBERwZ49e/Tu/lclhQ3oValULFiwQKcl4WEF50pxnT17lsDAQBo0aEBgYCD16tXDwsIClUrFZ599pnOM7O3tWbNmDSdPnuTIkSOcPHmSuXPnsmTJEubPn1/kuIfSGDlypN7F+7x58wCYMGGCTvnDLVRlpU6dOpiampKRkVHm6xalp9YY/nvVSD9nF0I8qQwlEOamMOgfFR+L+P9kTERJldk9roYNG5KQkEC7du2KNYVntWrV6NGjBz169AAezJYzYcIEfvjhBz7++GODnymY4SY+Pl5v2eXLl/XKCu6Y//XXX3rLkpKSdKaPPXr0KDdv3mTatGl6D+patGjRY/fHGPXr1wcMx1xQVlDnwoULxMXF4efnp/e8gu3bt+u8N/b4GKt+/fr89ttvZGVl6XUtunz5MtbW1trBy0Vp2LAhv/76K3Xr1qVx48ZF1i1oyYiLi9PpovWoPXv2kJ+fz4IFC7THDiAnJ0evVQnA1NSUzp07a2dRunDhAsOHD2f58uXMnz8fKFnrU1GfadKkiV6LUMFx7Natm9HbMlZiYiL5+fl63ctE1dCwBpgAj94SqCZjLYV4OlxJgfsGutC+1glsLfXLhajiyuznycPDA41GQ0hIiMHlBd1TAIN3Qlu1agVAZmZmodsomAY2JiaGq1evasvz8vJYt26dXv2CC9CjR4/qlO/Zs4ebN2/qlJmaPuin+OgYjcOHD+v0py8LrVq1om7dukRERJCWlqYtV6vVrF27FpVKpZ3JquBO/aNxXbx4kejoaJ0yY4+PsXr37o1Go2HVqlU65YcOHSI2NhY3N7dCWxYeVvDsgtDQUL0WIdA9V9zd3TE3N2fZsmXasR8PKzguhX1/K1as0GupMXT+ubi4UL16dZ2Es2CMRVHn5KMsLS0NJq0VydD+aTQaFi5cCICbm1sFRySK43qWfgIBYCo3yYR4OlgWMjPec/IQUPFkKrOWiL59++Lp6cmmTZs4f/48PXv2xN7entTUVE6dOsX169cJDw8HYPz48dja2tKxY0fq1KlDVlYWERERqFSqxz4c68MPP2TMmDGMHj2awYMHa6cwNXQx6uLiQteuXdm6dSuKotCiRQvi4uKIjo6mYcOGOoNqO3TogIODA/PmzSM5OZnatWsTFxfHrl27aNasGRcvXiyrQ4WpqSlTpkxh8uTJvP3223h5eWFlZcW+ffs4ffo0vr6+2gSocePGNGnShDVr1pCbm4uzszMJCQls3bqVZs2ace7cuRIfH2N5enoSGRnJ6tWrSUpKolOnTly7do3Nmzfj4OCgMy1tUdq0aYO/vz9Lly5l2LBh9O3bF0dHR9LS0jh37hyHDh3i8OHDwIMuOBMnTmT27Nn4+Pjg4eGBk5MTqampxMTEMG3aNFq2bEnv3r1Zt24dH3zwAV5eXpibm3PkyBEuXryo1zoyc+ZMUlNT6datG05OTty7d499+/Zx584dPDw8tPXatWvHpk2bmDVrFj169MDMzIy2bdvqtHQ8ql27doSHh7No0SIaN26MSqXCzc1NZ3B8SSQnJ7Nz507g71alAwcOkJKSAqA9LgBffPEFd+7coX379tSpU4eMjAx+/vlnzp07R69evXB3dy9VLKJ8xKYbnmTiaApoFAWTMhyXJYSoBFdvFrJA/m9XJpniteTKdMheUFAQnTt3Ztu2baxatYq8vDwcHBxo1aqVzgWmt7c3+/btY+vWrWRmZmJnZ0fLli2ZMmWK3kPhHtW+fXtCQ0MJCQlh9erV2NjYaB+m5uPjo1d/xowZfPXVV+zZs4ddu3bRsWNHFi9ezJdffklycrK2nq2tLSEhISxYsICNGzeSn59Pq1atmD9/PuHh4WWaRMCDu8ELFy5k+fLlrF27lry8PFxcXJg6darOw+ZMTU2ZP38+8+bNIzIykpycHJo2bUpwcDBxcXF6SYSxx8cYZmZmhISEaB82FxUVha2tLe7u7owbN466desWe13+/v60bt2aDRs2sH79enJycqhVqxZNmzZl0qRJOnW9vb1p0KABa9asYcOGDeTl5eHo6EiXLl20z53o0KEDc+bM4bvvvmPx4sVYWFjQtWtXli5dip+fn876+vfvT0REBDt37uT27dtYW1vTpEkTZs+erXOB3a9fP2JjY9m7dy8//fQTGo2GoKCgIpOIcePGkZmZSVhYGFlZWSiKwo4dO0qdRCQmJrJ48WKdsqioKKKiorT7X5BEvPTSS+zatYtt27aRmZlJtWrVaNKkCR9//DGDBg0qVmuRqHhdnVSYm0DeI80RqXfhaDK8WLrnFQohKtu6XwyXv9i8YuMQooyoFGPmWBVCCFEuctUKNb/NJ9dAo+GfvqY87yB3y55GeXl5rFy5EgBfX1/Mzc0rOSJRbqath8/D9Mv/8y/4dFDFxyMAuKcaW+y6FkrZjpF90sktSSGEqAJS72IwgWhoiyQQQjwN/F4xXH70QsXGIUQZkSRCCCGqgIa2UN3Ac6hs5ca0EE+HjDuGy2W8k3hCSRIhhBBVgEqlooGBSVoS9SclE0I8iaZvNFzeu03FxiFEGZEkQgghqojOdfTLcko/sZoQoiq4nKJfZlkNRvSu8FCEKAuSRAghRBXxbnv9P8mvNZauDkI8Ffp11C/792CoaVPxsQgtBVWxX0KXJBFCCFFFuDub8GVPE2r8/2dS9WmoYlFf+TMtxFPh34PBpweYmkA1MxjbD6YMrOyohCixMn1OhBBCiNL5pJsJH7qquKuGmtXlzpcQTw0rC1j/ESwJeJBIWFev7IiEKBVJIoQQooqxMFNhIX+dhXg61bCq7AiEDrlZU1LSTi6EEEIIIYQwiiQRQgghhBBCCKNIg7kQQgghhHgmyaxLJSctEUIIIYQQQgijSBIhhBBCCCGEMIokEUIIIYQQQgijyJgIIYQQQgjxjJIxESUlLRFCCCGEEEIIo0hLhBBCCCFEeTsSB7/GQgcX6NOusqMRotQkiRBCCCGEKE9T18EXm/9+/25fWDau8uIRWjLFa8lJdyYhhBBCiPKSkgGztuqWfbcf/rxWKeEIUVYkiRBCCCGEKC8JNyFfo18e9mvFxyJEGZIkQgghhBCivGw/arj8ckrFxiFEGZMkQgghhBCiPNzKgq+2G17WwKFCQxGirEkSIYQQQghRHpLTIS9fv9zWEsb2q/h4hChDkkQIIcQTQq1RUBSFvHylskMRQhSHTXXD5f9ygwbPVWwsQpQxmeJVCCGquMx7Cv57NWyOVUAFGgW6OcF3r5rS1lGmJxSiyqplCyb//z/tw/b+XinhCH0yxWvJSUuEEEJUcR9FadgUq6Dh72uRI8ngFZ6PokirhBBVVg0raOakX345Bc5crfh4hChDVTqJCA4OpnPnzsWqm5SUROfOnVmyZEk5R/WAMbH5+/vj6elZzhEVzdjjExsby9ixY+nTp0+FHlchhL4tcYYThYsZ8Oetio1FCGGk8f80XB75v4qNQ4gyJt2ZhB61Ws2UKVNQq9UEBARga2tL8+bNKzusChcdHU1sbCxjxowp9mfWrVuHra1tmSeNZ86cYffu3Zw7d44LFy6Qk5NDUFCQwe0EBwcTGRlZ6LoaNmzItm3byjQ+Ub4MzDAPgAqoY1WRkQghjGZdyLiI+rUqNg5RCOnOVFJVOomYOnUqn376aWWH8cxJTEwkMTGRCRMmMHTo0MoOp9JER0cTGRlpVBKxfv16nJycyjyJOHToEGFhYbi4uNC8eXNOnTpVaN0333yTrl276pUfO3aMiIgIevbsWaaxifJX3RSyDJQrwLUseE4SCSGqrl/PGy4f0KVi4xCijJU6icjPzycvL4/q1QvJtEvBzMwMM7Mqnec8lW7detA/ws7OrkzXqygKOTk5WFnJFU8Bf39/AJYuXVpkPW9vb0aOHImlpSX79+8vMolo37497du31yvftWsXAG+88UYpIhaVIVdd+LJdVxQ61pE7aUJUWWcSDJfP2Q5f/KtCQxGiLBl1hR4REcH06dMJDQ3l9OnTREREcOPGDaZOnYqnpyeKorBlyxa2b9/OlStXMDExoXXr1vj5+emNH4iMjGTTpk0kJCSgVqtxcHCgXbt2TJw4kZo1awJ/d8s4fvy4zmd///13FixYQGxsLNbW1ri7uzNo0KBC4128eLHe9v39/UlOTiYiIkJbdvjwYcLDw/nzzz9JS0vD3NycNm3aMGrUKFxdXY05VMVy4sQJvvvuO86ePYtarcbFxYXBgwczcOBAnXpnzpxh8+bNnDp1ipSUFExNTWnWrBkjRoygT58+eust7vExxN/fnxMnTgAwffp0pk+fDsCOHTuoV68eOTk5LF++nH379pGamkqNGjXo1q0bY8eOxcnp78Fjx48fJyAggKCgIHJycggLC+P69eu888472jv7e/fuZePGjVy4cIH8/HztPvXt21cvruPHj7N27VrOnDlDTk4Ojo6OuLq68v7772Nvbw9AWFgY0dHRXL58mdu3b2NnZ0fXrl0ZO3Ys9erV01nfwYMHWbNmDZcuXSI3Nxd7e3tat25NYGAgzs7OOsfh4XOnsC5ED9dLTk7W+UzBsSsNB4fSPZQoOTmZo0eP0q5dO5o2bVqqdYmKdSRZISuv8OUqRUMVH94mxLPrVhYcv2R42dfh8OmbYGNZsTEJUUZKdJt//vz5qNVqvLy8sLa2xtnZGYBp06bx448/4u7ujqenJ3l5eezevZvx48czZ84cevXqBcDOnTsJDg6mY8eOBAQEYGFhQUpKCocOHSI9PV2bRBhy5swZxo0bh5WVFSNHjsTW1pa9e/cSFBRUkl3RERERQWZmJv3796dOnTqkpqYSHh7OuHHjWLx4MR07diz1NgocOHCAyZMn4+DgwPDhw7GysmLv3r3MnDmTxMRExo8fr60bHR1NfHw8ffv2xcnJiczMTCIjI5k8eTIzZ87kn//8e9BWaY/PqFGjeOGFF1i5ciVeXl7afa5ZsyZqtZrAwED++OMP3N3dGT58OAkJCWzZsoUjR46wZs0a6tSpo7O+9evXk5mZycCBA3FwcNAuX7hwIStWrKB79+4EBARgYmJCVFQUn3zyCVOmTGHIkCHadWzZsoVZs2ZRu3ZtBg0ahJOTEzdu3OCXX34hJSVFm0R8//33tG3blqFDh2JnZ8elS5fYvn07x44dY8OGDdp6//vf//joo49o2rQpvr6+2NjYkJaWxtGjR7l27RrOzs6MGjUKRVE4efIkM2bM0MZi6A5/gRkzZjB37lzs7e0ZNWqUtryo87mi7NixA41GI60QT6DErMJGRDyw/yp89o8KCkYIYZyPVupP71rgvhpSMiWJqGQyxWvJlSiJyM3NZd26dTpdmKKioti9ezefffYZb775prbcx8cHX19fvvnmG9zc3FCpVERHR2Ntbc2iRYt0uisFBAQ8dttz585Fo9GwfPlybfIyePBgRo8eXZJd0TF16lQsLXX/Mw8aNIghQ4awcuXKMksi8vPzmTNnDpaWlqxevRpHR0cAhgwZwpgxY1i9ejWenp40atQIgNGjRxMYGKizDh8fH4YNG8by5ct1kojSHp8XX3wRMzMzVq5cSfv27enfv7922bZt2/jjjz8YMWIEH3zwgba8W7duTJgwgZCQED7//HOd9d24cYPNmzdTq9bfA8jOnz/PihUr8PX11UmWfHx8mDhxIqGhoXh4eGBtbU1KSgpff/01Li4urFixAltbW239sWPHotH8fYG1YcMGve/Pzc2NcePGER4ezttvvw1ATEwMGo2G0NBQnbjeffddneOwZ88eTp48qXMMitK/f38WLVpErVq1iv2ZiqDRaIiIiMDKyopXX321ssMRZezojcqOQAhRqMc9D8J/Efw0vUJCEaKslagN3NvbW28MxK5du7C2tqZ3795kZGRoX9nZ2fTs2ZOkpCQSEh70C7SxsSE3N5eDBw8aNcd5eno6p06dolevXtoLZABzc3OGDRtWkl3R8fAF6N27d8nIyMDU1JS2bdty9uzZUq+/wLlz57hx4wYDBgzQJhDwYD9GjhyJRqMhJibGYFy5ublkZGSQm5tLly5duHLlCtnZ2UD5H5+oqChMTEzw9fXVKe/RowctWrTgwIEDOhf1AB4eHjoX6gC7d+9GpVLh4eGhc65kZGTg5ubGnTt3OH36NAD79+8nLy8PPz8/nQSigInJ36dwwXHSaDRkZ2eTkZFBixYtsLGx4cyZM9p6NjY2APz888+o1UV0Ni9jBefUwy+1Wo1ardYrv3v3bplt98iRI9y4cYNXXnmlyo1HSU9P5969e9r32dnZZGX9PYT4/v372jE6BZKTk4t8f+PGDZ2/K0/6Nk6lFf03slnNJ2M/ZBuP30ZqaupTsR+yjb/db/iYGZh+Po0Sm1jl96MqbENUPSVqiSi4Q/6w+Ph47ty5U+SdzvT0dJydnfH19eXEiRNMmjQJOzs7OnXqxEsvvcQrr7yCtbV1oZ9PTHzwH83FxUVvWZMmTYzfkUdcv36d0NBQDh8+rHOyA6hUZdfclZSUBBiOuaC/esG+woPjtmjRImJiYkhPT9f7THZ2NjY2NuV+fJKSknB0dKRGjRoG446LiyMjI0MnaTB0rly5cgVFUfD29i50WwV/XK5duwZAy5YtHxvfsWPHWLZsGWfPntX54wXofJ9DhgwhJiaGWbNm8e233/LCCy/QvXt3+vXrV65dj+bMmVPo1KuPjgN5/fXXCQ4OLpPthoeHA+iNtakKHk0wCxK8AtWqVdMbD/Lw2BtD7+vWrftUbePYY35Hg/6hKvU2Cjzpx+pJ3EZe3t8DXmrXrq3zW/Mk7Ydsw/A2qn3tC73+TVFUt7NLtY2n5Vg9bhvlRbozlVyJkghDMzEpikLNmjWZOXNmoZ8ruEBu1KgRYWFhHD16lGPHjnHixAlmzpzJkiVLWLZsGQ0aNChJWHqKuvDPz8/XeX/37l38/PzIycnhrbfeolmzZlhbW6NSqVi1ahXHjh0rk5iMpSgKgYGBXLlyBR8fH1q3bo2NjQ0mJiZERESwZ88evbv/VUlhs3apVCoWLFig05LwMGMH/549e5bAwEAaNGhAYGAg9erVw8LCApVKxWeffaZzjOzt7VmzZg0nT57kyJEjnDx5krlz57JkyRLmz59f5LiH0hg5ciSvvfaaTtm8efMAmDBhgk75wy1UpZGRkUFMTAxNmzalXbt2ZbJOUbHu5xe93NZCfgCFqLLc2oCpCeQX8jvdpA50aVaxMQlRRsps/tSGDRuSkJBAu3btitVlolq1avTo0YMePXoAD2bLmTBhAj/88AMff/yxwc8UzHATHx+vt+zy5ct6ZQV3zP/66y+9ZUlJSTrjMY4ePcrNmzeZNm0aAwYM0Km7aNGix+6PMerXrw8YjrmgrKDOhQsXiIuLw8/PT+95Bdu3b9d5b+zxMVb9+vX57bffyMrK0utadPnyZaytrbWDl4vSsGFDfv31V+rWrUvjxo2LrFvQkhEXF6fTRetRe/bsIT8/nwULFmiPHUBOTo5eqxKAqakpnTt31s6idOHCBYYPH87y5cuZP38+ULLWp6I+06RJE70WoYLj2K1bN6O3VRw7d+4kLy9PBlQ/wTrXVbE/ofAuTc3tJYkQokprWQ/+vK5f/oILbJoEpqYVHpIQZaHM5gX08PBAo9EQEhJicPnDfd8yMjL0lrdq1QqAzMzMQrdRMA1sTEwMV69e1Zbn5eWxbt06vfoFF6BHjx7VKd+zZw83b97UKTP9//+JHx2jcfjwYZ3+9GWhVatW1K1bl4iICNLS0rTlarWatWvXolKptDNZFdypfzSuixcvEh0drVNm7PExVu/evdFoNKxatUqn/NChQ8TGxuLm5lZoy8LDCgYdh4aG6rUIge654u7ujrm5OcuWLdOO/XhYwXEp7PtbsWKFXkuNofPPxcWF6tWr6yScBWMsijonH2VpaWkwaa0s4eHhmJubV6mB3sI4H7qaYG1ueJm5CTjbSRIhRJX2ZiE3iUa7Q4vSTf8tRGUqs5aIvn374unpyaZNmzh//jw9e/bE3t6e1NRUTp06xfXr17V9s8ePH4+trS0dO3akTp06ZGVlERERgUqleuzFzocffsiYMWMYPXo0gwcP1k5hauhi1MXFha5du7J161YURaFFixbExcURHR1Nw4YNdQbVdujQAQcHB+bNm0dycjK1a9cmLi6OXbt20axZMy5evFhWhwpTU1OmTJnC5MmTefvtt/Hy8sLKyop9+/Zx+vRpfH19tQlQ48aNadKkCWvWrCE3NxdnZ2cSEhLYunUrzZo149y5cyU+Psby9PQkMjKS1atXk5SURKdOnbh27RqbN2/GwcFBZ6alorRp0wZ/f3+WLl3KsGHD6Nu3L46OjqSlpXHu3DkOHTrE4cOHAahTpw4TJ05k9uzZ+Pj44OHhgZOTE6mpqcTExDBt2jRatmxJ7969WbduHR988AFeXl6Ym5tz5MgRLl68qNc6MnPmTFJTU+nWrRtOTk7cu3ePffv2cefOHTw8PLT12rVrx6ZNm5g1axY9evTAzMyMtm3b6rR0PKpdu3aEh4ezaNEiGjdujEqlws3NTW/WKGMlJyezc+dO4O9WpQMHDpCSkgKgPS4PO3PmDJcvX+aVV14pVguRqJpqW6voWQ/2XNVf1tS+wsMRQhgrp5AHvdwy9Bx6IZ4cZfo46KCgIDp37sy2bdtYtWoVeXl5ODg40KpVK50LTG9vb/bt28fWrVvJzMzEzs6Oli1bMmXKFL2Hwj2qffv2hIaGEhISwurVq7GxsdE+TM3Hx0ev/owZM/jqq6/Ys2cPu3btomPHjixevJgvv/xSZ+S/ra0tISEhLFiwgI0bN5Kfn0+rVq2YP38+4eHhZZpEwIOpRxcuXMjy5ctZu3YteXl5uLi4MHXqVJ0BsKampsyfP5958+YRGRlJTk4OTZs2JTg4mLi4OL0kwtjjYwwzMzNCQkK0D5uLiorC1tYWd3d3xo0bpzewqij+/v60bt2aDRs2sH79enJycqhVqxZNmzZl0qRJOnW9vb1p0KABa9asYcOGDeTl5eHo6EiXLl20z53o0KEDc+bM4bvvvmPx4sVYWFjQtWtXli5dip+fn876+vfvT0REBDt37uT27dtYW1vTpEkTZs+ejbu7u7Zev379iI2NZe/evfz0009oNBqCgoKKTCLGjRtHZmYmYWFhZGVloSgKO3bsKHUSkZiYyOLFi3XKoqKiiIqK0u7/o0lEQdIuXZmefN0bmLDnqn6f6n89L60QQlR5ZoV0V1r+EwSX7ndZiMqkUoyZY1UIIUSFu52r0PX7fC5m/F3WoiYcHW6KnQysfqLl5eWxcuVKAHx9fTE3L6TvmngyaTTgEgDX0vSX1bSB9DUVH5PQkaX6qNh1bZW55RjJk6dMWyKEEEKUvZrVVZwbZcq2OIWDSQpu9eGN5iaYmUgCIUSVlpBmOIEAeN21YmMRBskUryUnSYQQQjwBzExUDG6lYnCryo5ECFFsTjXBwdbw+Afb0nVzFaKyldnsTEIIIYQQ4iEW5rBgtOFlcUkVG4sQZUySCCGEEEKI8jLMDYM9ZqwsKjwUYYjKiJd4mCQRQgghhBDlydAzlKrLIHrxZJMkQgghhBCiPFUzMAS1baOKj0OIMiRJhBBCCCFEeRrzqu576+owsnelhCJEWZHZmYQQQgghytNXb0Nde9h+FOrVgk/fBOfalR2VQKZ4LQ1JIoQQQgghypOZKXz85oOXEE8J6c4khBBCCCGEMIq0RAghhBBCiGeSdGcqOWmJEEIIIYQQQhhFkgghhBBCCCGEUaQ7kxBCCCGEeEZJd6aSkpYIIYQQQgghhFEkiRBCCCGEEEIYRZIIIYR4St25r6DWKJUdhhDCWPn5cCe3sqMQokiSRAghxFMm7a7C61vzsV2Qj2NoPl8f01R2SEKI4lq0B+qOBpth0DcYktIrO6KnmmLES+iSJEIIIZ4y43/SsPOyggJk3IPJMRp+uiqJhBBV3tELMG4ppP314P1Pp8A3pHJjEqIQkkQIIcRTZudl/XtmP5yT+2hCVHm7/qdftvd3SJbWCFH1SBIhhBBPGQtT/bITKZJECFHludQ2XB6yu2LjeIYoqIr9ErokiRBCiKdMPRv9srO3ID1HEgkhqrShL4GJgYvVs9cqPhYhHkOSCCGEeMoMaq5/EaLWwOY4SSKEqNJy7oOhGdUcDNwZEKKSSRIhhBBPmX4uhsslhRCiitt9wnB5n7YVG4cQxWBW2QEIIYQoW8dSVBhKGfo0rPhYhBBGOHLBcPnAbhUbxzNFxjqUlLRECCHEU8bC1HCbQ3UDA66FEFWIofEQIM2Iokqq0klEcHAwnTt3LlbdpKQkOnfuzJIlS8o5qgeMic3f3x9PT89yjqhoxh6f2NhYxo4dS58+fSr0uAohSs+skOuQxafkSkSIKu35BobLr6RUbBxCFEOVTiJE5VCr1UyZMoWEhAQCAgKYMWMGL7/8cmWHVeGio6ONTp7WrVtHREREmcdy5swZvvrqK0aNGkXPnj3p3LlzsbeTlpamTQbXrl1b5rGJqud6luHyHRckiRCiSuva3HD5H/EVGsazRKZ4LbkqnURMnTqVQ4cOVXYYz5zExEQSExN56623GDp0KP3796d580L+sD3FoqOjWbZsmVGfWb9+fbkkEYcOHSIsLIzs7Gyjv4s5c+aQn59f5jGJqsvWwvCPXextuHhbEgkhqiwrC8PlP52u2DiEKIZSJxH5+fnk5uaWRSx6zMzMsLAo5D+UKDe3bt0CwM7OrkzXqygKd+/eLdN1Pun8/f3x9/d/bD1vb29iYmLYtGkTw4YNK/b6Y2JiiI6O5t133y1NmOIJ06uQHhFqBdquyic6QVOxAQkhHu96GvSZZnhZeiHNi0JUIqNmZ4qIiGD69OmEhoZy+vRpIiIiuHHjBlOnTsXT0xNFUdiyZQvbt2/nypUrmJiY0Lp1a/z8/PTGD0RGRrJp0yYSEhJQq9U4ODjQrl07Jk6cSM2aNYEH4w4iIyM5fvy4zmd///13FixYQGxsLNbW1ri7uzNo0KBC4128eLHe9v39/UlOTta5a3z48GHCw8P5888/SUtLw9zcnDZt2jBq1ChcXV2NOVTFcuLECb777jvOnj2LWq3GxcWFwYMHM3DgQJ16Z86cYfPmzZw6dYqUlBRMTU1p1qwZI0aMoE+fPnrrLe7xMcTf358TJx5MMTd9+nSmT58OwI4dO6hXrx45OTksX76cffv2kZqaSo0aNejWrRtjx47FyclJu57jx48TEBBAUFAQOTk5hIWFcf36dd555x3GjBkDwN69e9m4cSMXLlwgPz9fu099+/bVi+v48eOsXbuWM2fOkJOTg6OjI66urrz//vvY29sDEBYWRnR0NJcvX+b27dvY2dnRtWtXxo4dS7169XTWd/DgQdasWcOlS5fIzc3F3t6e1q1bExgYiLOzs85xePjcCQoKKnR8S0G95ORknc8UHLvScHBwMPozd+7cYc6cOQwaNIjWrVuXavviyfL9n4UnCffyYfpvCr0bVWBAQojH+3YXJN82vKxVIXcGRKlJN6WSK9EUr/Pnz0etVuPl5YW1tTXOzs4ATJs2jR9//BF3d3c8PT3Jy8tj9+7djB8/njlz5tCrVy8Adu7cSXBwMB07diQgIAALCwtSUlI4dOgQ6enp2iTCkDNnzjBu3DisrKwYOXIktra27N27l6CgoJLsio6IiAgyMzPp378/derUITU1lfDwcMaNG8fixYvp2LFjqbdR4MCBA0yePBkHBweGDx+OlZUVe/fuZebMmSQmJjJ+/Hht3ejoaOLj4+nbty9OTk5kZmYSGRnJ5MmTmTlzJv/85z+1dUt7fEaNGsULL7zAypUr8fLy0u5zzZo1UavVBAYG8scff+Du7s7w4cNJSEhgy5YtHDlyhDVr1lCnTh2d9a1fv57MzEwGDhyIg4ODdvnChQtZsWIF3bt3JyAgABMTE6Kiovjkk0+YMmUKQ4YM0a5jy5YtzJo1i9q1azNo0CCcnJy4ceMGv/zyCykpKdok4vvvv6dt27YMHToUOzs7Ll26xPbt2zl27BgbNmzQ1vvf//7HRx99RNOmTfH19cXGxoa0tDSOHj3KtWvXcHZ2ZtSoUSiKwsmTJ5kxY4Y2lvbt2xd67GbMmMHcuXOxt7dn1KhR2vKizufyFBISQn5+PuPHj+f8+fOVEoOoHLuvFL08MVu6NAlR5Zy4XPiyEb0qLg4hiqlESURubi7r1q2jevXq2rKoqCh2797NZ599xptvvqkt9/HxwdfXl2+++QY3NzdUKhXR0dFYW1uzaNEizMz+DiEgIOCx2547dy4ajYbly5drk5fBgwczevTokuyKjqlTp2JpaalTNmjQIIYMGcLKlSvLLInIz89nzpw5WFpasnr1ahwdHQEYMmQIY8aMYfXq1Xh6etKo0YNbhaNHjyYwMFBnHT4+PgwbNozly5frJBGlPT4vvvgiZmZmrFy5kvbt29O/f3/tsm3btvHHH38wYsQIPvjgA215t27dmDBhAiEhIXz++ec667tx4wabN2+mVq1a2rLz58+zYsUKfH19dZIlHx8fJk6cSGhoKB4eHlhbW5OSksLXX3+Ni4sLK1aswNbWVlt/7NixaDR/33HdsGGD3vfn5ubGuHHjCA8P5+233wYedPHRaDSEhobqxPVwl58XX3yRPXv2cPLkSZ1jUJT+/fuzaNEiatWqVezPlJfTp0+zZcsWZs6ciY2NPOn0WZN8p+jlbzSVO29CVDmGnlRdIPk2tHOuuFiEKIYSjYnw9vbWSSAAdu3ahbW1Nb179yYjI0P7ys7OpmfPniQlJZGQkACAjY0Nubm5HDx4EEUp/h2x9PR0Tp06Ra9evbQXyADm5uZG9RMvzMMXoHfv3iUjIwNTU1Patm3L2bNnS73+AufOnePGjRsMGDBAm0DAg/0YOXIkGo2GmJgYg3Hl5uaSkZFBbm4uXbp04cqVK2RnZwPlf3yioqIwMTHB19dXp7xHjx60aNGCAwcO6FzUA3h4eOhcqAPs3r0blUqFh4eHzrmSkZGBm5sbd+7c4fTpB4PI9u/fT15eHn5+fjoJRAETk79P4YLjpNFoyM7OJiMjgxYtWmBjY8OZM2e09Qouqn/++WfUanUpjohxCs6ph19qtRq1Wq1XXpqxI2q1mpkzZ9KtWzdeffXVMtyDspeens69e/e077Ozs8nK+rvv7/3797VjdAokJycX+f7GjRs6f1eexW3YVaNQPevDjJdMnoj9eNa2kZqa+lTsh2yjhNtoX0SSsOPok7Mf5bQNUfWUqCWi4A75w+Lj47lz506RFy3p6ek4Ozvj6+vLiRMnmDRpEnZ2dnTq1ImXXnqJV155BWtr60I/n5iYCICLi4vesiZNmhi/I4+4fv06oaGhHD58WOdkB1Cpyu7OXVJSEmA45qZNmwJ/7ys8OG6LFi0iJiaG9PR0vc9kZ2djY2NT7scnKSkJR0dHatSoYTDuuLg4MjIydJIGQ+fKlStXUBQFb2/vQrdV8Mfl2rVrALRs2fKx8R07doxly5Zx9uxZnT9egM73OWTIEGJiYpg1axbffvstL7zwAt27d6dfv37l2vVozpw5REZGGlz26DiQ119/neDg4BJtZ9WqVVy/fp1vvvmmRJ+vSI8mmI+2mlSrVk1vPMjDY28Mva9bt+4zvw13Z1hVyH2P5x1UWJqrnoj9eBa2kZeXp31fu3Ztnd+aJ2k/ZBtlsI2AfvDdfsg2MFnN1ZtPzn6U0zZE1VOiJOLRVgh4MPNOzZo1mTlzZqGfK7hAbtSoEWFhYRw9epRjx45x4sQJZs6cyZIlS1i2bBkNGpTNAKKiLvwfnfLy7t27+Pn5kZOTw1tvvUWzZs2wtrZGpVKxatUqjh07ViYxGUtRFAIDA7ly5Qo+Pj60bt0aGxsbTExMiIiIYM+ePXp3/6sSQ+cKPPhuFixYoNOS8LCCc6W4zp49S2BgIA0aNCAwMJB69ephYWGBSqXis88+0zlG9vb2rFmzhpMnT3LkyBFOnjzJ3LlzWbJkCfPnzy9y3ENpjBw5ktdee02nbN68eQBMmDBBp/zhFipjpKWlsXLlSjw8PFAURZuE3bz54AcoMzOTa9eu8dxzz+l1/RJPjxpFtER0rC1dmYSoklrWh33B8I9P9JfZFX6DVYjKUqIkwpCGDRuSkJBAu3btsLKyemz9atWq0aNHD3r06AE8mC1nwoQJ/PDDD3z88ccGP1Mww018fLzessuX9QckFdwx/+uvv/SWJSUl6YzHOHr0KDdv3mTatGkMGDBAp+6iRYseuz/GqF+/PmA45oKygjoXLlwgLi4OPz8/7axGBbZv367z3tjjY6z69evz22+/kZWVpde16PLly1hbW2sHLxelYcOG/Prrr9StW5fGjRsXWbegJSMuLk6ni9aj9uzZQ35+PgsWLNAeO4CcnBy9ViUAU1NTOnfurJ1F6cKFCwwfPpzly5czf/58oGStT0V9pkmTJnotQgXHsVu3bkZvy5Bbt25x7949tm7dytatW/WWr1q1ilWrVjFr1iyDs2CJp0PMdcPlNarBO20liRCiyqpTyNTqHYv+rRSiMpTZw+Y8PDzQaDSEhIQYXP5w37eMjAy95a1atQIe3CktTME0sDExMVy9elVbnpeXx7p16/TqF1yAHj16VKd8z5492juzBUxNTQH0xmgcPnxYpz99WWjVqhV169YlIiKCtLQ0bblarWbt2rWoVCrtTFYFd+ofjevixYtER0frlBl7fIzVu3dvNBoNq1at0ik/dOgQsbGxuLm5Fdqy8LCCQcehoaEGH4L28Lni7u6Oubk5y5Yt0479eFjBcSns+1uxYoVeS42h88/FxYXq1avrJJwFd+qLOicfZWlpaTBprSj169dn1qxZeq+CZ1F4eHgwa9ascmttEVXD1UJOwakvmlDdTJIIIaqsnHuGyy3K7J6veIQ8sbrkyuys7Nu3L56enmzatInz58/Ts2dP7O3tSU1N5dSpU1y/fp3w8HAAxo8fj62tLR07dqROnTpkZWURERGBSqV67Kw2H374IWPGjGH06NEMHjxYO4WpoYtRFxcXunbtytatW1EUhRYtWhAXF0d0dDQNGzbUGVTboUMHHBwcmDdvHsnJydSuXZu4uDh27dpFs2bNuHjxYlkdKkxNTZkyZQqTJ0/m7bffxsvLCysrK/bt28fp06fx9fXVJkCNGzemSZMmrFmzhtzcXJydnUlISGDr1q00a9aMc+fOlfj4GMvT05PIyEhWr15NUlISnTp14tq1a2zevBkHBwedmZaK0qZNG/z9/Vm6dCnDhg2jb9++ODo6kpaWxrlz5zh06BCHDx8GoE6dOkycOJHZs2fj4+ODh4cHTk5OpKamEhMTw7Rp02jZsiW9e/dm3bp1fPDBB3h5eWFubs6RI0e4ePGiXuvIzJkzSU1NpVu3bjg5OXHv3j327dvHnTt38PDw0NZr164dmzZtYtasWfTo0QMzMzPatm2r09LxqHbt2hEeHs6iRYto3LgxKpUKNze3UncdSk5OZufOncDfrUoHDhwgJSUFQHtcbGxsCn3OBkCzZs2kBeIZkGegh2MTO/ios/wIClGlLd1vuLxhybq4ClGeyjS1DQoKonPnzmzbto1Vq1aRl5eHg4MDrVq10rnA9Pb2Zt++fWzdupXMzEzs7Oxo2bIlU6ZM0Xso3KPat29PaGgoISEhrF69GhsbG+3D1Hx8fPTqz5gxg6+++oo9e/awa9cuOnbsyOLFi/nyyy91Rv7b2toSEhLCggUL2LhxI/n5+bRq1Yr58+cTHh5epkkEPJh6dOHChSxfvpy1a9eSl5eHi4sLU6dO1XnYnKmpKfPnz2fevHlERkaSk5ND06ZNCQ4OJi4uTi+JMPb4GMPMzIyQkBDtw+aioqKwtbXF3d2dcePG6Q2sKoq/vz+tW7dmw4YNrF+/npycHGrVqkXTpk2ZNGmSTl1vb28aNGjAmjVr2LBhA3l5eTg6OtKlSxftcyc6dOjAnDlz+O6771i8eDEWFhZ07dqVpUuX4ufnp7O+/v37ExERwc6dO7l9+zbW1tY0adKE2bNn4+7urq3Xr18/YmNj2bt3Lz/99BMajYagoKAik4hx48aRmZlJWFgYWVlZKIrCjh07Sp1EJCYmsnjxYp2yqKgooqKitPsvg9BEgTwD9ww61AZTE0kihKjSok7rl1U3h/6dKj4WIR5DpRgzx6oQQogqz2qempxHZi/u5wJ7vKVLRFWTl5fHypUrAfD19cXc3LySIxKVymWMdiYmLWdHiF9SOfE8A1JV/y523drK54+v9AwpszERQgghqgZzA3/ZT6ZWfBxCCCPZGZiYJikd7hiY9lWISiZJhBBCPGXaG+g+nXoXrmRIw7MQVZq7gUkv8vIhqmwneBGiLEgSIYQQT5nqpvplJiqwN/zYFiFEVfFSK8PlDraGy4WoRNJBVgghnjLpBno+ONeAmtVlYLUQVdqPJw2XN3quYuN4psjfxZKSlgghhHjKdK+v/6M4qq38uReiyjt+Sb/MxgKcalZ8LEI8hvyqCCHEUya4uwkvPTQT8T9dVPKMCCGeBCoD/09fbAnFeJCrEBVNujMJIcRTxsFSxcG3zDh3S8HcBJrVlARCiCfC233gxGXdsklvVE4szwiZbqLkJIkQQoin1PMOkjwI8UR5rz8oCqz8+cFD5j70hH4dKzsqIQySJEIIIYQQoipQqeCD1x+8hKjipJOdEEIIIYQQwijSEiGEEEIIIZ5JikzxWmLSEiGEEEIIIYQwiiQRQgghhBBCCKNIdyYhhBBCCPFMku5MJSctEUIIIYQQQgijSBIhhBBCCCGEMIp0ZxJCCCGEEM8o6c5UUtISIYQQT6BfritsOK/hVo5S2aEIIQDOJsAPMXD5RmVHIkSFkJYIIYR4guTlKwzYpmFP/IPkwcoMtg804RUXuSckRKX5eA3M2f7g3yoVzH0HJnhWZkRClDv51RFCiCfIlguKNoEAuKuG8fs1lRiREM+4C0nwVfjf7xUFPv0B0rMqLyYhKoAkEUII8QQ5m6bffelCBrz/U37FByOEgD+vP0gcHpZ7Hy4kV048wigKqmK/hC5JIoQQ4gni1sDwD9m3JxV+TpAWCSEq3IstHnRhetTVmxUfixAVSJIIIYR4grziYsKg5oaXHZEbn0JUvDr2hssnrIDk9AoNRYiKJEmEEEI8Qe7cV/gpwfCyTrUrNhYhxP/XtK5+WfJteO+7io9FGEUx4iV0SRIhhBBPkP+lQMY9/fI+DeFVF+mzK0Sl6NTYcPn+UxUbhxAVSJIIIYR4gjS1B1MDuYK5KagM9csWQpQ/M1PD5bVsKjYOISpQlU4igoOD6dy5c7HqJiUl0blzZ5YsWVLOUT1gTGz+/v54elbufNHGHp/Y2FjGjh1Lnz59KvS4CiGKFn1NwcLA9cpPV0Hz6AwxQoiKcauQ6VwLGy8hxFNAHjYn9KjVaqZMmYJarSYgIABbW1uaNy9kJOdTLDo6mtjYWMaMGVPsz6xbtw5bW9syTRoVRWH37t388ssvnDt3jps3b2Jvb0+LFi0YPXo0bdu21al/9epVdu/ezeHDh7l+/Tr379+nQYMGuLu7M2zYMCwtLcssNlGx9lzRMHyX4RmY6lqDibRECFE57qkNl9ewqtg4hNFk6taSq9ItEVOnTuXQoUOVHcYzJzExkcTERN566y2GDh1K//79n9kkYtmyZUZ9Zv369URERJRpHPfv32fatGlcvXqVV199lcmTJ+Pl5UVsbCy+vr7s2rVLp/6OHTtYt24dDRo04N133+X999/H2dmZRYsWMWrUKHJzc8s0PlFxvv+z8JaGRrZwN09aIoSoFJpCplc2q9KXWUKUSqlbIvLz88nLy6N69eplEY8OMzMzzMyksaSi3bp1CwA7O7syXa+iKOTk5GBlJXdmCvj7+wOwdOnSQuuYmpqyZMkSXF1ddcq9vLwYMmQI8+bN45///CcmJg9+rNzd3fH19cXG5u++uN7e3jRs2JAVK1YQHh7O0KFDy2FvRHmL/6vwJOG3ZHgrMp9wL/mbKUSFq1PI72WePARSPL2M+rWJiIhg+vTphIaGcvr0aSIiIrhx4wZTp07F09MTRVHYsmUL27dv58qVK5iYmNC6dWv8/Pz0xg9ERkayadMmEhISUKvVODg40K5dOyZOnEjNmjWBB+MOIiMjOX78uM5nf//9dxYsWEBsbCzW1ta4u7szaNCgQuNdvHix3vb9/f1JTk7WuWt8+PBhwsPD+fPPP0lLS8Pc3Jw2bdowatQovQu4snDixAm+++47zp49i1qtxsXFhcGDBzNw4ECdemfOnGHz5s2cOnWKlJQUTE1NadasGSNGjKBPnz566y3u8THE39+fEydOADB9+nSmT58OPLi7Xa9ePXJycli+fDn79u0jNTWVGjVq0K1bN8aOHYuTk5N2PcePHycgIICgoCBycnIICwvj+vXrvPPOO9ruQXv37mXjxo1cuHCB/Px87T717dtXL67jx4+zdu1azpw5Q05ODo6Ojri6uvL+++9jb28PQFhYGNHR0Vy+fJnbt29jZ2dH165dGTt2LPXq1dNZ38GDB1mzZg2XLl0iNzcXe3t7WrduTWBgIM7OzjrH4eFzJygoqNCuSgX1kpOTdT5TcOxKyszMzOD55+DgQKdOnYiKiiI9PZ3nnnsOgNatWxtcz6uvvsqKFSu4dOlSiWMRlevaX0Uv33EJbtxRqGstzfNCVKg+7SDsN/3ytMyKj0UYSf5ellSJblnNnz8ftVqNl5cX1tbWODs7AzBt2jR+/PFH3N3d8fT0JC8vj927dzN+/HjmzJlDr169ANi5cyfBwcF07NiRgIAALCwsSElJ4dChQ6Snp2uTCEPOnDnDuHHjsLKyYuTIkdja2rJ3716CgoJKsis6IiIiyMzMpH///tSpU4fU1FTCw8MZN24cixcvpmPHjqXeRoEDBw4wefJkHBwcGD58OFZWVuzdu5eZM2eSmJjI+PHjtXWjo6OJj4+nb9++ODk5kZmZSWRkJJMnT2bmzJn885//1NYt7fEZNWoUL7zwAitXrsTLy0u7zzVr1kStVhMYGMgff/yBu7s7w4cPJyEhgS1btnDkyBHWrFlDnTp1dNa3fv16MjMzGThwIA4ODtrlCxcuZMWKFXTv3p2AgABMTEyIiorik08+YcqUKQwZMkS7ji1btjBr1ixq167NoEGDcHJy4saNG/zyyy+kpKRok4jvv/+etm3bMnToUOzs7Lh06RLbt2/n2LFjbNiwQVvvf//7Hx999BFNmzbV3rFPS0vj6NGjXLt2DWdnZ0aNGoWiKJw8eZIZM2ZoY2nfvn2hx27GjBnMnTsXe3t7Ro0apS0v6nwurdTUVMzNzbG1tX1s3ZSUFOBB8iGePPkahZS7j68nY6uFqASNC3lIS7aB+ZiFeEqUKInIzc1l3bp1Ol2YoqKi2L17N5999hlvvvmmttzHxwdfX1+++eYb3NzcUKlUREdHY21tzaJFi3S6KwUEBDx223PnzkWj0bB8+XJt8jJ48GBGjx5dkl3RMXXqVL1Bp4MGDWLIkCGsXLmyzJKI/Px85syZg6WlJatXr8bR0RGAIUOGMGbMGFavXo2npyeNGjUCYPTo0QQGBuqsw8fHh2HDhrF8+XKdJKK0x+fFF1/EzMyMlStX0r59e/r3769dtm3bNv744w9GjBjBBx98oC3v1q0bEyZMICQkhM8//1xnfTdu3GDz5s3UqlVLW3b+/HlWrFiBr6+vTrLk4+PDxIkTCQ0NxcPDA2tra1JSUvj6669xcXFhxYoVOhfLY8eORfNQP9QNGzbofX9ubm6MGzeO8PBw3n77bQBiYmLQaDSEhobqxPXuu+/qHIc9e/Zw8uRJnWNQlP79+7No0SJq1apV7M+UxsGDBzl79iz9+/fHwsKiyLr5+fksX74cU1NT+vXrV+6xibK3N17h3mN6RjxXHZxs5K6aEBUuIc1w+b28io1DiApUohE/3t7eemMgdu3ahbW1Nb179yYjI0P7ys7OpmfPniQlJZGQ8OAxqzY2NuTm5nLw4EEUI26bpaenc+rUKXr16qW9QAYwNzdn2LBhJdkVHQ9fgN69e5eMjAxMTU1p27YtZ8+eLfX6C5w7d44bN24wYMAAbQIBD/Zj5MiRaDQaYmJiDMaVm5tLRkYGubm5dOnShStXrpCdnQ2U//GJiorCxMQEX19fnfIePXrQokULDhw4oHNRD+Dh4aFzoQ6we/duVCoVHh4eOudKRkYGbm5u3Llzh9OnTwOwf/9+8vLy8PPzM3i3vWAcAPx9nDQaDdnZ2WRkZNCiRQtsbGw4c+aMtl7BWIGff/4ZtbqQGTXKQcE59fBLrVajVqv1yu/eLfqWc0JCAkFBQdSuXZsPP/zwsdv+5ptvOHXqFAEBAbi4uJTRHpVeeno69+79facuOzubrKy/p0q8f/++doxOgeTk5CLf37hxQ+fvytOyjaT0bB7HyUr3fK6K+yHbKPx9amrqU7Efz+Q2fr+CIfn3dZOIKr8fVXgb5UVBVeyX0FWiloiCO+QPi4+P586dO7z66quFfi49PR1nZ2d8fX05ceIEkyZNws7Ojk6dOvHSSy/xyiuvYG1tXejnExMTAQxeBDVp0sT4HXnE9evXCQ0N5fDhwzonO5TtQ5ySkpIAwzE3bdoU+Htf4cFxW7RoETExMaSnp+t9Jjs7Gxsbm3I/PklJSTg6OlKjRg2DccfFxZGRkaGTNBg6V65cuYKiKHh7exe6rYI/LteuXQOgZcuWj43v2LFjLFu2jLNnz+r88QJ0vs8hQ4YQExPDrFmz+Pbbb3nhhRfo3r07/fr1K9euR3PmzCEyMtLgskfHgbz++usEBwcbrJuYmMjYsWMBWLBgwWNjXrRoEZs2bcLLy0svAaxsjyaYDw8GB6hWrZpe96uHx94Yel+3bt2nchvPO9kAhcwA8/+N7VStVNt4Wo7Vk7SNvLy/LzJr166t81vzJO3HM7+Nk4aTCNP2uk+yrvL7UYW3IaqeEiURhmZiUhSFmjVrMnPmzEI/V3CB3KhRI8LCwjh69CjHjh3jxIkTzJw5kyVLlrBs2TIaNGhQkrD0FHXhn5+v2y/g7t27+Pn5kZOTw1tvvUWzZs2wtrZGpVKxatUqjh07ViYxGUtRFAIDA7ly5Qo+Pj60bt0aGxsbTExMiIiIYM+ePXp3/6uSwmbtUqlULFiwQKcl4WEF50pxnT17lsDAQBo0aEBgYCD16tXDwsIClUrFZ599pnOM7O3tWbNmDSdPnuTIkSOcPHmSuXPnsmTJEubPn1/kuIfSGDlyJK+99ppO2bx58wCYMGGCTvnDLVQPS0pKIiAggJycHBYuXEizZs2K3OaSJUtYvnw5np6efPbZZyWOXVS+zMd0re7VAMZ2kOkkhagUhT1s7vx1uJ8H1cwrNh4hKkCZzQXYsGFDEhISaNeuXbGm8KxWrRo9evSgR48ewIP+3RMmTOCHH37g448/NviZghlu4uPj9ZZdvnxZr6zgjvlff+lPaZKUlKQzHuPo0aPcvHmTadOmMWDAAJ26ixYteuz+GKN+/fqA4ZgLygrqXLhwgbi4OPz8/PQeerZ9+3ad98YeH2PVr1+f3377jaysLL2uRZcvX8ba2lo7eLkoDRs25Ndff6Vu3bo0bty4yLoFLRlxcXE6XbQetWfPHvLz81mwYIH22AHk5OTotSrBg2lTO3furJ1F6cKFCwwfPpzly5czf/58oGStT0V9pkmTJnotQgXHsVu3bo9dd1JSEmPGjCE7O5uFCxfSqlWrIusXJOWvv/46//73v8u0NU1UPLcGKqzM4G4hPfDUMqBaiMrTuRlcMND9JiENNv8Gw9wqPiYhylmZ3bby8PBAo9EQEhJicPnDfd8yMjL0lhdcEGVmFj4dWsE0sDExMVy9elVbnpeXx7p16/TqF1yAHj16VKd8z5493Lx5U6fM1NQUQG+MxuHDh3X605eFVq1aUbduXSIiIkhL+3swllqtZu3atahUKu1MVgV36h+N6+LFi0RHR+uUGXt8jNW7d280Gg2rVq3SKT906BCxsbG4ubkV2rLwsIJBx6GhoXotQqB7rri7u2Nubs6yZcu0Yz8eVnBcCvv+VqxYoddSY+j8c3FxoXr16joJZ8EYi6LOyUdZWloaTFpLKzk5mYCAALKysggJCeH5558vsv6yZctYtmwZ/fv3Z9q0acX6XkTVZl1NxSsuhS+/IjNJClF53Ir4m3w+sfBlotIpRryErjJriejbty+enp5s2rSJ8+fP07NnT+zt7UlNTeXUqVNcv36d8PBwAMaPH4+trS0dO3akTp06ZGVlERERgUqleuysNh9++CFjxoxh9OjRDB48WDuFqaGLURcXF7p27crWrVtRFIUWLVoQFxdHdHQ0DRs21BlU26FDBxwcHJg3bx7JycnUrl2buLg4du3aRbNmzbh48WJZHSpMTU2ZMmUKkydP5u2338bLywsrKyv27dvH6dOn8fX11SZAjRs3pkmTJqxZs4bc3FycnZ1JSEhg69atNGvWjHPnzpX4+BjL09OTyMhIVq9eTVJSEp06deLatWts3rwZBwcHnZmWitKmTRv8/f1ZunQpw4YNo2/fvjg6OpKWlsa5c+c4dOgQhw8fBqBOnTpMnDiR2bNn4+Pjg4eHB05OTqSmphITE8O0adNo2bIlvXv3Zt26dXzwwQd4eXlhbm7OkSNHuHjxol7ryMyZM0lNTaVbt244OTlx79499u3bx507d/Dw8NDWa9euHZs2bWLWrFn06NEDMzMz2rZtq9PS8ah27doRHh7OokWLaNy4MSqVCjc3N71Zo4xx584dAgICSEpKYujQoVy9elUnSYQHLRkF/Us3bdrEkiVLqFu3Ll27dmXPnj06dWvVqsWLL75Y4nhE5Rn+vAnhFw13X3zBcA84IURFaFyn8GXu5dNFVojKVqaPNg0KCqJz585s27aNVatWkZeXh4ODA61atdK5wPT29mbfvn1s3bqVzMxM7OzsaNmyJVOmTNF7KNyj2rdvT2hoKCEhIaxevRobGxvtw9R8fHz06s+YMYOvvvqKPXv2sGvXLjp27MjixYv58ssvdUb+29raEhISwoIFC9i4cSP5+fm0atWK+fPnEx4eXqZJBDyYenThwoUsX76ctWvXkpeXh4uLC1OnTtV52JypqSnz589n3rx5REZGkpOTQ9OmTQkODiYuLk4viTD2+BjDzMyMkJAQ7cPmoqKisLW1xd3dnXHjxukNrCqKv78/rVu3ZsOGDaxfv56cnBxq1apF06ZNmTRpkk5db29vGjRowJo1a9iwYQN5eXk4OjrSpUsX7XMnOnTowJw5c/juu+9YvHgxFhYWdO3alaVLl+Ln56ezvv79+xMREcHOnTu5ffs21tbWNGnShNmzZ+Pu7q6t169fP2JjY9m7dy8//fQTGo2GoKCgIpOIcePGkZmZSVhYGFlZWSiKwo4dO0qVRGRmZmoHzW/cuNFgncWLF2uTiD///BN4MFuGocHZnTp1kiTiCTWohQq/drDstP6yOzKTpBCVJ1l/0hMAujSDXm0qNhYhKohKMWaOVSGEEJUqX6PQeFk+1wyM44z0MsGjqXRde5Lk5eWxcuVKAHx9fTE3lwG4T6TPN8G0DfrlmyfDoH9UfDyi2K6q/lPsus6KTFDyMPm1EUKIJ4ipiYoV/zT8pzv6mtwTEqJSGBr3UM0U3pRWX/H0kiRCCCGeMIV1XWrtIDNwCVEpmhnozqtSQV7FPdBUiIomSYQQQjxhNsfqD66uZgrDnpckQohK0d5Fv+yeGv5X+unVRfmSJ1aXnCQRQgjxhDlyQ7+srQNYmMmPnBCVokU9w+V17Ss0DCEqkiQRQgjxBMnIVbh4W7/8pfqSQAhRaTLvGi5PLGTWJiGeApJECCHEE6S6GVgamJz7H/UkiRCi0tS0Nq5ciKeAJBFCCPEEqW6m4qPOugnD87XAq7kkEUJUmjaNYEAX3bIBXR6UiypOZcRLPKxMHzYnhBCi/H3ew5SOtTX8GK/Q1F6FX3sV1WU8hBCVK2wSrI6GYxehc1N4p09lRyREuZIkQgghnkBvtjDhzRaVHYUQQquaOfi98uAlxDNAkgghhBBCCPFMkkd0lpyMiRBCCCGEEEIYRZIIIYQQQgghhFEkiRBCCCGEEEIYRcZECCGEEEKIZ5IiU7eWmLRECCGEEEIIIYwiSYQQQgghhBDCKNKdSQghhBBCPJOkO1PJSRIhhBBCCFEW/roLy/ZBXBK4t4fB3UElF6ni6SRJhBBCCCFEaeWpwW0q/BH/4P3SfXAkDr7xrdSwhCgvMiZCCCGEEKK0dp34O4EoELr7QeuEqLIUVMV+CV2SRAghhBBClNalG/pl99RwJ7fiYxGiAkgSIYQQQghRWvkaw+UJaRUbhxAVRJIIIYQQQojSalLHcPmXWys2DiEqiAysFkKIZ4CiKKhklhghyo+FueHymLMVG4cwilLZATzBpCVCCCGeYrlqhTF787Gan0/Nb9V8/lshXS6EEKUTsstw+V93H8zcJMRTRpIIIYR4CuWqFbZf0PDm9nyWnlLIVUPGPZh2SMP6c5JICFHmUjIMl2sUOH+9QkMRoiJIEiGEEE+ZKxkKLZbn4xWuYXe8/vLtF6UBX4gy51y78GU7jldcHMJIKiNe4mFVOokIDg6mc+fOxaqblJRE586dWbJkSTlH9YAxsfn7++Pp6VnOERXN2OMTGxvL2LFj6dOnT4UeVyFE6X1+WMO1rMKXN7CpuFiEeGb0alP4srPXKi4OISqIDKwWetRqNVOmTEGtVhMQEICtrS3Nmzev7LAqXHR0NLGxsYwZM6bYn1m3bh22trZlnjSeOXOG3bt3c+7cOS5cuEBOTg5BQUGFbicjI4PVq1dz4MABbty4gY2NDY0bN8bHx4fevXuXaWyi6jmbVnhLQ41q8H6nKn3/SIgnUwunyo5AiApVpX9Jpk6dyqFDhyo7jGdOYmIiiYmJvPXWWwwdOpT+/fs/s0nEsmXLjPrM+vXriYiIKPNYDh06RFhYGNnZ2Y/9LnJzcxk1ahSbNm3ixRdfZPLkyQwbNoxbt24xadIkNm/eXObxiaqlUY3Cl0UNNcHZTprlhShzPZ6HwmZAa9eoYmMRxSZPrC65UrdE5Ofnk5eXR/Xq1csiHh1mZmaYmUljSUW7desWAHZ2dmW6XkVRyMnJwcrKqkzX+yTz9/cHYOnSpUXW8/b2ZuTIkVhaWrJ//35OnTpVaN3o6GgSEhKYOHEib731lrb8zTffpH///mzduhVvb++y2QFRJcWmF76ssSQQQpS9tL9g25EH3eYNNQT+8id8OqiioxKiXBl1hR4REcH06dMJDQ3l9OnTREREcOPGDaZOnYqnpyeKorBlyxa2b9/OlStXMDExoXXr1vj5+emNH4iMjGTTpk0kJCSgVqtxcHCgXbt2TJw4kZo1awIPxh1ERkZy/LjugKTff/+dBQsWEBsbi7W1Ne7u7gwapP+fsyDexYsX623f39+f5ORknbvGhw8fJjw8nD///JO0tDTMzc1p06YNo0aNwtXV1ZhDVSwnTpzgu+++4+zZs6jValxcXBg8eDADBw7UqXfmzBk2b97MqVOnSElJwdTUlGbNmvH/2LvzuKjK/YHjn5lhFRAUUXEDxS3XFJcyI03NhexqklpXLSwVTcuyrF+Z2/Xea3avV01zyyUrd3PBLU0Rl8x9T3FXRBARQZYBZjm/P4iBcWbYUZTv+/Wal84zzznPc84MM+d7nm3gwIF07NjRYr/5PT/WDB06lOPHjwMwadIkJk2aBMCmTZuoVq0aWq2WRYsWsXPnTmJjYylfvjxt27Zl+PDheHtnN+UePXqUkJAQJkyYgFarZc2aNdy6dYt33nnH1D1ox44drFq1ikuXLmEwGEzH1LlzZ4t6HT16lB9//JGzZ8+i1Wrx8vLC39+fDz74AA8PDwDWrFnDnj17uHr1Kvfv38fd3Z02bdowfPhwqlWrZra//fv3s2zZMq5cuUJaWhoeHh40atSIkSNH4uPjY3Yecn52cutClJUvOjrabJusc1cUnp6e+c6bkpICgJeXl1m6q6srzs7OJRLwi9IjMV3hTC4L5G67ZuStZzSPrkJCPO0OXYQukyBJazvPTts3foR4UhXqNv/MmTPR6/X07t0bFxcXfHx8ABg/fjy//vornTp1omfPnuh0OrZt28b777/PtGnTeOmllwDYsmULEydOpEWLFoSEhODo6MidO3c4cOAA8fHxpiDCmrNnzzJixAjKlSvHoEGDcHNzY8eOHUyYMKEwh2ImNDSUxMREevToQZUqVYiNjWXjxo2MGDGCefPm0aJFiyKXkWXv3r18+umneHp6MmDAAMqVK8eOHTuYMmUKUVFRvP/++6a8e/bs4fr163Tu3Blvb28SExPZvHkzn376KVOmTKFbt26mvEU9P4MHD6Z58+YsWbKE3r17m465QoUK6PV6Ro4cyalTp+jUqRMDBgzg5s2brFu3jkOHDrFs2TKqVDFfsXPFihUkJibSq1cvPD09Ta9/9913LF68mHbt2hESEoJarSYsLIzPP/+csWPH0rdvX9M+1q1bx9SpU6lcuTJ9+vTB29ubmJgY9u3bx507d0xBxE8//USTJk3o168f7u7uXLlyhQ0bNnDkyBFWrlxpynfs2DE+/vhj/Pz8CA4OxtXVlbi4OA4fPkxkZCQ+Pj4MHjwYRVE4ceIEkydPNtWlWbNmNs/d5MmTmT59Oh4eHgwePNiUntvnuSS0bt0ajUbD7NmzcXJyol69eiQlJfHzzz+TlJRkVjfx9HGxB08nuJdm/fUjMQpvPfNo6yTEU+3L5bkHEAAVZTYD8RRSCmDTpk2Kv7+/0rt3b0Wr1Zq9tnv3bsXf319Zt26dWbpOp1MGDBig9OzZUzEajYqiKMonn3yiBAQEKDqdLtfyJkyYoPj7+5ulBQcHK23btlWuX79uSsvIyFAGDhyo+Pv7K/PmzbOo75EjRyz2PWTIEOXVV181S0tNTbXIFxcXp7z88svKqFGj8qybLQ+XpdfrlcDAQOWll15SYmNjzY4jODhYad26tXLjxo1c66XVapXevXsrQUFBZukFOT+2HDlyRPH391c2bdpklv7LL78o/v7+yowZM8zS9+3bp/j7+yvjxo2z2EfHjh2Ve/fumeU/f/684u/vr8yePdui7I8//lgJCAhQkpOTFUVRlJiYGOW5555TgoKClAcPHljkNxgMpv9bO0+HDh1S/P39laVLl5rS/vvf/yr+/v4W9XpYQd7jLK+++qoyZMiQfOcfMmRIgfIriqLs3LnT6vuT065du5QePXoo/v7+pscrr7yinDhxokBllbR79+4paWlppudJSUlm73N6eroSFxdnts3t27dzfR4dHW36rimrZXwerlf4Rmf14bdAVyxlPIrjKAtlZGRkKPPnz1fmz5+v3Lp164k9jjJdRs0hikLv3B+BU0r/cZTyMkrKBf6b74cwV6iB1UFBQRZdIrZu3YqLiwsdOnQgISHB9EhOTubFF1/k9u3b3Lx5E8jsVpGWlsb+/ftRlPzPVx4fH8/p06d56aWXTK0fAPb29rz11luFORQzzs7Opv+npqaSkJCARqOhSZMmnDtXfMvWnz9/npiYGF577TWzLif29vYMGjQIo9FIeHi41XqlpaWRkJBAWloarVu35tq1ayQnJwMlf37CwsJQq9UEBwebpbdv35769euzd+9ejEbzRawCAwOpWLGiWdq2bdtQqVQEBgaafVYSEhIICAggJSWFM2fOAPDbb7+h0+kYMmQIbm5uFnVSq7M/wlnnyWg0kpycTEJCAvXr18fV1ZWzZ8+a8rm6Zt4R2r17N3r9o1tFNOszlfOh1+vR6/UW6ampqUUqy83Njbp16zJ06FD+85//8Nlnn+Hk5MSYMWO4ePFiMR1R0VWsWBFHR0fTc1dXV7P32cHBwaIrV85uc9aeV61aFVWOwY1lsYznc5kk5moi3E1VnojjKGtlVK5c+ak4jjJXRmfbLdQmTWqV/uMo5WWI0qdQ3Zlq1bKcZeD69eukpKTwyiuv2NwuPj4eHx8fgoODOX78OJ988gnu7u60bNmSF154gS5duuDi4mJz+6ioKAB8fX0tXqtTp07BD+Qht27dYs6cOfzxxx8kJZlPsq6yNeNCIdy+fRuwXmc/Pz8g+1gh87zNnTuX8PBw4uMtR0wmJyfj6upa4ufn9u3beHl5Ub685dQvfn5+XLx4kYSEBLOgwdpn5dq1ayiKkuvg3qzB3ZGRmXNrN2jQIM/6HTlyhIULF3Lu3DnS09PNXsv5fvbt25fw8HCmTp3Kt99+S/PmzWnXrh1du3Yt0a5H06ZNY/PmzVZfe3gcyKuvvsrEiRMLVc7Bgwf58MMPmTFjBu3atTOld+zYkaCgIL7++msWLVpUqH2LJ4ODna3RnbYnjxFCFNI3b0NUPOw4aTuPzM4knkKFCiKsDcxUFIUKFSowZcoUm9tlXSDXqlWLNWvWcPjwYY4cOcLx48eZMmUK8+fPZ+HChdSoUaMw1bKQ24W/wWAwe56amsqQIUPQarW8+eab1K1bFxcXF1QqFUuXLuXIkSPFUqeCUhSFkSNHcu3aNfr370+jRo1wdXVFrVYTGhrK9u3bLe7+lya2BvGqVCpmzZpl1pKQU9ZnJb/OnTvHyJEjqVGjBiNHjqRatWo4OjqiUqn44osvzM6Rh4cHy5Yt48SJExw6dIgTJ04wffp05s+fz8yZM3Md91AUgwYNonv37mZpM2bMAGD06NFm6Q8Pii6IH374AWdnZ7MAAqBSpUq0aNGC33//HZ1Oh729faHLEKVbqyq2X/ubnwqvchJJCFFsPN3g1/FwKAKe+z/reYyySnxpJe9M4RXb/Kk1a9bk5s2bNG3aNF9TeDo4ONC+fXvat28PZM6WM3r0aH7++Wc+++wzq9tkzXBz/fp1i9euXr1qkZZ1x/zBgwcWr92+fdts+tjDhw9z9+5dxo8fz2uvvWaWd+7cuXkeT0FUr14dsF7nrLSsPJcuXeLixYsMGTLEYtGzDRs2mD0v6PkpqOrVq3Pw4EGSkpIsuhZdvXoVFxcX0+Dl3NSsWZPff/+dqlWrUrt27VzzZrVkXLx40ayL1sO2b9+OwWBg1qxZpnMHoNVqLVqVADQaDa1atTLNonTp0iUGDBjAokWLmDlzJlC41qfctqlTp45Fi1DWeWzbtm2By7IlNjYWo9GIoigW9TEYDBgMhlIdeIqiq+Ckws0BkjIsX3uxeO7RCCEeViWXluxJq2Fgh0dWFSEehWJbbC4wMBCj0cjs2bOtvp7VPQUyV9N9WMOGDQFITEy0WUbWNLDh4eHcuHHDlK7T6Vi+fLlF/qwL0MOHD5ulb9++nbt375qlaTSZUx4+PEbjjz/+MOtPXxwaNmxI1apVCQ0NJS4uey5GvV7Pjz/+iEqlMs1klXWn/uF6Xb58mT179pilFfT8FFSHDh0wGo0sXbrULP3AgQNEREQQEBBgs2Uhpx49egAwZ84cixYhMP+sdOrUCXt7exYuXGga+5FT1nmx9f4tXrzY4oLZ2ufP19cXJycns4Aza4xFbp/Jhzk7O1sNWh+lOnXqoNVq+e2338zSo6KiOH78OHXr1jXrqyqePhq1ilkvWw9ooyz/jIQQxWHnKduvXbvz6OohxCNSbC0RnTt3pmfPnqxevZoLFy7w4osv4uHhQWxsLKdPn+bWrVts3LgRgPfffx83NzdatGhBlSpVSEpKIjQ0FJVKZbrAtOWjjz5i2LBhvPvuu7zxxhumKUytXYz6+vrSpk0bfvnlFxRFoX79+ly8eJE9e/ZQs2ZNs0G1zz77LJ6ensyYMYPo6GgqV67MxYsX2bp1K3Xr1uXy5cvFdarQaDSMHTuWTz/9lLfffpvevXtTrlw5du7cyZkzZwgODjYFQLVr16ZOnTosW7aMtLQ0fHx8uHnzJr/88gt169bl/PnzhT4/BdWzZ082b97MDz/8wO3bt2nZsiWRkZGsXbsWT09Ps2lpc9O4cWOGDh3KggULeOutt+jcuTNeXl7ExcVx/vx5Dhw4wB9//AFAlSpVGDNmDF9//TX9+/cnMDAQb29vYmNjCQ8PZ/z48TRo0IAOHTqwfPlyPvzwQ3r37o29vT2HDh3i8uXLFq0jU6ZMITY2lrZt2+Lt7U16ejo7d+4kJSWFwMBAU76mTZuyevVqpk6dSvv27bGzs6NJkyZmLR0Pa9q0KRs3bmTu3LnUrl0blUpFQECA2eD4woiOjmbLli1AdqvS3r17uXMn84cp67wABAcHc/DgQb766iuOHTtG/fr1iY2NZe3atWRkZOT7fRJPtneaaFh5Qc+v183Te9SRrkxClIjwXG44NvN9ZNUQ4lEp1uWgJ0yYQKtWrVi/fj1Lly5Fp9Ph6elJw4YNzS5cgoKC2LlzJ7/88guJiYm4u7vToEEDxo4da7Eo3MOaNWvGnDlzmD17Nj/88AOurq6mxdT69+9vkX/y5Ml88803bN++na1bt9KiRQvmzZvHv//9b6Kjo0353NzcmD17NrNmzWLVqlUYDAYaNmzIzJkz2bhxY7EGEQABAQF89913LFq0iB9//BGdToevry/jxo0zW2xOo9Ewc+ZMZsyYwebNm9Fqtfj5+TFx4kQuXrxoEUQU9PwUhJ2dHbNnzzYtNhcWFoabmxudOnVixIgRVK1aNd/7Gjp0KI0aNWLlypWsWLECrVZLxYoV8fPz45NPPjHLGxQURI0aNVi2bBkrV65Ep9Ph5eVF69atTetOPPvss0ybNo3vv/+eefPm4ejoSJs2bViwYAFDhgwx21+PHj0IDQ1ly5Yt3L9/HxcXF+rUqcPXX39Np06dTPm6du1KREQEO3bsYNeuXRiNRiZMmJBrEDFixAgSExNZs2YNSUlJKIrCpk2bihxEREVFMW/ePLO0sLAwwsLCTMefFUQ0btyYRYsWsXjxYnbv3s369espV64cTZo04e23387zb0w8PZZ11/DOdiPbryl4OMGXbdW8XKvYGqCFEDk5Odh+bViXR1cPUSAKcmOlsFRKQeZYFUII8cRJyVBwtAM7tfxYljY6nY4lS5YAma2IMuHBE+zoZWgz1nKkrqMd3P8RnKUbaWl0XvW/fOd9RvmoBGvy5JFbUkII8ZRzcVBJACFESWtVF8pbmVimYQ0JIMRTqVi7MwkhhBBClFlpOsu0OrnMuSweO+nOVHjSEiGEEEIIUVTxSZBuJYioXtEyTYingAQRQgghhBBF5WCX+XjYC888+roI8QhIECGEEEIIUVSuzjC8q3laPW/4W+vHUx+RL0oBHsKcjIkQQgghhCgO04OhRR349WRmADGyuwyqFk8tCSKEEEIIIYqDWg1vd8x8CPGUk+5MQgghhBBCiAKRlgghhBBCCFEmyRSvhSctEUIIIYQQQogCkSBCCCGEEEIIUSDSnUkIIYQQQpRJ0p2p8KQlQgghhBBCCFEgEkQIIYQQQgghCkSCCCGEEEIIIUSByJgIIYQQQghRJimPuwJPMGmJEEIIIYQQQhSIBBFCCCGEEEKIApHuTEIIIYQQokySKV4LT1oihBCiDDMYFeJSjChK6e4ZnKo1kp5ufNzVEKJsS0iBtIzHXQtRSkhLhBBClFGbz+sZsSGNyESFBl5qlgQ58byP5nFXy0xampHvvr/H4WOp2Gmgc0c3Br1ZAbVa7h4K8cjcTYQBM2HHSXBxgk//BhP6Pe5aicdMWiKEEKIMik9V6LtcS2RiZgtExF0jfX7SojOUrhaJ1esTOHQ0FUUBnR627UwibF/y466WEGXLh4szAwiAlDSYuAo2H32sVSouCqp8P4Q5CSKEEKIM2ndNj1ZnnhadpHA6unR1GTp5Js0i7ZSVNCFECdp+In9pokyRIEIIIcqgOp6WX//2GqjpUbrutlXxsux1W6Wy9MQV4pHyq2Ilreqjr4coVSSIEEKIp8SNBCNJ6fnrjtS0qoZ3/M0vxv+vgwOVXfP+WVAUhWv3DGgzSr7r0xu93XF2zg5svDw1dO/iVuLlJsRmkJZiKPFyROljTMlAfz3hcVejZOn0cDU289/8+PcAcMjxfdGkFgx+uWTqJp4YcjtHCCGecFfijQStyuBkjIKzPXz2gh0TOtrnus0fNw2EX8u8SHaygzEvOjCpi2OeZR29qaf/smSuxBlxd1Ix7TVnhrZzKpbjsKZGNXueqe/E8VNaAHxqOeDqUnL3vxLuZrBy6jUiI1Kxs1fx/GtedAuuXmLlidIlafpBkiaEoyRnYPdMJSquDsK+SeXHXa3iFXochiyCO4lQ1R2+fw8CW+S+zW+nMQ0J8KsKv4wFd5cSr+qjULpGgT1ZpCWiFDp69CitWrUiNDT0sdUhIiKC4cOH07FjR1q1asX8+fMfW12EELkbsknHyZjMn0KtDibu0RN2zfZddKNR4c0VWq7FZ26Tpod/78ngenzu4yEUReHNvwIIgMQ0hZA1qVy+W3J37DdufWAKIACOntCyccuDEisvdN4tIiNSAdDrFPati+X8ocQSK0+UHhknonkwZidKcuYUpvrzcdwftOHxVqq4PUiFv3+XGUAAxCTCm3MgOZdxRqFH4Ov1kP5Xq8WVGBiztMSrKko/aYkQFvR6PWPHjkWv1xMSEoKbmxv16tV73NV65Pbs2UNERATDhg3L9zbLly/Hzc2Nnj17Fmtdzp49y7Zt2zh//jyXLl1Cq9UyYcIEq+VMnDiRzZs329xXzZo1Wb9+fbHWTzw+RqNC2DXLi//dV410rG19utYr8QrX75vffzMqEH7NgG9F2/eWbt43cjnOvCxFgbDLOup6lczUsGf/tLy4OXs+jTd6l0hxXD2VZDXtmbbuJVOgKDXSd1+3SNOdiMGYkIbao+Ra2x6pI1ch6aG/qaS0zPSOjaxvs+u0Zdrus8VfN/HEkSCiFGrZsiUHDhzAzu7xvD1RUVFERUUxevRo+vUru/NA79mzh82bNxcoiFixYgXe3t7FHkQcOHCANWvW4OvrS7169Th92sqX+l9ef/112rRpY5F+5MgRQkNDefHFF4u1buLxUqtVNKikIiLOPCh4xsv2AOnq5VWUd4QH6ebpz1TOvXG6ipuaCuVU3E99qKwqJbe2RPVq9ly4mG6RVlK8ajoRdSnVIk08/ewbelqkqau7oXJzeAy1KSH1vUGtyrxrkEWjhnpWBk5neaaGlbSnp4ufTN1aeNKdqRRJSUkBQK1W4+joiEbzeBZ9unfvHgDu7sV7501RFFJTU/POWIYMHTqUoUOH5pkvKCiI8PBwVq9ezVtvvZVr3mbNmtGjRw+Lx927dwH429/+Vix1f5ql6xVOxSokphk5F6cQnZz/XrNXE4ysjTCSnFG4qVJvJiocvm3k1B1jvtdsmNbFDvscXxcv+agJamT7+6Ocg4ppPRxR5fjt7NNYQ5uauX/nONmr+LSjEznXeXvL34H2dfJ3Ua83KJy+nM6pS+no9Pk7tt6vulOxQna9PCtq6P1qybUKdB9cDQen7J/Gmg3K8WzHiiVWnig5isFI+ulY0s/EknH+Xp75HbvXw+m1+tkJGhXu019BpcnfpZKSpkN/KholOT3vzDm3Mxoxnr2N8c4DjOeiMUbnv/uccvEOyo28j82kpieMfMU87YvXoIZlAGUyqAM83yD7uYsTfPN2/ssUTy1piSgmoaGhTJo0iTlz5nDy5ElCQ0O5d+8ePj4+BAcH07VrV7P8PXv2xNvbm48//pjZs2dz5swZ3N3d2bRpE0ePHiUkJMSiu4qiKGzYsIENGzZw9epVAKpVq0bHjh0JCQkx5cvIyOCnn35i+/bt3Lp1CwcHB1q0aMGwYcNo2LBhrscxdOhQjh8/DsCkSZOYNGkSAJs2baJatWpotVoWLVrEzp07iY2NpXz58rRt25bhw4fj7e1t2k/OY9BqtaxZs4Zbt27xzjvvmO7s79ixg1WrVnHp0iUMBgN169Zl4MCBdO7c2aJeR48e5ccff+Ts2bNotVq8vLzw9/fngw8+wMPDA4A1a9awZ88erl69yv3793F3d6dNmzYMHz6catWqme1v//79LFu2jCtXrpCWloaHhweNGjVi5MiR+Pj4mJ2HVq1ambaz1YUoZ77o6GizbbLOXVF4eubyBZ8P0dHRHD58mKZNm+Ln51ekfT3tdlw3MmCLkbvazHGECpk37oY0U/FdZzVqle27VoHr9Gy9lvl/tQq+CVD4uHX+bgak6xUGbNKz9kL2xXUVF1j7uh3ta9q+iNl2ycC7G3XocgxLOHrbyM9nDAS3sP0VP6ytAy2raXhrpZbL9xTWnTPw+o9aVrzphKOd5THGpxjpvTiZvVcy+0U3r6bhf73K0bF+/gKIU5cy+GxOPClpmcfn7KjiXyEVaPVM7oO5Iy6lk6rNPDhHBxVvBXngVankfrqq1ytHzYYuXDmZ2a3JzkGNQW9E7rk9WdJP3CG69wb0N7LHzzi2qIx36OvYVbc+u5dKrcLe35u0bZdBZ0RdxRW72h75Ki9j05+kBK9FideCqwMus3riGNwqz+2Mf8aQ9reFKJfjshPVKuzeex6HuW+gUlv/3ClxSRh6fYdy4Epm3Xs9i2bFEFROufw9Go0wcC4sP5id1r4+jOuVeyXtNFDLCw5GZD6vWxUaFO03TTwdJIgoZt9++y1arZagoCAgM7j48ssvycjIsLj4vHPnDsOHD6dz5868/PLLed6lHz9+PNu2baNJkyYMHjwYNzc3rl+/zq5du0xBhF6vZ9SoUZw+fZoePXrQt29fkpOTWb9+Pe+++y4LFy6kUSMb/R6BwYMH07x5c5YsWULv3r1p0SJzxoYKFSqg1+sZOXIkp06dolOnTgwYMICbN2+ybt06Dh06xLJly6hSxbxJdMWKFSQmJtKrVy88PT1Nr3/33XcsXryYdu3aERISglqtJiwsjM8//5yxY8fSt29f0z7WrVvH1KlTqVy5Mn369MHb25uYmBj27dvHnTt3TEHETz/9RJMmTejXrx/u7u5cuXKFDRs2cOTIEVauXGnKd+zYMT7++GP8/PwIDg7G1dWVuLg4Dh8+TGRkJD4+PgwePBhFUThx4gSTJ0821aVZs2Y2z93kyZOZPn06Hh4eDB482JReoUKFXN/XR2HTpk0YjUZphchDhkFh4NbMAAKyZ+0wKjD/lMLLNRX6NrQeRKyOMJoCiKxtPt2r8G4zBXfHvJvL5x43mgUQAHdSYOAmPVdG2FsNXtL1CoN+ySDuoa+OFB0MC9XRva6Gqm62y150VMfle9llrj+nZ/bvOsYEWHbfmLhdawogAE7dNnDwhj5fQYTRqDBp0X1TAAGgTVeY+P19Nkyrgp3Geh2Tkg3MW3wP3V+L4qVnKCxcFo9/i3I4O5fMRf3+9bGmAALg2plkwlbG0OM9K106RKl1Z/B2swACIP1ELHFj9lB1pfUbQRmHo0iaEG56brydxP13NlHl3PBcy1JSM0h5ew1Kwl9jDZIzSBm2AfseDVBXyX064vShK80DCACjgn7B72heroddv5ZWtzN+tckUQAAoG05inB2G5pNXrOYHYMVB8wACYP9FmLcLPuhqfRuARbtg1f7s56euw6fL4KfRtrd5okh3psKSIKKYJSQksHLlSlxdXYHMbij9+/fnf//7H126dMHJKbtvbVRUFOPGjaNXr1557nfnzp1s27aN7t27M2nSJNQ57k4YjdndJlatWsWxY8f49ttvef75503pQUFB9OvXjxkzZrBgwQKb5Tz33HPY2dmxZMkSU7eYLOvXr+fUqVMMHDiQDz/80JTetm1bRo8ezezZs/nHP/5htr+YmBjWrl1LxYrZ3QEuXLjA4sWLCQ4O5v333zel9+/fnzFjxjBnzhwCAwNxcXHhzp07/Oc//8HX15fFixfj5pb9hTx8+HCzY1+5ciXOzs5m5QcEBDBixAg2btzI229nNr+Gh4djNBqZM2eOWb3ee+89s/Owfft2Tpw4YXYOctOjRw/mzp1LxYoV873No2A0GgkNDaVcuXK88kouPzCCS/chNpdYfl+UQl8bjXkbL1l2XzIqcPyOQsdaef9I7Y+03v3peiJEJUHN8pavXYhTLAKILDoDHIoy8reGtltC9l+3nFVp33UDYwKs5L1mOZ/8/qv5m2P+boKRuwmWx5eYonArVo+vt/VA5Or1DHQ688AqLU3h2s0MGjUomXEK18+l5CtNlF7G5AwyTsZafU27/5bN7dL337RI0/95F2O8FnVFZytbZDKcvZMdQGTRGdAfisThNds37RRFwXjgms3XDfuu2g4i9l+y3N++S5BbELH/oo30iNyDiP3n85cmyhxpny1mQUFBpgACwNXVlT59+vDgwQOOHTtmltfd3T3fA3C3bdsGwOjRo80CCMDs+bZt2/D19eWZZ54hISHB9NDr9bRt25ZTp06RlpbLVG65CAsLQ61WExwcbJbevn176tevz969e80u6gECAwPNLtSz6qhSqQgMDDSrY0JCAgEBAaSkpHDmzBkAfvvtN3Q6HUOGDDELIKwde1YAYTQaSU5OJiEhgfr16+Pq6srZs9kzSWS9P7t370avz+dCO8UgNTXV4nj1ej16vd4ivTjHjhw6dIiYmBi6dOlCuXLlim2/xSE+Pp709Oz+w8nJySQlZd8FzsjIMI3RyRIdHZ3r85iYGBQl+8KzIGX4lIfcxlA2+2uwsrUy2laxHgQ846nK13H4Olu/UPUql9mtydpxVLJLwcVGfVUqqIz5Hc6Hy6znnmGxXSOv7OPIea6aelsGI029Nfl6Pyq4qXAtZxlIOTuCq2OazfejRjV7Hu7NYWcHdup4izIK+54/XO+qvpbBSdXazsVahq3nsbGxJV7GoziOx12GysUeTW0rUTfg2NTL5j6TqlneV9XULI/qr5mZbB2Hul6lzMVWclKp0DSpmutxqFQqDA29sEXdrJrNc6VqatkypmpWw+pxmc6VlW0A0htUyf39aFrLYpu0hwZiP4r3XJQ+0hJRzHx9fS3SateuDWS2PORUvXr1fA+ejoyMpFKlSnn2jb927Rrp6elWxxVkSUhIoGrVgi9Xf/v2bby8vChf3vLL2c/Pj4sXL5KQkGAWNNSqZfnlc+3aNRRFMXX5sibryyUyMhKABg0a2Myb5ciRIyxcuJBz586ZfXkBZl9effv2JTw8nKlTp/Ltt9/SvHlz2rVrR9euXUu069G0adNsTr368Pv16quvMnHixGIpd+PGjQD5avF61B4OMHMG4AAODg4Wn/mcY2+sPX/4s12QMlwdVPyvo5qQnUb0D8UEL9dSMbCRymYZIzwUvjtjICLH9e3QZiqquqiAvI/jy47u7I7Wc+JO9g+xvRq+fUWDg0Zl9ThcXWF6Vz0jNuvIOQZbpYIvXrTj+YbmP/QPl/nNa+4cXZjKrcTMjZtVVfPJS9mBZs5zNbGbM+GX9dy4n3liGlfV8MnLTni5mgemtt6PMW+684/FCaZJYVTA6H7uVKpovn3O98Ozoh1v9PJg9foEFCXzuPr3qUD9eubfQUV5zx+ud0CfKlw8lsTdyMybLRWqOPBy/6p4VDaP1orrs6vL6qsFVK5cGVWObmul7e/jSSlDpVJReU4XYoI2oqRm3yhSeznj+XV2M5tFGf1acX/zLbQ/Z97EwskO99ndUf01k0Bux1Hum+6kfrg5s/lRpcLpyw5o6lTEvATLMl3m9iOt50J4aDC2umM97Aa1xv6hMQ5Z50qZ/Br6fZfg1v3MF5rVQP1RZ6tlmM5V8EuwZC8czdH60bAajmNexdEte+E4i/djeDdY9wccuZz5vFJ5nGZkt9yblfGXknjPRekjQcRjlLNrU3GqW7cuH330kc3XH2UffVvHqFKpmDVrlkWrSpaCDv49d+4cI0eOpEaNGowcOZJq1arh6OiISqXiiy++MGsh8fDwYNmyZZw4cYJDhw5x4sQJpk+fzvz585k5c2au4x6KYtCgQXTv3t0sbcaMGUBmC1NOXl62704VREJCAuHh4fj5+dG0adNi2efT7t2marr5qvj9toJveYhKhkrOKtrXyL1Lkp1axYXBdqy9aOSP2woDG6lonseUqTlVcFZxdLAdYdcV/oxTqOgMnX3VVHHNvdyXfNVUKw+Rf03o0q6mmgU97Wicj2lX7dRQLsc1Si0PbLZs1PbUcPFLd3ZG6HCwU/FyPTs06vz3Je7c2pmWDRzYeViL0Qhd2jhTySPvOnZ40YW9vycTHaNHUeD0WS1dXnbFybFkGtJdK9gzanZDrp5KwmhQ8HvWDTt7abR/0rh0r4NvZAipu29iuKfFrqoL5br4oi5newyPSqXCsaMv2rV/QroBUDDGa23mz8lpZDvsez6D4fAtNM2roqmfv+9wTYd6lIuciGH3JfBwhgdpqCq5oGmf+2+gqm5l7C5PQdl5HpzsUHVsmPcsUs4OcHgy7DoHYX9Cu3rQvTkWzX0PK18OvgyCv/8PUtIhMQVCj0Jjy5uETyKZ4rXwJIgoZtevX7dIu3YtM+qvXr3w8yrXqlWL8PBw7t27l2trRM2aNbl//z6tW7e2eYFeWNWrV+fgwYMkJSVZdC26evUqLi4upsHLualZsya///47VatWNbXS2JLVknHx4kV8fHxs5tu+fTsGg4FZs2aZnWetVmvWCpFFo9HQqlUr0yxKly5dYsCAASxatIiZM2cCmN0RzK/ctqlTpw516tQxS8s6j23bti1wWfmxZcsWdDqdDKguoOpuKt5okPleti7gtkH11QTVzzufNWqVik61VXTK/c/CzIfbdKYAAuD3SCPHohUa5zLte5ax29K5mGN9ic0XjCw8rGNkO+uRhIOdisDGhZ8zv2J5Df06u+adMYdVvyQQHZN9N/n0uTS270yiVwlO86rRqKjX0np3GPHk0FR0xi0o71bsLIa4VBLe3/pXAAGkGUgcsRXn1xrkOibCVJ5PBTQ+Bb9Jp/Ioh93rzQu+naM9qlcLeNNLpYLOTTIf+ZWugyHfZQYQkDng6ouf4fXnoL7M0lSWye2VYrZ27VqSk5NNz5OTk1m3bh1ubm74+/sXer9Zd7BnzZplMe4gZz/EwMBA7t27x88//2x1Pw/3QSyIDh06YDQaWbp0qVn6gQMHiIiIICAgIF+BS9ag4zlz5mAwWA7szFnHTp06YW9vz8KFC83Oa5asY8/qFpbzXAAsXrzY4nwlJCRY7MfX1xcnJycePMiezSNrjEViYv7n7HZ2djbbx+O2ceNG7O3tS9VAb1G8/rhlORbjkJU0q9vetPz7OxRpmfY4XbpiOW7j8tWCzcMvRH7oTsZkBxB/UbR6dKdiHlONSomrd+DuQ79rigKHLQd3i7JFWiKKmYeHB2+//bZpwHRoaCgxMTGMGzeuSN2XOnfuTJcuXdiyZQuRkZEEBATg5ubGzZs3OXjwIKtXrwbgzTff5NChQ8ycOZMjR47QunVrXFxciImJ4ciRIzg4ODB//vxC1aFnz55s3ryZH374gdu3b9OyZUsiIyNZu3Ytnp6eZjMt5aZx48YMHTqUBQsW8NZbb9G5c2e8vLyIi4vj/PnzHDhwgD/++AOAKlWqMGbMGL7++mv69+9PYGAg3t7exMbGEh4ezvjx42nQoAEdOnRg+fLlfPjhh/Tu3Rt7e3sOHTrE5cuXLVpHpkyZQmxsLG3btsXb25v09HR27txJSkoKgYGBpnxNmzZl9erVTJ06lfbt22NnZ0eTJk1ybVFq2rQpGzduZO7cudSuXRuVSkVAQIDFrFEFFR0dzZYtWwBMa4Ts3buXO3fuAJjOS05nz57l6tWrdOnSJV8tROLJ5O+tZvc186ChpXf+7g/5V9cQmWg+uUDLao9nkUtb6vg4EHVbZ5ZW2+cpWkFYlBr2TStnDkTS5fh7ctRg16Ty46tUaVC7MlR0hfiHbuS1rGM9/xMm/0uJiodJEFHMRo0axcmTJ1mzZg3x8fHUqlWLKVOm0K1btyLv+5///CctWrRg48aNLFy4EI1GQ7Vq1cwG5drZ2TFjxgzWrl3L1q1bTQGDl5cXjRs35tVXXy10+XZ2dsyePdu02FxYWBhubm506tSJESNGFGiw9tChQ2nUqBErV65kxYoVaLVaKlasiJ+fH5988olZ3qCgIGrUqMGyZctYuXIlOp0OLy8vWrdubVp34tlnn2XatGl8//33zJs3D0dHR9q0acOCBQsYMmSI2f569OhBaGgoW7Zs4f79+7i4uFCnTh2+/vprOnXqZMrXtWtXIiIi2LFjB7t27cJoNDJhwoRcg4gRI0aQmJjImjVrSEpKQlEUNm3aVOQgIioqinnz5pmlhYWFERYWZjr+h4OIrAHV0pXp6Tajuz3dfkzn9l+99no2UDOwef4CgWk9HDkZbeD6/cyf0Zf9NAxrm7/F4x6Vfn08uHw1neg7mcFOzRr2dOuS+9z7QhSGpoor7tNfIfHjHZmBhL0a9+mvoPFyyXvjp5mTA8wLgbdngTYjcwzFl32gUc3HXTPxmKmUh/t/iELJWrF63rx5ZqsVCyFEScvQK+y/acSznIrmVQvWS1VvUNh/3YCbowr/GqWrFSJL7F0dE/51h/j7mV1N/Go78OUnVXBxefJ75Op0OpYsWQJAcHAw9valK4griwwxyehOxmDfoiqaKgUbw/NUu5+c2YWpYXXweXpaZ46q5uY7bysl94UHyxppiRBCiCecg52Kl+sULgCw06jo4Fe6fwrWbkw0BRAAV65lsOXXB/R93ePxVUo8tTRVXdF0q/u4q1H6VHCFri0edy1EKVK6fzmEEEKUedduWA6utpYmhBAFJVO8Ft6T3xYshBDiqVbPzzFfaUIIIR4daYkoJj179jTNyCSEEKL49O3twbXrGVy9ntn60KyxEz26yuBqIYR4nCSIEEIIUap5uGv490Rvrt/IwM4OalSXKV6FEMVDZhcqPAkihBBCPBF8ZX0IIYQoNWRMhBBCCCGEEKJApCVCCCGEEEKUSUaZnanQpCVCCCGEEEIIUSASRAghhBBCCCEKRIIIIYQQQgghRIHImAghhBBCCFEmyYrVhSctEUIIIYQQQogCkSBCCCGEEEIIUSDSnUkIIYQQQpRJsmJ14UlLhBBCCCGEEKJAJIgQQgghhBBCFIgEEUIIIYQQQogCkTERQgghhBCiTJIpXgtPWiKEEEIIIYQQBSJBhBBClBJ3kowMXqul/n+S6fOTloi7xsddJSGEEMIq6c4khBClxGvLtBy+lRk4XLqn51CkgcufuOBkL83tQghREqQ7U+FJS4QQQpQC52MNpgAiS9QDhV1XDI+pRkIIIYRtEkQIIUQpUM5Ga4OLwyOuiBBCCJEPEkQIIUQp4FNBTVAT8x6m/tXVBPhqHlONhBDi6acU4CHMSRAhhHjq3U9TGLzdgPdcPe2W6wm7mb8By3qjwlfhenxmZ9B4gY6lp/PXtUirU/hoWwY1/qul5bw0fvkz7+1SMhQqlYPyTlDBGQY8a8eu98qhVpdcf90NB1J5Y3IcPcfdZcGWZAxG+Zl8lIw6IxH/PEOlf5Wj4v+ciVp9o0TK0SWkc37IAfZ7r+To85uJ33W7RMrJkvzrda62XUFEtYXcDtmFISmjxMpS9AaSxu0i1ud/3G0yh9QfTuZvu+R0Ut/fQEL1f/Kg9bfotpwvkfoZZu9G12AcOr8vMEzdhqLk829s11l4fiJ4vw9DvofE1Ly3URSYth78hkP992Hm5iLVXYi8qJR8f6LFo3L06FFCQkKYMGECPXv2fCx1iIiIYMaMGVy4cIGkpCSGDBnCsGHDHktdhCiqXhsMbLyc/VXnZAcXB2uoWT73C/RJ+wxM3GceAPza345X6uR+/+X9zRl8dyR7O7UKDg91xL+a7e3eXZfG4qM603M7NZwYVY4mVUumJWLv6XQ+npdgljbyb66809WlRMoTls5POcXF/54zS2u38WW8AqoWazln+uzm7i/ZAYraUUPbC71x9nUr1nIA0i/e50qTH1F02YG6+5sNqLG8e7GXBZA0MYzkSeFmaRV/HYDjK3Vz3S7lndVk/HAsO8FOTflTo9E0qlJsdTMuP4Th79+bpam/fRPNyJdz3/BaLDzzGaRnfx/QpzWs/TD37eb9CsPnm6ct+wAGdsh/pcugfarv8870lxeV90qwJk8eaYkQFvR6PWPHjuXmzZuEhIQwefJkXn45jy+9p9CePXuYP39+3hlzWL58OaGhocVel7Nnz/LNN98wePBgXnzxRVq1amWznDNnzjB27Fh69epFQEAAAQEB9O3blwULFpCcnFzsdSvtkjMUQq+Y3ytJ08P6y3nfP1lxzrIFYcWfebdirDhrvp1RgdVnc2+NWHFKZ/Zcb4Q1Z/R5llVY249qLdJ+PZpWYuUJS7fWWbY8RP1SvK0RBq2euxtumqUZ0w1mQUVxerDuklkAAZC45hKKvmSmK9auOJuvtIdlrDxlnqA3krHmdHFVCwDjisMWaYqVNAu/HDUPIAA2HANtHi06y/dZpq3Yn3d5QhSSTPFaCrVs2ZIDBw5gZ/d43p6oqCiioqIYPXo0/fr1eyx1KA327NnD5s2bC9QCs2LFCry9vYu9BenAgQOsWbMGX19f6tWrx+nTtn/sbty4QVpaGt27d6dSpUooisK5c+dYvHgxu3bt4ocffsDJyalY61eaOWignB0kP/Sb7OGY97YeTioe7gmb3+3uax/aLo9T7uGkQqt7aBvnkuvKVN7Z8h6SWwmWJyzZu9tbppUv3pH0Kns1Glc7DA/M/wDsPEpmxL7Gyh+IprwDaErms6X2cOLh8Fyd1x8boHJ3Qok1v6mi8nAuxpoBHuXyl/awClZaA12dwD6PVklr23lIy2JeZIrXwpOWiFIkJSUFALVajaOjIxrN4xlQee/ePQDc3d2Ldb+KopCamo9+nWXI0KFDGTp0aJ75goKCCA8PZ/Xq1bz11lu55n311VeZNWsWw4YNo0+fPgQFBTFhwgRGjBjBlStX2LfPyt2qp5iDRsWYVuY/EvUqQFD9vH84PnteQ84hCeUdYYR/3n+X/9fe/AZAFVcIbpH7TYH/62B+UVe9vIpBLSwvMotL3w7lKOeYfXAaNQzqIhccj1K90Y3Jef1i526P7+B6xVqG2k5NrU+amKU5+7lRuW/tYi0ni/ubDbD3Me8mVemzVqhUJXOh5vp5e7NzqHJ3pNyI1nlu5/R/Hcyeq2q44zCwZbHWTfNRZ3DK8Tdsp0H9ySt5b9i3LfhVNk/7pAfY5fHdM+Y1sM/xPePkAB+9mv8KC1FA0hJRTEJDQ5k0aRJz5szh5MmThIaGcu/ePXx8fAgODqZr165m+Xv27Im3tzcff/wxs2fP5syZM7i7u7Np0yabYyIURWHDhg1s2LCBq1evAlCtWjU6duxISEiIKV9GRgY//fQT27dv59atWzg4ONCiRQuGDRtGw4YNcz2OoUOHcvz4cQAmTZrEpEmTANi0aRPVqlVDq9WyaNEidu7cSWxsLOXLl6dt27YMHz4cb29v035yHoNWq2XNmjXcunWLd955x3Rnf8eOHaxatYpLly5hMBioW7cuAwcOpHPnzhb1Onr0KD/++CNnz55Fq9Xi5eWFv78/H3zwAR4eHgCsWbOGPXv2cPXqVe7fv4+7uztt2rRh+PDhVKtWzWx/+/fvZ9myZVy5coW0tDQ8PDxo1KgRI0eOxMfHx+w8tGrVyrRdbuNUsvJFR0ebbZN17orC09OzSNsDpvfnwYMHRd7Xk2biCxruag0sOauQpocr9yFoo4H5r+Q+LiIhTaGqC8SlwjOV4MfX7KhXMe+LoQfpCp7lIDkdWnirWBnkQFW33Lcb1c6BNJ3Cv/dkkJAG0UkKgUtT+b6PU7GPi0hNM/LzrsybFm7OKp6pZceIv7nRxLfkghZhqWq36lTpXo2YX6NQ7KH2sHq4+LoWezm+XzYn+cx97oVGorJT4fWGLxqX3H/+M24lc33EPh7sisKpgQe1/vM85V+unmdZGg8nav/Rn1v9t6I9FIPKyQ5jugFFUXINJIzJGdwb/RspayLQeDnj8dULuL3dNM/yHHs1xHlwC7TLz4BKhfOg5mjqVsx1GyVDj+H47czBSkYFPJwoN7836oq2WwmUlHQyPlqP4acjmX0N1So0rzfHYXYQqorWg29VSx802z7E8N4PcOMe1PbM3DYvrk7w2avwxWpI1MIL9WFUHsHH2RswYVXm4GrNX/eHOzSG2sU3xkOIh0kQUcy+/fZbtFotQUFBQGZw8eWXX5KRkWFx8Xnnzh2GDx9O586defnll/O8Sz9+/Hi2bdtGkyZNGDx4MG5ubly/fp1du3aZggi9Xs+oUaM4ffo0PXr0oG/fviQnJ7N+/XreffddFi5cSKNGjWyWMXjwYJo3b86SJUvo3bs3LVq0AKBChQro9XpGjhzJqVOn6NSpEwMGDODmzZusW7eOQ4cOsWzZMqpUMf/CWrFiBYmJifTq1QtPT0/T69999x2LFy+mXbt2hISEoFarCQsL4/PPP2fs2LH07dvXtI9169YxdepUKleuTJ8+ffD29iYmJoZ9+/Zx584dUxDx008/0aRJE/r164e7uztXrlxhw4YNHDlyhJUrV5ryHTt2jI8//hg/Pz+Cg4NxdXUlLi6Ow4cPExkZiY+PD4MHD0ZRFE6cOMHkyZNNdWnWrJnNczd58mSmT5+Oh4cHgwcPNqVXqFAh1/e1pKSlpZke58+f59tvv8Xe3p62bds+lvo8TuGRCt+dzO4qpADbrkPQJgOHBlj/Gtx308jgLdkdJU7FwnfHjMztnnsD7qqzej7ZkT2W4Y9bCstOGfiqQ+7bxacqTN6dQfJf3Z4VBQ7dMtJjqZarn7pgV4zdQf63LpmNv2ePfzgcoWOoQebYeNTO//MUd7beRoUKlQEuTfsTz9aVqdK5aDcdHnbr2z+5u+a66fnNqWdwruNG9SENbG5zKWgHKYdiAUg9EcfFnttofu3v2FfOu8vPg1UXSQ2PAkBJM3B3/EHsqpaj4hDbQUH8x7tIXpTZTVP/IJ24d7ZgX7cCTi/UyLWs1HlH0S46kf3828PY1ffEZaTt7znt+J1k/Hg8OyEhjZR+y7GP+QqVjYVZdGM2YFj4u1maYcUxMtL1OK5712ZZxvEb4crdzCeXYjG8NhvVlX+hquZh+6COX4OQJZkBDsCe8zBiKfw8wnp+vQF6/BMi48zTt5+AwbNh0xe2yxLSnakIJIgoZgkJCaxcuRJX18y7SUFBQfTv35///e9/dOnSxawvelRUFOPGjaNXr1557nfnzp1s27aN7t27M2nSJNTq7AsSozH7zsaqVas4duwY3377Lc8//7wpPSgoiH79+jFjxgwWLFhgs5znnnsOOzs7lixZQrNmzejRo4fptfXr13Pq1CkGDhzIhx9mzxLRtm1bRo8ezezZs/nHP/5htr+YmBjWrl1LxYrZd4YuXLjA4sWLCQ4O5v333zel9+/fnzFjxjBnzhwCAwNxcXHhzp07/Oc//8HX15fFixfj5pbdTD58+HCzY1+5ciXOzuY/cAEBAYwYMYKNGzfy9ttvAxAeHo7RaGTOnDlm9XrvvexZF5577jm2b9/OiRMnzM5Bbnr06MHcuXOpWLFivrcpSfPmzeOnn34yPa9Tpw7/+9//qFEj9x/lp9G6i9bv/h2OgcgHitXWiLUXLLdZe8HI3DwmmVlnZeD12j8NfNUh97v8v17UmwKInCITFQ5FGnjBt/i+rnedsBxAvftEOs/6ycp2j1L0pkiLtNubIos9iIhdazmI+u7a6zaDiIxbyaYAIosxVU/C1ht4vZN7azbAg7WXrKblFkSkrI2wTFsXkWcQkbbuT8u0tX/mGkRkLD9hmZicgW73ZRx6Wr/Jpl970mq6YeMZFL0BlZWuRkrsA5R9D52LNB3K5tOohgbYrB/rj2YHEFnWHrYdRBy+ZBlAZNlyHNIyMrs2CVHMZExEMQsKCjIFEACurq706dOHBw8ecOzYMbO87u7u+R6Au23bNgBGjx5tFkAAZs+3bduGr68vzzzzDAkJCaaHXq+nbdu2nDp1irS0ws3AEhYWhlqtJjg42Cy9ffv21K9fn71795pd1AMEBgaaXahn1VGlUhEYGGhWx4SEBAICAkhJSeHMmTMA/Pbbb+h0OoYMGWIWQFg79qwAwmg0kpycTEJCAvXr18fV1ZWzZ7Nn68h6f3bv3o1eX3Kz3zwsNTXV4nj1ej16vd4ivTjGjrz++uvMmTOHqVOn8ve//x0HBwcSEhKKfiDFKD4+nvT0dNPz5ORkkpKSTM8zMjJMY3SyREdH5/o8JibGbC72+Ph4KjpanxnJUQPOKp3VMqq4WAYWlf9Ks1ZG1nFUttKzoVI5Jc/j0GTct1pHgMqu6mI9VxXcLL/6K7oVbxlZcjtXZb0Mlbvl++BYKXtgcnEdh0Nly4HGWS0K1spIVWWgcrK8KM7aJq9zpS9veVxqz+w6WDsOPK0MyK6c3b3I1vuhtvIHp67skuu5Ule1PrVtvNr8tzHne66qYn0bpaKzqfuQxfvh6ojibOXmQeXsfVn7XOmsdY+qXN56GUCskm6ZP0sFF2LuxT2Rfx8PPxelj7REFDNfX1+LtNq1MwewRUVFmaVXr14934OnIyMjqVSpUp59469du0Z6errVcQVZEhISqFq14POQ3759Gy8vL8qXL2/xmp+fHxcvXiQhIcEsaKhVq5bVOiqKYuryZU3Wl0tkZOadugYNbDe7Zzly5AgLFy7k3LlzZl9egNmXV9++fQkPD2fq1Kl8++23NG/enHbt2tG1a9cS7Xo0bdo0Nm+2vvjPw+/Xq6++ysSJE4tUXq1atUznv3Pnzhw8eJBRo0YB0K1btyLtu7g8HGDmDMABHBwcLD7zOcfeWHv+8Ge7YsWKDG+h8P1ZA1EPzXD7kb+KSm4OgGUZ75VXmHvcwK2/PjoqYHx7tc0ysnz4nB3Lzxi4/9cMqvYaGPeSA56e5q1kD9f7jdZezDmpZe8184DnreZ21KukBorvXA3p4cJXSx+Q9ZtfpYKav7VzpoKb+cVLSb0fUkamJv/XgsMD96H81ZXMoZIjtXMMrC6u43D5zI57225h1GZ+tjSudqbB1lbLcIWqHzcj+l/Zd+xdnquCe9eaNsvIqfqE9lwPW4uizbxJo3a1p/Jn2YOdrR7H5Je4+/dNpsnQNDXL4/Zuc5tlZL0frp++QPqmCJSUzNmnVOXscRn7Ag65nCvnSV1IfnWp2d1+TUBtqgaaD6zO+Z7bj+9GRv+lPMxhQnfTWI+H3w9VOUc0n3XDODF7Om5VKx9Ur2Z3i7X6uQp+CWb/BldztAZN6G21DIDKLzSHvwfAz3st6se4IKpWN2/ZelL+Ph5+XlKkI2fhSRDxGJXUNJt169blo48+svn6o+yjb+sYVSoVs2bNsmhVyeLn51egcs6dO8fIkSOpUaMGI0eOpFq1ajg6OqJSqfjiiy/MWkg8PDxYtmwZJ06c4NChQ5w4cYLp06czf/58Zs6cmeu4h6IYNGgQ3bub94WZMWMGkNnClJOXl1exl//888/j6enJ2rVrS00Q8ahUcVFxfKCGt7cZ2HUzc2zjSzXhi+dsN8ZWdlFxfLA9S04bidMqvNFQTetcFovLUs9Tzanhjiw9YSBND28109C4ct7bqVQqQtra8ecdA3GpUKkcjO/kyIjnin+wc7fWztTwsmPX8TQquKl57XlnPFylYfpRq9q9Bi/s6Myv/9iC0Unhb9+8inON4p8hy7lueTxerEL8ztuoy9lR67OmuDXPffBxzX+2xa1dVRJ3ReHc0INKA+uj0uTvM1KuTVX8Tv2dxB8vgBo8BjXCoU7us/25vtkIez8PUtZGoPYqh1twUzSV8p4OVVO3IvYv1yZj80VwsqPcqDY4tMp9ALh994Y4r3wT7dBfICENqrjgNC73tZDs+rVEVccT/U9HUa7dQ13DA03/lmgCcl/UTjPhNVRt66DsOAf1q6Ae+LzVrk9mPFzg6D9g6V64fR96tcocXJ2bH0bBq61g359wJQaOXoZ7yZmBRUAjaFmw31Qh8kOCiGJ2/fp1i7Rr164BmS0PhVWrVi3Cw8O5d+9erq0RNWvW5P79+7Ru3drmBXphVa9enYMHD5KUlGTRtejq1au4uLiYBi/npmbNmvz+++9UrVrV1EpjS9ad9IsXL+Lj42Mz3/bt2zEYDMyaNcvsPGu1WrNWiCwajYZWrVqZZlG6dOkSAwYMYNGiRcycOROgUFMS5rZNnTp1qFOnjlla1nl8VIOd09PTy+TsTACHYxS2X89+vicSxoYbmdvF9g+6l4uKsc8XfGakmu7qPAdSP+xavJFBq9NNk7fEpWYuQDeqXcn0ZW7iay+zMZUC5Zt6kNw9czCMU5ViXqfgLxHvHyR+x20AjCl6rn11ggodvPFon/vMPR6BPngE2v7ezY1jvQpUnvx83hlzbtOmGo5tCjYeJOnTHWSEXsx8otWT8vUBHF70wSnQ9kW3YjCS/um2zAAC4E4KKUE/YR/5Barytm/uaVr7oGld8POh7tYEujXJO2NOFVzgowKs8q3RQP/20LMV1BwK9/9qdj16BV77N1yfn/cUsUIUkNx6KmZr1641WxU4OTmZdevW4ebmhr+/f6H3m3UHe9asWRbjDnL2QwwMDOTevXv8/PPPVvfzcB/EgujQoQNGo5GlS5eapR84cICIiAgCAgLyFbhkDTqeM2cOBoNlX/WcdezUqRP29vYsXLjQ6mrLWcee1S0s57kAWLx4scX5sjYuwNfXFycnJ7ML7KwxFomJiXkeU85tHvdFelyc9QF2mzdvJjk5mSZNCvhj9pTYdMWy0XpjPlatflS2RugtZn88eNPI3eSSWelXlB1xG29apm2yTHsSpW2yHJCdtvFCrtsYTkdjvPHQGKQH6ej2XC3Oqj0e+/7MDiCyRMXDsSuPpz7iqSYtEcXMw8ODt99+2zRgOjQ0lJiYGMaNG1ek7kudO3emS5cubNmyhcjISAICAnBzc+PmzZscPHiQ1atXA/Dmm29y6NAhZs6cyZEjR2jdujUuLi7ExMRw5MgRHBwcmD9/fqHq0LNnTzZv3swPP/zA7du3admyJZGRkaxduxZPT0+zmZZy07hxY4YOHcqCBQt466236Ny5M15eXsTFxXH+/HkOHDjAH3/8AUCVKlUYM2YMX3/9Nf379ycwMBBvb29iY2MJDw9n/PjxNGjQgA4dOrB8+XI+/PBDevfujb29PYcOHeLy5csWrSNTpkwhNjaWtm3b4u3tTXp6Ojt37iQlJYXAwEBTvqZNm7J69WqmTp1K+/btsbOzo0mTJrm2KDVt2pSNGzcyd+5cateujUqlIiAgwGLWqIKKjo5my5YtAKY1Qvbu3cudO3cATOcF4MMPP8Td3Z1mzZpRtWpVkpOTOXnyJOHh4VSpUiVfi9s9jWq4Wq4+XcP6WMnHooa7ZStWeUco7yTTD4qicazhgvbSA4u0p4GmRnmM0eYXzZqauXedUnuXzxwMbTAP0NU1ineB1ceihpWeCmo1VMu9+1pZJlO8Fp4EEcVs1KhRnDx5kjVr1hAfH0+tWrWYMmVKsfRB/+c//0mLFi3YuHEjCxcuRKPRUK1aNbNBuXZ2dsyYMYO1a9eydetWU8Dg5eVF48aNefXVwq9eaWdnx+zZs02LzYWFheHm5kanTp0YMWJEgQZrDx06lEaNGrFy5UpWrFiBVqulYsWK+Pn58cknn5jlDQoKokaNGixbtoyVK1ei0+nw8vKidevWpnUnnn32WaZNm8b333/PvHnzcHR0pE2bNixYsIAhQ4aY7a9Hjx6EhoayZcsW7t+/j4uLC3Xq1OHrr7+mU6dOpnxdu3YlIiKCHTt2sGvXLoxGIxMmTMg1iBgxYgSJiYmsWbOGpKQkFEVh06ZNRQ4ioqKimDdvnllaWFgYYWFhpuPPCiJ69+7N7t272bBhAwkJCdjZ2VGjRg3efvttBgwYkK8uZ0+jYc1VLDoDN//q3WavhkntSk9jbGADO17w0XDgRnbr3PhOjjjayQ+cKJo6U1py7s1w00Dicg3c8X479778TwrXSR25/7cVoMsMCDQ+7pQblnurv7qqG46j2pE+Y78pzb5PE+xaFr7LcanRxAfefBFW7MtOC3kFalZ6fHUSTy2V8nD/D1EoWStWz5s3z2y1YiFE6ZGQprD8vML9dAiqr6JBPlaffpTS9Qprzui5fM/IK/XsaOcjfZifdjqdjiVLlgAQHByMvX3JjFNJPhPP3Q03cajiTJW36mDn+vSMh9FHxKFd+yfqCk44v9UUtUf+btrodlxEf+A6mubVsP9bo3wPHC/1jEbYdAROXIPn60O3lnlvU4aFqZbkO29HJTjvTGWItEQIIcoMDycVI1qUrsAhJ0c7FQNaPD0Xd6L0cG1aEdemT2eXFrsGlXD7MpfF22ywf6U+9q/kMevRk0ithl5tMx8iT3InvfCekrBbCCGEEEII8ahIECGEEEIIIYQoEOnOVEx69uxpmpFJCCGEEEKIp5kEEUIIIYQQokySKV4LT7ozCSGEEEIIIQpEggghhBBCCCFEgUh3JiGEEEIIUSZJd6bCk5YIIYQQQgghRIFIECGEEEIIIYQoEOnOJIQQQgghyiTj467AE0xaIoQQQgghhBAFIkGEEEIIIYQQokAkiBBCCCGEEEIUiIyJEEIIIYQQZZKilileC0taIoQQQgghhBAFIkGEEEIIIURujEaIuZ/5rxACkCBCCCGEEMK2HSehdgh4vwt+I2DX6cddI1GMFFX+H8KcBBFCCCGEENYka6HPNLgZl/n8eiy88R9ITX+89RKiFJAgQgghhBDCmtCjkJxmnnY/GY5cfjz1EaIUkdmZhBBCCCGsCTtjPb1OlUdbD1FiZHamwpOWCCGEEEIIa36PsEyz10DNSo++LkKUMhJECCFEGWMwKly4p5CSoTzuqghRut1PsUzTGWDxrkdfFyFKGQkihBCiDDkQpVB7oYFnlhjwnmdg3kmZslIIm571tZ7+r7WPtBpClEYSRAghRBlhMCq8GWogMinzeVIGjPjNyJUEaZEQwqp//h3UVi6VouIffV1EiVDU+X8Ic3JKhBCijLiWCJHJ5mkKEHZTWiOEsOq3U9YXmJO4W4jSHURMnDiRVq1a5Svv7du3adWqFfPnzy/hWmUqSN2GDh1Kz549S7hGuSvo+YmIiGD48OF07NjxkZ5XIUTJcbazfuUTnyazkwhh1fRQ6+nu5WT1alHmyRSvwoJer2fs2LHo9XpCQkJwc3OjXr16j7taj9yePXuIiIhg2LBh+d5m+fLluLm5FWvQqCgK27ZtY9++fZw/f567d+/i4eFB/fr1effdd2nSpInFNkuWLOHChQtcuHCBqKgovL29CQ218WMoyoRUncJ/jli/6KnoJLdVhbDK1qJysYmw+nfo3/7R1kcUO0UjN1EKq1S3RIwbN44DBw487mqUOVFRUURFRfHmm2/Sr18/evToUWaDiIULFxZomxUrVhT7xXpGRgbjx4/nxo0bvPLKK3z66af07t2biIgIgoOD2bp1q8U2c+bM4ejRo1SvXp3y5csXa33Ek6lvqJEZx62/Vs310dZFiCfGOx1tv/afjY+uHkKUQkVuiTAYDOh0OpycnIqjPmbs7Oyws5PGkkft3r17ALi7uxfrfhVFQavVUq5cuWLd75Ns6NChACxYsMBmHo1Gw/z58/H39zdL7927N3379mXGjBl069YNdY7Bfxs2bKBGjRoA9O3bF61WWwK1F0+Ky/eNbLlqu7Vh6K8K4W8q+HnIHTkhzOgMtl87fQMUBVTydyPKpgJdoYeGhjJp0iTmzJnDmTNnCA0NJSYmhnHjxtGzZ08URWHdunVs2LCBa9euoVaradSoEUOGDLEYP7B582ZWr17NzZs30ev1eHp60rRpU8aMGUOFChWAzHEHmzdv5ujRo2bbnjx5klmzZhEREYGLiwudOnWiT58+Nus7b948i/KHDh1KdHS02V3jP/74g40bN/Lnn38SFxeHvb09jRs3ZvDgwRYXcMXh+PHjfP/995w7dw69Xo+vry9vvPEGvXr1Mst39uxZ1q5dy+nTp7lz5w4ajYa6desycOBAOna0vEuS3/NjzdChQzl+PPN25aRJk5g0aRIAmzZtolq1ami1WhYtWsTOnTuJjY2lfPnytG3bluHDh+Pt7W3az9GjRwkJCWHChAlotVrWrFnDrVu3eOedd0zdg3bs2MGqVau4dOkSBoPBdEydO3e2qNfRo0f58ccfOXv2LFqtFi8vL/z9/fnggw/w8PAAYM2aNezZs4erV69y//593N3dadOmDcOHD6datWpm+9u/fz/Lli3jypUrpKWl4eHhQaNGjRg5ciQ+Pj5m5yHnZ2fChAk2uypl5YuOjjbbJuvcFZadnZ3Vz5+npyctW7YkLCyM+Ph4KlXKXvwoK4AQAuC3G7m/HpUCo3YZ2NpHbtoIYfLrCfhuu+3XdfrMh4P9o6uTEKVIoX4xZs6ciV6vp3fv3ri4uODj4wPA+PHj+fXXX+nUqRM9e/ZEp9Oxbds23n//faZNm8ZLL70EwJYtW5g4cSItWrQgJCQER0dH7ty5w4EDB4iPjzcFEdacPXuWESNGUK5cOQYNGoSbmxs7duxgwoQJhTkUM6GhoSQmJtKjRw+qVKlCbGwsGzduZMSIEcybN48WLVoUuYwse/fu5dNPP8XT05MBAwZQrlw5duzYwZQpU4iKiuL999835d2zZw/Xr1+nc+fOeHt7k5iYyObNm/n000+ZMmUK3bp1M+Ut6vkZPHgwzZs3Z8mSJfTu3dt0zBUqVECv1zNy5EhOnTpFp06dGDBgADdv3mTdunUcOnSIZcuWUaVKFbP9rVixgsTERHr16oWnp6fp9e+++47FixfTrl07QkJCUKvVhIWF8fnnnzN27Fj69u1r2se6deuYOnUqlStXpk+fPnh7exMTE8O+ffu4c+eOKYj46aefaNKkCf369cPd3Z0rV66wYcMGjhw5wsqVK035jh07xscff4yfnx/BwcG4uroSFxfH4cOHiYyMxMfHh8GDB6MoCidOnGDy5MmmujRr1szmuZs8eTLTp0/Hw8ODwYMHm9Jz+zwXVWxsLPb29ri5uZVYGeLJF5mU95iHvAINIcqcg1ZWq37YjlPwav4mWRGlk1EtLUmFVaggIi0tjeXLl5t1YQoLC2Pbtm188cUXvP7666b0/v37ExwczH//+18CAgJQqVTs2bMHFxcX5s6da9ZdKSQkJM+yp0+fjtFoZNGiRabg5Y033uDdd98tzKGYGTduHM7OzmZpffr0oW/fvixZsqTYggiDwcC0adNwdnbmhx9+wMvLC8jsdjJs2DB++OEHevbsSa1atQB49913GTlypNk++vfvz1tvvcWiRYvMgoiinp/nnnsOOzs7lixZQrNmzejRo4fptfXr13Pq1CkGDhzIhx9+aEpv27Yto0ePZvbs2fzjH/8w219MTAxr166lYsWKprQLFy6wePFigoODzYKl/v37M2bMGObMmUNgYCAuLi7cuXOH//znP/j6+rJ48WKzi+Xhw4djzDE7xsqVKy3ev4CAAEaMGMHGjRt5++23AQgPD8doNDJnzhyzer333ntm52H79u2cOHHC7BzkpkePHsydO5eKFSvme5ui2L9/P+fOnaNHjx44OjqWeHniydWyioq85qTUGeH8PYVnPOUHVQggcwamvIQekSBClFmFGlgdFBRkMQZi69atuLi40KFDBxISEkyP5ORkXnzxRW7fvs3NmzcBcHV1JS0tjf3796Mo+Z8VJD4+ntOnT/PSSy+ZLpAB7O3teeuttwpzKGZyXoCmpqaSkJCARqOhSZMmnDt3rsj7z3L+/HliYmJ47bXXTAEEZB7HoEGDMBqNhIeHW61XWloaCQkJpKWl0bp1a65du0ZycubE7yV9fsLCwlCr1QQHB5ult2/fnvr167N3716zi3qAwMBAswt1gG3btqFSqQgMDDT7rCQkJBAQEEBKSgpnzpwB4LfffkOn0zFkyBCrd9tzjgPIOk9Go5Hk5GQSEhKoX78+rq6unD171pTP1TVzFOnu3bvR6/VFOCMFk/WZyvnQ6/Xo9XqL9NTU1Fz3dfPmTSZMmEDlypX56KOPHtERFL/4+HjS07NnP0lOTiYpKcn0PCMjwzRGJ0t0dHSuz2NiYsy+V6QMqJDPGDM+IbFUH8fTXkZsbOxTcRxPSxlxDSqTl4z4B6X+OJ6WMkTpU6iWiKw75Dldv36dlJQUXnnlFZvbxcfH4+PjQ3BwMMePH+eTTz7B3d2dli1b8sILL9ClSxdcXFxsbh8VFQWAr6+vxWt16tQp+IE85NatW8yZM4c//vjD7MMOoCrGgVO3b98GrNfZz88PyD5WyDxvc+fOJTw8nPh4y1Uyk5OTcXV1LfHzc/v2bby8vKzO9uPn58fFixdJSEgwCxqsfVauXbuGoigEBQXZLCvryyUyMhKABg0a5Fm/I0eOsHDhQs6dO2f25QWYvZ99+/YlPDycqVOn8u2339K8eXPatWtH165dS7Tr0bRp09i8ebPV1x4eB/Lqq68yceJEq3mjoqIYPnw4ALNmzSrROpe0hwPMrAAvi4ODA56enmZpOcfeWHtetWpVKeOhfR67Q56erwYv+HkUugxbz5+0c/Woy9DpdKbnlStXNvuteZKO42kso1KP56BlHTh+FVscWvgVqYyn5Vw9ijJKiqxEXXiFCiKszcSkKAoVKlRgypQpNrfLukCuVasWa9as4fDhwxw5coTjx48zZcoU5s+fz8KFC4ttUGhuF/4Gg/mMC6mpqQwZMgStVsubb75J3bp1cXFxQaVSsXTpUo4cOVIsdSooRVEYOXIk165do3///jRq1AhXV1fUajWhoaFs377d4u5/aWJr1i6VSsWsWbPMWhJyyvqs5Ne5c+cYOXIkNWrUYOTIkVSrVg1HR0dUKhVffPGF2Tny8PBg2bJlnDhxgkOHDnHixAmmT5/O/PnzmTlzZq7jHopi0KBBdO/e3SxtxowZAIwePdosPWcLVU63b98mJCQErVbLd999R926dUuiquIp06pq7q93qAHr/qZ5NJUR4kmybRz4jYDkNMvXVEA/WSdClF3FNhVHzZo1uXnzJk2bNs3XFJ4ODg60b9+e9u0z/wD379/P6NGj+fnnn/nss8+sbpM1w83169ctXrt61fJOQdYd8wcPHli8dvv2bbPxGIcPH+bu3buMHz+e1157zSzv3Llz8zyegqhevTpgvc5ZaVl5Ll26xMWLFxkyZIjFomcbNmwwe17Q81NQ1atX5+DBgyQlJVl0Lbp69SouLi6mwcu5qVmzJr///jtVq1aldu3auebNasm4ePGiWReth23fvh2DwcCsWbNM5w5Aq9VatCpB5rSprVq1Ms2idOnSJQYMGMCiRYuYOXMmULjWp9y2qVOnjkWLUNZ5bNu2bZ77vn37NsOGDSM5OZnvvvuOhg0bFrh+omzqWEuNu6ORRBvrZn3cWk1FZxkLIYSFyh7g6WY9iBjwEvjlEaEL8RQrtkacwMBAjEYjs2fPtvp6zr5vCQkJFq9nXRAlJibaLCNrGtjw8HBu3MieSkSn07F8+XKL/FkXoIcPHzZL3759O3fv3jVL02gy78I9PEbjjz/+MOtPXxwaNmxI1apVCQ0NJS4uzpSu1+v58ccfUalUppmssu7UP1yvy5cvs2fPHrO0gp6fgurQoQNGo5GlS5eapR84cICIiAgCAgJstizklDXoeM6cORYtQmD+WenUqRP29vYsXLjQNPYjp6zzYuv9W7x4sUVLjbXPn6+vL05OTmYBZ9YYi9w+kw9zdna2GrQWVXR0NCEhISQlJTF79myeeeaZYi9DPN0mPG/9b1MFdPWVAEIIm0K6Wk+vXLxrKYnHQ1Gr8v0Q5oqtJaJz58707NmT1atXc+HCBV588UU8PDyIjY3l9OnT3Lp1i40bM1d3fP/993Fzc6NFixZUqVKFpKQkQkNDUalUec5q89FHHzFs2DDeffdd3njjDdMUptYuRn19fWnTpg2//PILiqJQv359Ll68yJ49e6hZs6bZoNpnn30WT09PZsyYQXR0NJUrV+bixYts3bqVunXrcvny5eI6VWg0GsaOHcunn37K22+/Te/evSlXrhw7d+7kzJkzBAcHmwKg2rVrU6dOHZYtW0ZaWho+Pj7cvHmTX375hbp163L+/PlCn5+C6tmzJ5s3b+aHH37g9u3btGzZksjISNauXYunp6fZTEu5ady4MUOHDmXBggW89dZbdO7cGS8vL+Li4jh//jwHDhzgjz/+AKBKlSqMGTOGr7/+mv79+xMYGIi3tzexsbGEh4czfvx4GjRoQIcOHVi+fDkffvghvXv3xt7enkOHDnH58mWL1pEpU6YQGxtL27Zt8fb2Jj09nZ07d5KSkkJgYKApX9OmTVm9ejVTp06lffv22NnZ0aRJE7OWjoc1bdqUjRs3MnfuXGrXro1KpSIgIMBi1qiCSElJISQkhNu3b9OvXz9u3LhhFiRCZktGzv6lW7ZsMQ1KS0hIQKfT8f333wOZ/UxzHqcoG0a2UPFpOBgemsuijjs4aOTHUQib3ukI//eTZXqazjJNiDKkWFcWmjBhAq1atWL9+vUsXboUnU6Hp6cnDRs2NLvADAoKYufOnfzyyy8kJibi7u5OgwYNGDt2rMWicA9r1qwZc+bMYfbs2fzwww+4urqaFlPr37+/Rf7JkyfzzTffsH37drZu3UqLFi2YN28e//73v81G/ru5uTF79mxmzZrFqlWrMBgMNGzYkJkzZ7Jx48ZiDSIgc+rR7777jkWLFvHjjz+i0+nw9fVl3LhxZovNaTQaZs6cyYwZM9i8eTNarRY/Pz8mTpzIxYsXLYKIgp6fgrCzs2P27NmmxebCwsJwc3OjU6dOjBgxwmJgVW6GDh1Ko0aNWLlyJStWrECr1VKxYkX8/Pz45JNPzPIGBQVRo0YNli1bxsqVK9HpdHh5edG6dWvTuhPPPvss06ZN4/vvv2fevHk4OjrSpk0bFixYwJAhQ8z216NHD0JDQ9myZQv379/HxcWFOnXq8PXXX9OpUydTvq5duxIREcGOHTvYtWsXRqORCRMm5BpEjBgxgsTERNasWUNSUhKKorBp06YiBRGJiYmmQfOrVq2ymmfevHlmQcTGjRtNi+XlzAPQsmVLCSLKIJUKHDWQ+tCEZG82lABCiFzN/9V6enPfR1oNIUoblVKQOVaFEEI8scaEGZh+LPsrv5IznA/WUKmcBBKPi06nY8mSJQAEBwdjby+rH5c63SfD9pPmaSog/kfwsD2jpHgybKyQ/+7ef7tf9OnyH7WoqCj27t1LbGwsffr0oUaNGhgMBtNN/Kzu4IVRrC0RQgghSq9vOqipW0Eh9IpCrfLwSSu1BBBC5CXOcjwedhoJIJ4SylP6FagoCmPGjGH27Nno9XpUKhVNmzalRo0aJCcn4+vry+TJky1mhywImR1XCCHKCLVKxfBn1Wzto2FeFw11Kzylv55CFKfIOMs0J4dHXw8hCuCbb75h5syZfPLJJ+zcudNs4hl3d3def/111q1bV6QyJIgQQgghhLAlNsEyzcvNMk2IUmThwoUMGjSIf/3rXzz77LMWrzdr1oyLFy8WqQwJIoQQQgghbKniYZmmK72LvIqCeVqneI2MjKRdu3Y2X3dxcSnylPQSRAghhBBC2NK5mWVaVY9HXg0hCqJy5cpERkbafP3YsWOm5QQKS4IIIYQQQghb/q8PuDiZp4157fHURYh8ev3115k3bx5Xr141palUma0pO3bsYOnSpbzxxhtFKkNmZxJCCCGEsKVRTTj8NXy3HZLTYOBL0MlK64QQpcikSZMICwvj2Wef5cUXX0SlUvH111/z1VdfcfDgQVq0aMEXX3xRpDKkJUIIIYQQIjeNasLsIbB0lAQQTxmjKv+PJ4m7uzt//PEHY8eOJSoqCicnJ8LDw0lISGDChAns27ePcuXKFakMaYkQQgghhBDiKePs7My4ceMYN25ciexfWiKEEEIIIYQQBSItEUIIIYQQokx60qZuza/BgwfnmUelUrFo0aJClyFBhBBCCCGEEE+R3bt3m2ZjymIwGIiOjsZgMODl5YWLi0uRypAgQgghhBBCiKfI9evXrabrdDrmz5/PjBkz2LlzZ5HKkDERQgghhBCiTFJU+X88Dezt7Rk5ciSvvPIKI0eOLNK+JIgQQgghhBCiDGnevDl79+4t0j4kiBBCCCGEEKIM2blzp6wTIYQQQgghhMg2efJkq+kJCQns3buX48eP8/nnnxepDAkihBBCCCFEmaSonpLBDg+ZOHGi1fQKFSrg5+fHvHnzGDJkSJHKkCBCCCGEEEKIp4jRaCzxMmRMhBBCCCGEEKJApCVCCCGKWVK6wsZLRjQqeK2eGheH0tNc/vs1HWduG3ihjh1NvOUnQAhrlPPRGPdeRNWoGuoX6z3u6ogSZCw9X89FcvPmzUJtV6tWrUKXKb8gQghRjC7FK7z4o447KZnPa7gZODDInlruj/+XauiqFBYeTDc9n/aaM5++7PwYayRE6WOYuQvj6FWm58ZBz2P3Q/BjrJEQefP19bVYoTo/DAZDocuUIEIIIYrRP/YbTAEEwK0k+PqggTndHu/X7akovVkAATB+m5b3nnOkQjnp2SoEgJKUhvHLDeZpyw5iHNURdSvfx1InIfJj8eLFhQoiikKCCCGEKEYX4xWLtAgraY/axbuWg+zSdHDzvlGCCCGyRN2HlHTL9Ig7IEHEU0lRP/5W4uLwzjvvPPIy5ZdDCCGKUWdfyx+kzr6P/6s2wM8OB415mnd5FY2raqxvIERZVK8K1KponmanRtWh/mOpjhClmbRECCFEHpIzFNZEKCTp4PV6Kmq42b5z9cULGiLiFdZdyGx98K+qIqhh3ne64lMV1pwzYFQgqLEGL5e8t7mXorDmjA6AN5ra45nLNlXc1Cz7uwvD16ZyP1WhqpuKVW+7Yqcp/rtwZ//UcuV6BvXqONKooVOx7188Gtqz90jafgOHOuVxf60OKrviD4YVo0L6tkvo/ozDsYMPDq2rF+/+45LRrz0JgN0bLVB5uuSaX6VRo148COOb38PdZKhYDs3M/qiqVyjWegFw9DKEnYVnakCPlqDO4/zuPw+/X4CWdaBTM3hK1zcQxevAgQMcP36cxMREi2lfVSoVX331VaH3LUGEEELkIjZF4bnlBq4lZj7/v72wPUjDizWs/4CXs1cxt5sdx6J1XEuEozEKzb7Xs7WfHR18rF8kXL5npN2idO7+NZZi3G4dewc70riy7YuKiLtGXpibyr3UzGBl3I4M9oc407Cy7ZaFi3eN3P8rf0ySwux96bzoZ5/XKSiQ73+4x86wZNPzHq+48fZbFXPZQpRG9xad49aQ3fBXTzyXl6rj91uvYg8k4l9fTdrGCNPz8lM74fbZC8Wyb+OFO2jbz4R7mX9YGV9txXn/h6gbVLG5jRIZj/HtpZkBBIDOiOoZ72Kpj5lvNsDYZdnPe7aCTV/Yzv/ZMpi2Ift58MuweGTx10s8NeLj4wkMDOTw4cMoioJKpUJRMv+gs/5f1CDi8bexCwtHjx6lVatWhIaGPrY6REREMHz4cDp27EirVq2YP3/+Y6uLEI/TnJNGUwABkKqH8QdyX8Rn7nHzbbR6+Crc9gwY0w7oTQEEQLwW/rVXn2sZ/w5LNwUQAPdSFabuybCZPz7FyD93as3SVp/M4PCN3MspiJg7OrMAAmDbziTi7hVfGaLkKXojMf930BRAAKSER/Eg9FqxlpO+74ZZAAGQNHkvxiQrYxIKQffvnaYAAoC4FHRTf8t1G+P/foOohBwVSsMweXOx1MckWQuTVpunhR6F8HPW80fHw383mact2Q1/RhZvvcooRZX/x5Pk008/5fTp0yxfvpyrV6+iKAq//vorFy9eJCQkhGeffZbbt28XqQwJIoQFvV7P2LFjuXnzJiEhIUyePJmXX375cVfrkduzZ0+Bg6fly5eXSPB39uxZvvnmGwYPHsyLL75YoCAzLi7OFAz++OOPxV63p13OYCA7LfeB0tcSLF/PbZtr963kt7KPPLexkpYl+oGRdCvX8tfuFX56v4fFxlkWoChw10q6KL2MKTr0d7UW6RnXHhRrOYZrCRZpSqoOY87pzYrAeC0+X2lm5V+Ls0y7erdY6mMSmwgpaZbp1+5Yzx95DwxWblzYyi8EsHXrVoYNG0a/fv1wc3MDQK1WU7duXebMmYOvry+jR48uUhkSRJRCLVu25MCBA/To0eOxlB8VFUVUVBRvvvkm/fr1o0ePHtSrV/YW29mzZw8LFy4s0DYrVqwokSDiwIEDrFmzhuTk5AK/F9OmTSvSPNBlXffalrefelhJM9vGz/KrtYeVNFP+elbyW0kze72BZbcla2lZnqmioban+T6d7OHl+sXXnal+XUdcHprpyc1NjV9tx2IrQ5Q8jbsj5Z6vap6oArduPsVajmPnOmBv/nmxq++Jxq94xh9oejxjJa1RrtuouzexTOvRtFjqY1K7CjR8aOyHvR10aW49/7O+UNXDPM3NGV7M/VhE2ZaQkEDjxo0BcHV1BSA5Obul+JVXXuHXX38tUhkSRJQiKSmZd1/UajWOjo5oNI9n1pR79+4B4O7uXqz7VRSF1NTUYt3nk27o0KEMHTo0z3xBQUGEh4ezevVq3nrrrXzvPzw8nD179vDee+8VpZpl2pvPqPmirQqXv661KzmDnRqSMmzf9a9bAQJqqnDUgFoFveur+OZl23/PH7S1I6SVBke7zH0H+KjQ6hT23bAd/H38ogO9G9uhVoFGBe/42/Hxiw428yvAiBccqeyaGQDV9MgcWO3lWnw/A06OakYN86R8+cx9Vqqo4ZNRXjiUohW7SxttRCKVtkDF3aCPL55uPNbo7mq5PeMMkf86gfZK3i0KtX56BccmngCo3eypMa8DTo1yH9uiu57I/amHuD/9CPp8tCZoqrlR/p8voyqf+bm1a16FimuDcp3rXsnQk778JKnjd6ILu5Lr/u1GBaDuUDfzSkcN6g51sRue+3gL1XvtUX/UGRztMv94W/mgGtUxz2MhSQvzd8H4tfB1aOa/u210T1KpYM4QqPbX+aziDstHQ3VP6/kd7GH9Z1Dnr7Ecldzgh1FQvlze9RJ5UlSqfD+eJNWqVSMmJgYAR0dHKleuzKlTp0yvR0VFFXldCRlYXUxCQ0OZNGkSc+bM4eTJk4SGhnLv3j18fHwIDg6ma9euZvl79uyJt7c3H3/8MbNnz+bMmTO4u7uzadMmjh49SkhICBMmTKBnz56mbRRFYcOGDWzYsIGrV68CmR+Sjh07EhISYsqXkZHBTz/9xPbt27l16xYODg60aNGCYcOG0bBhw1yPY+jQoRw/fhyASZMmMWnSJAA2bdpEtWrV0Gq1LFq0iJ07dxIbG0v58uVp27Ytw4cPx9s7e/BZzmPQarWsWbOGW7du8c477zBs2DAAduzYwapVq7h06RIGg4G6desycOBAOnfubFGvo0eP8uOPP3L27Fm0Wi1eXl74+/vzwQcf4OHhAcCaNWvYs2cPV69e5f79+7i7u9OmTRuGDx9OtWrVzPa3f/9+li1bxpUrV0hLS8PDw4NGjRoxcuRIfHx8zM5Dq1atTNs9/J7klJUvOjrabJusc1cUnp42flxykZKSwrRp0+jTpw+NGskdq6KY/IKaNREGLiVAnBa+PaGw8oKBy+9pKO9o/iX801kDgzYZTN3JG3rCstfscM3lQtpOo2JuTwf+84qRrj9msPeGwt4bBv61z8DUznZ89qJla8GKk3o2/Knnr3FyHL1lJMMA9jZilb//mMKqE9ljJno2duC1JraDjsLQ6xXWbEjkwYPMrhdx8Qau38ygYX2Zocma+ztucf7VX6miy/xsnNm/kWeP9MbBu3gvDtOuJ3G67UZ0sZldlG794wSNd/agfPuqNrd5sPEq6WczbygZk3TEL7lAxcGNbQ6sTjt0m6iXV6OkZs4Wdv9fh6jxx99xqGu7VSFl6UkefPZb9tgLg4Kmju38iqKQ1H0p+t2ZwUPaP3bjPKkzzuM7WeY1GknvMR/j3uxAw7jnMumvzMVp7weobPyhqNRqVN2bwJw9YFTg6A0Mz01FdeQLVN4e1iv2IBXaTICIaPP0f2yAr3rB5CDz9D8joc83kPBXoJWaAXXzGLwdfR9u/NWtKi4JPl0GLzWGim65byfKrICAAHbu3MmXX34JQL9+/Zg2bRoajQaj0ciMGTMsrk0LSoKIYvbtt9+i1WoJCsr80ggNDeXLL78kIyPD4uLzzp07DB8+nM6dO/Pyyy/neZd+/PjxbNu2jSZNmjB48GDc3Ny4fv06u3btMgURer2eUaNGcfr0aXr06EHfvn1JTk5m/fr1vPvuuyxcuDDXC8rBgwfTvHlzlixZQu/evWnRogUAFSpUQK/XM3LkSE6dOkWnTp0YMGAAN2/eZN26dRw6dIhly5ZRpYr5rBcrVqwgMTGRXr164enpaXr9u+++Y/HixbRr146QkBDUajVhYWF8/vnnjB07lr59+5r2sW7dOqZOnUrlypXp06cP3t7exMTEsG/fPu7cuWMKIn766SeaNGlCv379cHd358qVK2zYsIEjR46wcuVKU75jx47x8ccf4+fnR3BwMK6ursTFxXH48GEiIyPx8fFh8ODBKIrCiRMnmDx5sqkuzZo1s3nuJk+ezPTp0/Hw8GDw4MGm9AoVSmBqwHyYPXs2BoOB999/nwsXLjyWOjwttl5TuJRgnnZXC9+fMfJxK/OLkXHhhpzjUblwD34+a2RYy7xbFvfcUDgQad7CMWWvng+es8PZ3jwIGbcj3RRAAJy9Y2T5SR1D2lgGBqei9GYBBMC839P5vy7O1PAovpaIw8dSuXLNvJw16xPp0tENTQlMJfuki5x0HEWX3dddF5VK9Nw/8ZncKpetCu72zLOmAALAmGYg8h/Hafyr9S6zxgwDMZMOm6Wl/hHDg9BruPf2s7pN/D//MAUQAMZ7WhKmH6Xyd11s1uvBuDCzwdv6s7FoV5zF5b2WVvPrd10xBRBZtFPDcfqoPSo38y5zhl8vmAUQpnr9cR1D6FnsXrfRdQgwTgyFjBzjeKISMH4XjuYff7O+wQ/7LQOILNO2wMfdwSPH1LLTNmQHEJDZijH1F1g5xmad+GqF+biIKzGweBd80sv2NqJM+/jjj9m5cyfp6ek4OjoyceJEzp07Z5qNKSAggG+//bZIZUgQUcwSEhJYuXKlqf9ZUFAQ/fv353//+x9dunTBySn7jlxUVBTjxo2jV69eee53586dbNu2je7duzNp0iTUOeaTzjnv76pVqzh27Bjffvstzz//vCk9KCiIfv36MWPGDBYsWGCznOeeew47OzuWLFlCs2bNzMZlrF+/nlOnTjFw4EA+/PBDU3rbtm0ZPXo0s2fP5h//+IfZ/mJiYli7di0VK2Y3g1+4cIHFixcTHBzM+++/b0rv378/Y8aMYc6cOQQGBuLi4sKdO3f4z3/+g6+vL4sXLzYNDgIYPny42bGvXLkSZ2dns/IDAgIYMWIEGzdu5O233wYyu/gYjUbmzJljVq+cXX6ee+45tm/fzokTJ/I9NqVHjx7MnTuXihUrPrbxLFnOnDnDunXrmDJliumzWBrFx8fj4uKCo2PmBUBycjKKopje54yMDJKSksxaYqKjo81avR5+HhMTQ5UqVUzNtMVRxrlbiYDlHb/riZbHEZVkeZw3Egzcu5eQ53HcSvSy2DY5AxLTQJuUXYaiKNx+YNmd6mJ0KpAdRGSVEZVoOSjTqMDZa3ep/mzlYjtX8fctu18lpxhJTzdSrpymWMqw9rwk3vNHUYb2hmW3oozI7IvL4jqOjFuWXYsyolJtlqG/l4Yx0XKmL11Uss0yDLcsP/iGv/JbK8NoMGKMTrayTZLNMiresjLLgVaHMT6VRF2KWRlpl+9gK2xVohJtluHt7Y2Sc3amrG1u3bf9fkTlMlg7XQf3kk1BRHR0NN5R9yzz3cpMK1AZf6U9rX8fDz8XBdO0aVOaNs0ez1OhQgV+++03EhIS0Gg0ZtdThSVjIopZUFCQ2UWbq6srffr04cGDBxw7dswsr7u7u82uMQ/btm0bAKNHjzYLIACz59u2bcPX15dnnnmGhIQE00Ov19O2bVtOnTpFWpqVWSHyISwsDLVaTXBwsFl6+/btqV+/Pnv37rVYyCQwMNDsQj2rjiqVisDAQLM6JiQkEBAQQEpKCmfOnAHgt99+Q6fTMWTIEKsf+JzHnhVAGI1GkpOTSUhIoH79+ri6unL27FlTvqz3Z/fu3ej1j27WmNTUVIvj1ev16PV6i/SijB3R6/VMmTKFtm3b8sorrxTjERS/ihUrmn5kIPO9yfk+Ozg4WHTlevhH5eHnVatWNevnWRxlvPmsh9ULkjefUVuU8Vo985wqoHdDu3wdR/d6aovuSG2qq6jqpjIrQ6VS0fMZ83tAKhX09zf/G8kqI8DPngrlzOtV00NN52aVi/VctXzW2WK9rMbPOJoCiOIow9rzknjPH0UZXq/X4WEVe2UPXi6u46j4N8sB0RVf87FZhodPJVzaP3TxZqfGrYevzTJc/lbXogyX1/xsllHevTxOrz40SYQKnHrWt1mGfbf6mWMVctA090bjU8GijHK9W2CxRPtfx5E1uNrWe67+m2UrhfpvzW2/H69ZbzkBoHEN8Mtuoff29oa/tbHM91eazTKsbfNa61yPI8uT+vfxqAIIoyr/jyfJn3/+aTXdw8OjWAIIkJaIYufr62uRVrt2bSCz5SGn6tWr53vwdGRkJJUqVcqzb/y1a9dIT0+3Oq4gS0JCAlWr2u4La8vt27fx8vKifPnyFq/5+flx8eJFEhISzIKGWrVqWa2joiimLl/WZA3ujozMnAe7QYMGedbvyJEjLFy4kHPnzpGebj5AMSkp+y5Z3759CQ8PZ+rUqXz77bc0b96cdu3a0bVr1xLtejRt2jQ2b7Y+3/jD79err77KxIkTC1XO0qVLuXXrFv/9738Ltb2w5OOuYtErEPIbZBgzBz9Pbqfi+WqWvyrzu9uRmK5n93UFVwf46gUNravl735NLQ81a/s6MOZXHVfuK7xcW833r1mfPWnB65k/0KEX9Hi7qfhHF0f8a1j/PnHQQEg7RxYeTCcuRaF1TTUL+hX/atXVqtrzQUglfl59n7h7Bpo3dWJYcMHH85QVPv9ujS4xndjllzA6Qe0vW+P5N99iL6fygHqkXU0iesZZjFo9Xm/Xo+aEXC58gVrLu3Lttc2knYxDU8mJ6rNewrGO7ck2Kvzfcxjuanmw5CwqezXuo1riNjj3WY08vu9JwpDNpG2+iMbbDbcpHXFoafvCUV3VDddf/k7qx1sxRtzFrkMdXBb2tp63hgeOaweT/sE6uJ55x15VqwIO03uh9quUa73U/+6Ncv0eypbT4GiP+qPOqHu1sL1Bu/qw4F2YsA7uJIKLIySlQUBDWPiuZf4R3SAyDub+mtkkOLQLfJzHDcWZgzNbNdYeBE83GP8GdCzmWaPEU6VJkyY0adKE/v3707dvX+rWtQz0i0qCiMcoZ9em4lS3bl0++ugjm68/yj76to5RpVIxa9Ysi1aVLH5+1vvd2nLu3DlGjhxJjRo1GDlyJNWqVcPR0RGVSsUXX3xh1kLi4eHBsmXLOHHiBIcOHeLEiRNMnz6d+fPnM3PmzFzHPRTFoEGD6N69u1najBkzACzmavbysuzWkh9xcXEsWbKEwMBAFEUxBWF372YOyEtMTDQFpA93/RK5++mCigxjZhcivRFuWfbEAOBMrMLemwoKkJQB//zdwGv11TTwzN8F+2sNNbzWUIPRqKBW297Gy1XN+kHOeeYD6L04ma1/ZvdXb+Jtx7M1Subr//k2LjzfxiVf9SrrNC721Pm+PeHPXwI1tAu2nF60uNQa35Ja41uaVqnNS9zs06SdzFwzwRCXRtysU3j0rYtKY/07W+WgwWt2Zyp92ynfM75ovFzw3NAPxaigyudnxaFHQxx6NEQxGlHZ+P3IYtezCXY9m6D89f2fV/4syv7LKFvPgEGB1AyM3+1BHdwOlV9l2xsN6Zj5MBpBrc7+1xq1Gr4eBFMHZj7Pz/lyd4EVH8PPuexXiBzmzp3L6tWrGT9+PF999RXPPvusKaDw8Sme6ZoliChm169ft0i7di1zlc/q1atbvJZftWrVIjw8nHv37uXaGlGzZk3u379P69atbV6gF1b16tU5ePAgSUlJFk1hV69excXFxTR4OTc1a9bk999/p2rVqqZWGluyWjIuXryY64d++/btGAwGZs2aZXaetVqtWStEFo1GQ6tWrUyzKF26dIkBAwawaNEiZs6cCVCoqc9y26ZOnTrUqWPefSHrPLZt27bAZVlz79490tPT+eWXX/jll18sXl+6dClLly5l6tSpubZWidNUUwABAABJREFUCXP7binsvmk+BmH+KYXxzytUcTF/z/990ECOsbIkpsPMIwa+61awr9v8XoDnle/oTb1ZAAGw9EgGE7sbqFWh5KaRlgCiAB7hNWF+vtcMienEzTxllpb6RwxJOyMpn8daEYX63izEZyW/AUFB8wIY/7Ut805BlvupGL8NQzOjX94bZ5WVnzILM72mBBDF7kmbujW/hg0bxrBhw7hz5w5r1qxh9erVfP7553z++ee0adOG/v3788YbbxRp9kj5NBaztWvXmi3mkZyczLp163Bzc8Pf37/Q+826gz1r1iyLcQdKjilaAgMDuXfvHj///LPV/WR1EyqMDh06YDQaWbp0qVn6gQMHiIiIICAgIF+BS9ag4zlz5lhdBC1nHTt16oS9vT0LFy40O69Zso49q1tYznMBsHjxYovzlZCQYLEfX19fnJycePAge6Bj1p36xEQrg/lscHZ2NtvHo1a9enWmTp1q8chaiyIwMJCpU6eWWGvL0+puquUgZoMC8VaGF8VamR4/NiX31adL0t1ky0HVigJxyY+vTqJ0MyRmoKRbfjfrY8vGOj9KrOWNJ2tpQjwJqlSpwsiRI9m7dy83b97kv//9LyqVijFjxhS5RUJaIoqZh4cHb7/9tmnAdGhoKDExMYwbN65I3Zc6d+5Mly5d2LJlC5GRkQQEBODm5sbNmzc5ePAgq1evBuDNN9/k0KFDzJw5kyNHjtC6dWtcXFyIiYnhyJEjODg4MH/+/ELVoWfPnmzevJkffviB27dv07JlSyIjI1m7di2enp5mMy3lpnHjxgwdOpQFCxbw1ltv0blzZ7y8vIiLi+P8+fMcOHCAP/74A8j88I8ZM4avv/6a/v37ExgYiLe3N7GxsYSHhzN+/HgaNGhAhw4dWL58OR9++CG9e/fG3t6eQ4cOcfnyZYvWkSlTphAbG0vbtm3x9vYmPT2dnTt3kpKSQmBgoClf06ZNWb16NVOnTqV9+/bY2dnRpEmTXFuUmjZtysaNG5k7dy61a9dGpVIREBBQ5K5D0dHRbNmyBcC0RsjevXu5c+cOgOm8uLq62lxnAzK7ukkLRMF19lHh4QgJOYbaNPaEZ6x0UXrjGTWnYs0vwIIaPr77NS/VtaeSi4q4HIFM3Upqnq3+eBazFKWfQy03yrWpQurhO6Y0tYs95bv7Pr5KPULqN/wxTjYfv6YOyn0MiRBPAm9vbxo3bswzzzzD2bNnTYscF5YEEcVs1KhRnDx5kjVr1hAfH0+tWrWYMmUK3bp1K/K+//nPf9KiRQs2btzIwoUL0Wg0VKtWzeyi0M7OjhkzZrB27Vq2bt1qChi8vLxo3Lgxr776aqHLt7OzY/bs2abF5sLCwnBzc6NTp06MGDGiQIO1hw4dSqNGjVi5ciUrVqxAq9VSsWJF/Pz8+OSTT8zyBgUFUaNGDZYtW8bKlSvR6XR4eXnRunVr07oTzz77LNOmTeP7779n3rx5ODo60qZNGxYsWMCQIUPM9tejRw9CQ0PZsmUL9+/fx8XFhTp16vD111/TqVP2okVdu3YlIiKCHTt2sGvXLoxGIxMmTMg1iBgxYgSJiYmsWbOGpKQkFEVh06ZNRQ4ioqKimDdvnllaWFgYYWFhpuOXqfBKTnlHFVv7aPg4zMCZOHixuorZna0HBp89r+ZBusLiU0ac7GB0Gw39Gz++C/ZyDiq2DXNj9PpUTtzSU91dTdNqGn46msGAVg7S7UhY5bO2O1Hvh5O8+xaOz1Sg2jcvYOdVNsZRqcf1gOR0jD/8Di6OqD/ugvp1CSKeVspT/hWoKAp79uxh1apVrF+/nri4OCpUqED//v3p1y8fXfRyoVIe7v8hCiVrxep58+aZrVYshBClgcGo8Nz/HnA0MruVZOjzjszv55LLVqKk6XQ6lixZAkBwcDD29tZn4xJClIwfaq/Nd963r9meVbK02bdvH6tXr2bt2rXExsZSvnx5evXqRb9+/ejcuTN2dkVvR5CWCCGEKAN+i9CZBRAAiw6lMyXQGS9XGR4nhBBPk5deeglXV1d69uxJv3796NatGw4ODnlvWAASRAghRBmQmGZlcLgRktIUvErvouZCCCEKYc2aNQQGBpbYcgIgQYQQQpQJ3Z5xoEK5VO7nmGnqOR8NdSrJAGshRNllfEqneO3Tp0+JlyFt2MWkZ8+eHD16VMZDCCFKpfJOKnYOd6NTfTu8y6vo38KBXwa75b2hEEIIYYW0RAghRBnhX9OO30aUf9zVEEII8RSQIEIIIYQQQpRJT/sUryVJujMJIYQQQgghCkSCCCGEEEIIIUSBSBAhhBBCCCHKJEWlyvfjSfPgwQOmTp1K165dadGiBYcPHwYgPj6e6dOnc/ny5SLtX8ZECCGEEEII8RS5desWL730EpGRkdSrV48LFy6QnJwMQMWKFZk/fz43btxg5syZhS5DggghhBBCCCGeIp9++ilJSUmcPHmSypUrU7lyZbPXe/XqxebNm4tUhnRnEkIIIYQQ4imyY8cOPvjgAxo1aoTKSlesOnXqEBkZWaQypCVCCCGEEEKUSU/iWIf80Gq1eHl52Xw9KSmpyGVIS4QQQgghhBBPkUaNGrF3716br2/YsIEWLVoUqQwJIoQQQgghhHiKjB49mpUrV/L111+TmJgIgNFo5PLlywwcOJCDBw/y0UcfFakM6c4khBBCCCHKpKd1xeoBAwZw48YNxo0bx5dffglAt27dUBQFtVrNv/71L3r16lWkMiSIEEIIIYT4IwJ2n4FnasBrrUGjedw1EqJIvvzySwYOHMi6deu4fPkyRqMRPz8/Xn/9derUqVPk/UsQIYQQQoiy7etf4POfsp93awFbx8FTOuhWPN1SU1N58cUXGTJkCCEhIUXutmSLjIkQQgghRNmVrIXJa8zTtp/IbJUQ4glUrlw5rl27ZnVq1+IkQYQQQpQxt5IULt1XHnc1hCgd4pIgNd0yfe72R18X8cgpalW+H0+Sbt268euvv5ZoGRJECCFEGZFhUOgXaqDWfAP1Fxlot1zP3VQJJkQZ51sZKrhYph++/OjrIkQx+eqrr7h48SIDBw5k//79REVFER8fb/EoChkTIYQQZcTckwqrI7KDhoO34f/2Gvi+m/wUiDLOxwvup5inWWudEOIJ0bhxYwD+/PNPli9fbjOfwWAodBnyyyGEEGXE/ijLVod1l+D7bo+hMkKUJtYa5BzkEqkseFpXrB4/fnyJj4mQvxAhhCgjKjhapiWmQ3Sygrfr0/lDKkS+JGkt04zS1U88uSZOnFjiZciYCCGEKCN8ylumKUBs6iOvihCli4uTZdqdBNhw6JFXRYgnhbRECCFEGXEh3vqd1VG7DIS+rsHdUVojRBnV7Vk4c8My/adw6NX2kVdHPDpP2qxL+TV58uQ886hUKr766qtCl1Gqg4iJEyeyefNmjh49mmfe27dv89prrzFkyBCGDRtWquo2dOhQoqOjCQ0NLfF62VLQ8xMREcGMGTO4cOECSUlJj+y8CiFKzu+3rafvi4JvjhiZ0l5W6BVl1O371tPLl3u09RCimOTWnUmlUqEoytMdRIjHQ6/XM3bsWPR6PSEhIbi5uVGvXr3HXa1Hbs+ePURERBQoeFq+fDlubm707Nmz2OqhKArbtm1j3759nD9/nrt37+Lh4UH9+vV59913adKkiVn+69ev8/3333PhwgXu3r2LXq+natWqvPDCCwwaNIhKlSoVW93EkyXyge3XDkU/unoIUeocvmSZpgJG9XjkVRGiOBiNRqtpN27cYM6cOezdu5dt27YVqYxSPSZi3LhxHDhw4HFXo8yJiooiKiqKN998k379+tGjR48yG0QsXLiwQNusWLGi2FucMjIyGD9+PDdu3OCVV17h008/pXfv3kRERBAcHMzWrVvN8sfGxhIXF0fHjh0ZOXIkY8aMoW3btqxfv54BAwYUeV5o8eRJ1yuM+M2ALpdxoi0rP7r6CFGqPEiFlDTLdAWo6vGoayNEiVGr1dSuXZv//Oc/1KtXj1GjRhVpf0VuiTAYDOh0OpycrAxKKiI7Ozvs7KSx5FG7d+8eAO7u7sW6X0VR0Gq1lCsnzcNZhg4dCsCCBQts5tFoNMyfPx9/f3+z9N69e9O3b19mzJhBt27dUKsz7wm0adOGNm3aWOynZcuWfP7554SGhvL2228X41GI0u7L/UbmnrQdQXg5w9g2pfqekhAl5/2Ftrsz/XkLvCs+2vqIR+spneI1LwEBAXz22WdF2keBrtBDQ0OZNGkSc+bM4cyZM4SGhhITE8O4cePo2bMniqKwbt06NmzYwLVr11Cr1TRq1IghQ4bQqlUrs31t3ryZ1atXc/PmTfR6PZ6enjRt2pQxY8ZQoUIFwPa4g5MnTzJr1iwiIiJwcXGhU6dO9OnTx2Z9582bZ1G+tXEKf/zxBxs3buTPP/8kLi4Oe3t7GjduzODBgy0u4IrD8ePH+f777zl37hx6vR5fX1/eeOMNevXqZZbv7NmzrF27ltOnT3Pnzh00Gg1169Zl4MCBdOzY0WK/+T0/1gwdOpTjx48DMGnSJCZNmgTApk2bqFatGlqtlkWLFrFz505iY2MpX748bdu2Zfjw4Xh7e5v2c/ToUUJCQpgwYQJarZY1a9Zw69Yt3nnnHVP3oB07drBq1SouXbqEwWAwHVPnzp0t6nX06FF+/PFHzp49i1arxcvLC39/fz744AM8PDwAWLNmDXv27OHq1avcv38fd3d32rRpw/Dhw6lWrZrZ/vbv38+yZcu4cuUKaWlpeHh40KhRI0aOHImPj4/Zecj52ZkwYYLNrkpZ+aKjo822yTp3hWVnZ2f18+fp6UnLli0JCwsjPj4+z25KVatWBSApKanQdRFPpu/P5D5VZS8/8HQumz+kQrA6lx4Pf/s37JwIzzd4ZNUR4lE4evSo6eZjYRXqNv/MmTPR6/X07t0bFxcXfHx8gMyFLX799Vc6depEz5490el0bNu2jffff59p06bx0ksvAbBlyxYmTpxIixYtCAkJwdHRkTt37nDgwAHi4+NNQYQ1Z8+eZcSIEZQrV45Bgwbh5ubGjh07mDBhQmEOxUxoaCiJiYn06NGDKlWqEBsby8aNGxkxYgTz5s2jRYsWRS4jy969e/n000/x9PRkwIABlCtXjh07djBlyhSioqJ4//33TXn37NnD9evX6dy5M97e3iQmJrJ582Y+/fRTpkyZQrdu2StFFfX8DB48mObNm7NkyRJ69+5tOuYKFSqg1+sZOXIkp06dolOnTgwYMICbN2+ybt06Dh06xLJly6hSpYrZ/lasWEFiYiK9evXC09PT9Pp3333H4sWLadeuHSEhIajVasLCwvj8888ZO3Ysffv2Ne1j3bp1TJ06lcqVK9OnTx+8vb2JiYlh37593LlzxxRE/PTTTzRp0oR+/frh7u7OlStX2LBhA0eOHGHlypWmfMeOHePjjz/Gz8+P4OBgXF1diYuL4/Dhw0RGRuLj48PgwYNRFIUTJ06YzXDQrFkzm+du8uTJTJ8+HQ8PDwYPHmxKz+3zXFSxsbHY29vj5uZm8Vp6ejparZb09HSuXbvGrFmzAHjhhRdKrD6i9LmVpJCYx8K7u25CcoaCq4MEEqIM0uTyuU9Jh/cXwPH/Prr6CFEMli1bZjU9ISGBvXv38ssvv/Dee+8VrRClADZt2qT4+/srvXv3VrRardlru3fvVvz9/ZV169aZpet0OmXAgAFKz549FaPRqCiKonzyySdKQECAotPpci1vwoQJir+/v1lacHCw0rZtW+X69eumtIyMDGXgwIGKv7+/Mm/ePIv6HjlyxGLfQ4YMUV599VWztNTUVIt8cXFxyssvv6yMGjUqz7rZ8nBZer1eCQwMVF566SUlNjbW7DiCg4OV1q1bKzdu3Mi1XlqtVundu7cSFBRkll6Q82PLkSNHFH9/f2XTpk1m6b/88ovi7++vzJgxwyx93759ir+/vzJu3DiLfXTs2FG5d++eWf7z588r/v7+yuzZ/8/encfXdO2P/3+dDIIkEtIgpgQpLmIeepWg0WoT6W0qSF3VG5oIckur3H76UcH1+V3Ve100MdbcmoKKBClaidKaSk0lMYSQQaQkTUg4J2f//sg3h+2cROaQvJ+Px3m0Z+21z1p7ZTtnv/cadqhR2R999JHi7u6uZGdnK4qiKKmpqcpLL72k+Pr6Kn/88YdR/ry8PMP/m2qno0ePKt27d1fWrFljSPvPf/6jdO/e3aheTyrJ37jAkCFDlICAgGLnDwgIKFH+xxW0+2effWZy+6ZNm5Tu3bsbXt7e3sru3btLVVZF+f3335Xc3FzD+6ysLNXf+cGDB0p6erpqn+Tk5CLfp6SkGL5rpIxkJepynsIX2qe+Xt6gfaaPo7qW8fDhQ2XZsmXKsmXLlJs3bz63x/HclvHZBkXB5+kvvf7ZPo4aUEZFWewWWezX80Sj0RT6cnR0VP7nf/7H6Fq+pErVE+Hr62s0B2L37t1YW1szYMAAMjIyVNv69evH8uXLSUxMxNnZGRsbG3Jzczl06BD9+/cv9mO579y5w5kzZ/Dw8DD0fgBYWloycuRIpk+fXprDMahTp47h/+/fv8/Dhw8xNzenY8eOnDt3rkyf/bgLFy6QmprKyJEjcXR0NKRbWloyevRoPv74Y2JjY3n33XeN6pWbm0tubv4EsJ49e7Jt2zays7OxsbGp8PY5cOAAZmZm+Pv7q9L79u1LmzZtOHjwIHq9XtU95uXlRYMG6vGke/bsQaPR4OXlZXSuuLu7Exsby9mzZ3nppZfYv38/Wq2WgIAAk3fbHy+roJ30ej33799Hp9PRpk0bbGxsVH8/GxsbAH744QfeeuutSpt3U3BOPU6n0wEYtUOtWrWKnDuSmJhISEgIDRs25MMPPzSZZ8CAAbi4uJCTk0NcXByxsbFG5VS1J8+Ngr9NgVq1auHg4KBKe3zYnKn3BcO2pIz8z+x+T8HSDLTGC3WoHE6CCzn1ebnBo+/jZ+k4qmsZWq3W8L5hw4aq38Pn6TieyzJecIT/FmMhjF4vgkbz7B5HDSlDlExCQoJRmkajoX79+iavp0qjVFdPLVq0MEq7du0a9+7d47XXXit0vzt37uDs7Iy/vz8nT57k448/xs7Ojm7duvHyyy/z6quvYm1tXej+SUlJALi4uBhta9WqVckP5Ak3b94kLCyMI0eOGI0bL26gUxzJyfmLtZuqc+vWrYFHxwr57bZkyRJiY2NNrqxTEERUdPskJyfj6OhIvXrGj71t3bo18fHxZGRkqL48TJ0rCQkJKIqCr69voWUVTO6+ceMGAG3bPn086vHjx1mxYgXnz5/nwQP1+I3H/57Dhw8nNjaWuXPn8uWXX9K5c2f69OnD4MGDK3To0bx584iKijK57cl5IEOGDCl0jeekpCTGjx8PwKJFiwqtc6NGjQzDxwYMGMArr7zC6NGjyc3NNQoERfXV2FrDolfM+OAH/VMDiT8eKOSvaylEDaDLg5yHRedxsoel8owk8fzRaDQ4OjqqbkQ/Licnh9u3b5u8TiuuUgURplZiUhSF+vXrM2fOnEL3K7hAbtGiBeHh4Rw7dozjx49z8uRJ5syZw7Jly1ixYgXNmjUrTbWMFHXhn5eXp3p///59AgICyMnJ4Z133sHV1RVra2s0Gg1r1qzh+PHj5VKnklIUheDgYBISEvDz86N9+/bY2NhgZmZGZGQk0dHRJtcCflYUtmqXRqNh0aJFhU7qKThXiuv8+fMEBwfTrFkzgoODadKkCVZWVmg0Gj799FNVG9nb27Nu3TpOnTrF0aNHOXXqFPPnz2fZsmUsXLiwyHkPZTF69GjeeOMNVdqCBQsAmDx5sir98R6qxyUnJxMUFEROTg6LFy/G1dW12OW/+OKLtG3blq1bt0oQUcMEdTGjlZ3C4G2FT7BuWBdeaSEBhKhB6ljB2y9B+E+mt3dygV++AAt5CKN4/rRs2ZL169czcuRIk9t37tzJyJEjja6HS6LcxnE0b96cxMRE3NzcirWEZ61atejbty99+/YF8lfLmTx5Mt98802hS04VrHBz7do1o21Xr141Siu4Y/7HH8ZPWEpOTlYNYzl27Bi3b99mxowZvPnmm6q8S5YseerxlETTpk0B03UuSCvIc+nSJeLj400+MXrHjh2q9yVtn5Jq2rQpP//8M1lZWUZdYVevXsXa2towebkozZs356effqJx48a0bNmyyLwFEXJ8fLxqiNaToqOjycvLY9GiRYa2g/xI29RqRObm5vTo0cOwitKlS5cYNWoUK1euZOHChUDpep+K2qdVq1ZGPUIF7di7d++nfnZycjLjxo0jOzubxYsX065duxLX78GDB2RmZpZ4P/H8a2StIX/he9O6OoKVhQQRooZZOREUBbb+bLxt6l8kgKgBlGq6xKuiFL0qn1arLfPqTOW2MLiXlxd6vZ7Q0FCT2wuGp4Dx+G/AcEFU1AVOwTKwsbGxXL9+3ZCu1WrZsGGDUf6CC9Bjx46p0qOjo7l9+7Yqzdw8/4viyUY/cuRIuc6HgPxjbdy4MZGRkaSnpxvSdTod69evR6PRGFayKvgDP1mvy5cvExMTo0orafuU1IABA9Dr9axZs0aVfvjwYeLi4nB3dy/WCenpmf8E0LCwMJMR8OPnioeHB5aWlqxYsYLs7GyjvAXtUtjfb9WqVUY9NabOPxcXF2rXrq0KOAu6AEty0V2nTh2TQWtZpaSkEBQURFZWFqGhofzpT38qNO/j59TjTpw4wZUrV3Bzcyv3+oln3x8Pi/6hvCYr/4qayLYOfFHIc3NOXqncughRRn/88QeJiYkkJiYC+ddTBe8ff505c4ZNmzaVed5JufVEDBo0CG9vb7Zs2cLFixfp168f9vb2pKWlcebMGW7evElERAQAEydOxNbWlq5du9KoUSOysrKIjIxEo9EYLjAL8+GHHzJu3DjGjh3LsGHDDEuYmroYdXFxoVevXmzfvh1FUWjTpg3x8fHExMTQvHlzw6RWgC5duuDg4MCCBQtISUmhYcOGxMfHs3v3blxdXbl8+XJ5NRXm5uZMmzaNqVOn8t577+Hj40PdunXZt28fZ8+exd/f3xAAtWzZklatWrFu3Tpyc3NxdnYmMTGR7du34+rqyoULF0rdPiXl7e1NVFQUa9euJTk5mW7dunHjxg22bt2Kg4ODalnaonTo0IHAwECWL1/OyJEjGTRoEI6OjqSnp3PhwgUOHz7MkSNHgPxx/VOmTOHzzz/Hz88PLy8vnJycSEtLIzY2lhkzZtC2bVsGDBjAhg0bmDRpEj4+PlhaWnL06FEuX75s1DsyZ84c0tLS6N27N05OTjx48IB9+/Zx7949vLy8DPnc3NzYsmULc+fOpW/fvlhYWNCxY0dVT8eT3NzciIiIYMmSJbRs2RKNRoO7u3uhYxKL4969ewQFBZGcnMyIESO4fv26KkiE/J6Mgklqc+fOJT09nZ49e9K4cWMePnzIhQsX2Lt3L3Xr1jUaOiVqBrcXir4r5d6set6NE+KpWrwAdWoZz484dLFq6iNEKf33v/81LEuv0WiYPHlyob/5iqIUOQWhOMp1WZqQkBB69OjBt99+y5o1a9BqtTg4ONCuXTvVBaavry/79u1j+/btZGZmYmdnR9u2bZk2bZrRQ+Ge1KlTJ8LCwggNDWXt2rXY2NgYHqbm5+dnlH/27Nl88cUXREdHs3v3brp27crSpUv517/+RUpKiiGfra0toaGhLFq0iM2bN5OXl0e7du1YuHAhERER5RpEQP4qRIsXL2blypWsX78erVaLi4sL06dPVz1sztzcnIULF7JgwQKioqLIycmhdevWzJw5k/j4eKMgoqTtUxIWFhaEhoYaHjZ34MABbG1t8fDwYMKECUarMxQlMDCQ9u3bs2nTJjZu3EhOTg4NGjSgdevWfPzxx6q8vr6+NGvWjHXr1rFp0ya0Wi2Ojo707NnTMHG4S5cuzJs3j6+++oqlS5diZWVFr169WL58OQEBAarP8/T0JDIykl27dnH37l2sra1p1aoVn3/+OR4eHoZ8gwcPJi4ujr179/L999+j1+sJCQkpMoiYMGECmZmZhIeHk5WVhaIo7Ny5s0xBRGZmpmHS/ObNm03mWbp0qSGIGDx4MLt27WL37t3cvXsXjUZD48aNefvttxk9enSJ/k6i+lh7vvBtLzeF/+srT6wWNZSZGbRrCqeeWM3mtxtVUx9RqRRN9fnue+2117CxsUFRFKZNm8Y777xDt27dVHk0Gg3W1tZ07979qdfcT6NRnjZoSgghxHPv1fA89l9Xf91rgJ0+ZgxpXX1+RJ83Wq2W1atXA+Dv74+lpWUV16iGCloKy/Yap19dAi0bGaeLaiOsy55i55346xtPz/SMmDVrFkOHDqVjx44VVkblLJAvhBCiSjkbr8zMwBZIACEEwAsm/oFoCkkX4jkQEhJS4WVIECGEEDXAtJ5m7Licx+85+e/trGDBQFl5RggAvjtlnKYAteQyqbpTzKr3fLDDhw9z8uRJMjMzjRaa0Wg0fPbZZ6X+bPnXIYQQNUCbBhou+puz6aKCHhjeVkNj6+r94ylEsdx/AKevGae3bgxWMrxMPJ/u3LmDl5cXx44dQ1EUNBqNYQXLgv8vaxAh/dhCCFFDvFBXQ3A3Mz7oZiYBhBAqJv49jB5Q6bUQorxMnTqVM2fOsGHDBq5evYqiKHz33XfEx8cTFBREly5dSE5OLlMZEkQIIYQQouaqawWj3NVpDrYw8fmZRCvEk3bv3s24ceMYMWKE4cG2ZmZmuLq6EhYWhouLS5mXfJfhTEIIIYSo2ZaMg1aNYM9JaNUYPh2aH0iIaq+6PrE6IyODDh06AGBjYwOgemjva6+9xqefflqmMiSIEEIIIUTNZmUJ04flv4SoBpo0aUJqaioAVlZWNGzYkNOnT/OXv/wFgKSkJDRlDKAkiBBCCCGEEKIacXd3Z9++ffzv//4vACNGjGDevHmYm5uj1+tZsGABgwcPLlMZEkQIIYQQQoiaqXqOZuKjjz5i3759PHjwACsrK2bOnMn58+cNqzG5u7vz5ZdflqkMCSKEEEIIIYSoRtzc3HBzczO8r1+/Pvv37ycjIwNzc3PDZOuykCBCCCGEEEKIGsDe3r7cPkuWeBVCCCGEEDWSotEU+/W8SUxMJCgoiLZt29KgQQMOHjwIQHp6Oh988AGnTpl4UnsJSE+EEEIIIYQQ1chvv/1Gv3790Ov19O7dm8uXL6PT6QB44YUXOHToEPfu3WPlypWlLkOCCCGEEEIIIaqRadOmYW9vz5EjR9BoNDRs2FC13cvLi82bN5epDBnOJIQQQgghRDVy8OBBxo8fj6Ojo8nnQbRo0YKkpKQylSE9EUIIIYQQokZSzJ6/uQ7FodfrqVu3bqHbb9++jZWVVZnKkJ4IIYQQFSopS2HZaT07LunR6ZWqro4QQlR73bp1Y9euXSa36XQ6Nm3axEsvvVSmMiSIEEIIUWG+S9DT+qs8gvbp8YnQ02dDHve1EkgIIURF+p//+R+io6MZP348586dA+DWrVvs37+f1157jQsXLvDJJ5+UqQwZziSEEKJC7L+eHzg8yHuUdjwVvv5NIbBz9RxCIIR4vjyPS7cWxxtvvMGaNWuYNGkSy5cvB2DUqFEoikK9evVYt24d7u7uZSpDggghhBDl7sYfCp5b9ZjqdLh0V3oihBCior377ru8/fbb7N27l8uXL6PX62ndujWDBw+WJ1YLIYR4Ns3/Jc9kAAHwqkv1vPMnhBBV6dNPP8XPz49OnToZ0qytrfHx8amQ8mROhBBCiHK3/ZLp9E97w2su8tMjhBDlbe7cuYb5DwC///475ubm/PDDDxVSnvRECCGEKHd3ckynT+pmXrkVEUKIIlTXOREFFKXiho/K7SAhhBDl6tJdhXta09t2J+grtzJCCCEqhAQRQgghytUXx/UUdu9r9k8yqVoIIaoDGc4khBCiXCX+Ufi2G9mVVw8hRCW7kQ4bDoJGAyP7QbMXqrpGT1XdhjNdu3aNkydPApCZmQnApUuXsLe3N5m/W7dupS7rme6JmDlzJj169ChW3uTkZHr06MGyZcsquFb5SlK3wMBAvL29K7hGRStp+8TFxTF+/HgGDhxYqe0qhHj+ebUq/Ee5R6NKrIgQovKcToAOk+CTr+Ef66HjZDh3vaprVeN89tln9OzZk549ezJo0CAAJkyYYEgrePXo0YOePXuWqSzpiRBGdDod06ZNQ6fTERQUhK2tLS+++GJVV6vSxcTEEBcXx7hx44q9z4YNG7C1tS33oPHcuXPs2bOHCxcucOnSJXJycggJCTFZzv379/n666+5cOECcXFxpKWl0a1bN8PDZoSoaIGd4INCFgOxsYRcnUJti+p190+IGu+f4ZD12IoKmfdh3g5YN6nKqlTTrF69ulLLe6aDiOnTp/M///M/VV2NGicpKYmkpCQmT57MiBEjqro6VSYmJoaoqKgSBREbN27Eycmp3IOIw4cPEx4ejouLCy+++CJnzpwpNG9GRgbLly/HwcGBdu3a8fvvv5drXYR4Gq2+8ABhfyL882c9/9dPVmkSolqJPW+c9mtC5dejhKrTcKb33nuvUssrcxCRl5eHVquldu3a5VEfFQsLCywsnuk4p1oquOi0s7Mr189VFIWcnBzq1q1brp/7PAsMDAR4ai+Br68vo0ePpk6dOuzfv7/IIOKFF15g165dNGqUP26kX79+5VdhIYrhckbR2yOvKPyfnJZCVB9XUyE9yzj9cipk54BNncqvk6hwJbpCj4yMZNasWYSFhXH27FkiIyNJTU1l+vTpeHt7oygK27ZtY8eOHSQkJGBmZkb79u0JCAgwmj8QFRXFli1bSExMRKfT4eDggJubG1OmTKF+/fpA/ryDqKgoTpw4odr3119/ZdGiRcTFxWFtbY2HhwdDhw4ttL5Lly41Kj8wMJCUlBQiIyMNaUeOHCEiIoLffvuN9PR0LC0t6dChA2PGjKF79+4laapiOXnyJF999RXnz59Hp9Ph4uLCsGHDeOutt1T5zp07x9atWzlz5gy3bt3C3NwcV1dX3n33XQYOHGj0ucVtH1MCAwMNE3JmzZrFrFmzANi5cydNmjQhJyeHlStXsm/fPtLS0qhXrx69e/dm/PjxODk5GT7nxIkTBAUFERISQk5ODuHh4dy8eZO//e1vhjv7e/fuZfPmzVy6dIm8vDzDMRWM4XvciRMnWL9+PefOnSMnJwdHR0e6d+/OBx98YJgsFB4eTkxMDFevXuXu3bvY2dnRq1cvxo8fT5MmTVSfd+jQIdatW8eVK1fIzc3F3t6e9u3bExwcjLOzs6odHj93ChtC9Hi+lJQU1T4FbVcWDg4Oxc5bq1YtQwAhRFWYd6zoZVzr1aqkigghKseiXabTcx7CpkPw/quVWx9RKUp1m3/hwoXodDp8fHywtrbG2dkZgBkzZvDdd9/h4eGBt7c3Wq2WPXv2MHHiRObNm0f//v0B2LVrFzNnzqRr164EBQVhZWXFrVu3OHz4MHfu3DEEEaacO3eOCRMmULduXUaPHo2trS179+4lJCSkNIeiEhkZSWZmJp6enjRq1Ii0tDQiIiKYMGECS5cupWvXrmUuo8DBgweZOnUqDg4OjBo1irp167J3717mzJlDUlISEydONOSNiYnh2rVrDBo0CCcnJzIzM4mKimLq1KnMmTOH119/3ZC3rO0zZswYOnfuzOrVq/Hx8TEcc/369dHpdAQHB3P69Gk8PDwYNWoUiYmJbNu2jaNHj7Ju3Tqji9eNGzeSmZnJW2+9hYODg2H74sWLWbVqFX369CEoKAgzMzMOHDjAJ598wrRp0xg+fLjhM7Zt28bcuXNp2LAhQ4cOxcnJidTUVH788Udu3bplCCK+/vprOnbsyIgRI7Czs+PKlSvs2LGD48ePs2nTJkO+X375hY8++ojWrVvj7++PjY0N6enpHDt2jBs3buDs7MyYMWNQFIVTp04xe/ZsQ10ef5T8k2bPns38+fOxt7dnzJgxhvSizmchqqPffi96Gde3Xqw+wweEEMDpa4VvS82orFqISlaqICI3N5cNGzaohjAdOHCAPXv28Omnn/L2228b0v38/PD39+c///kP7u7uaDQaYmJisLa2ZsmSJarhSkFBQU8te/78+ej1elauXGkIXoYNG8bYsWNLcygq06dPp04ddZfb0KFDGT58OKtXry63ICIvL4958+ZRp04d1q5di6OjIwDDhw9n3LhxrF27Fm9vb1q0aAHA2LFjCQ4OVn2Gn58fI0eOZOXKlaogoqzt89JLL2FhYcHq1avp1KkTnp6ehm3ffvstp0+f5t1332XSpEcTpXr37s3kyZMJDQ3ln//8p+rzUlNT2bp1Kw0aNDCkXbx4kVWrVuHv768Klvz8/JgyZQphYWF4eXlhbW3NrVu3+Pe//42LiwurVq3C1tbWkH/8+PHo9Y/ueG7atMno7+fu7s6ECROIiIgwjBWMjY1Fr9cTFhamqtf777+vaofo6GhOnTqlaoOieHp6smTJEho0aFDsfYSojho8ZXRrUOdnemFAIURJ6YrofXyrV+XVoxSq05yIylaqb3JfX1+jORC7d+/G2tqaAQMGkJGRYXhlZ2fTr18/kpOTSUxMBMDGxobc3FwOHTpUosdx37lzhzNnztC/f3/DBTKApaUlI0eOLM2hqDx+AXr//n0yMjIwNzenY8eOnD9vYsJQKV24cIHU1FTefPNNQwAB+ccxevRo9Ho9sbGxJuuVm5tLRkYGubm59OzZk4SEBLKz8xder+j2OXDgAGZmZvj7+6vS+/btS5s2bTh48KDqoh7Ay8tLdaEOsGfPHjQaDV5eXqpzJSMjA3d3d+7du8fZs2cB2L9/P1qtloCAAFUAUcDM7NEpXNBOer2e7OxsMjIyaNOmDTY2Npw7d86Qz8bGBoAffvgBnU5XhhYpmYJz6vGXTqdDp9MZpd+/f7/S6lWV7ty5w4MHDwzvs7Ozycp6NK724cOHRhPDU1JSinyfmpqq+l6RMiq/jF6NKZQGhTVnHz3O+lk+jsouIy0trVoch5RR88q437SIOZQ5D8ulDPHsKVVPRMEd8sddu3aNe/fu8dprrxW63507d3B2dsbf35+TJ0/y8ccfY2dnR7du3Xj55Zd59dVXsba2LnT/pKQkAFxcXIy2tWrVquQH8oSbN28SFhbGkSNHVCc7gKYcI9Xk5GTAdJ1bt24NPDpWyG+3JUuWEBsby507d4z2yc7OxsbGpsLbJzk5GUdHR+rVq2ey3vHx8WRkZKiCBlPnSkJCAoqi4OvrW2hZBV8uN27cAKBt27ZPrd/x48dZsWIF58+fV31BAqq/5/Dhw4mNjWXu3Ll8+eWXdO7cmT59+jB48OAKHXo0b948oqKiTG57ch7IkCFDmDlzZoXV5VnxZIBZEOAVqFWrltF8kMfn3ph637ix+gpWyqj8Mnpm5UEhz6xW0PDBAQ0DWih0dNQ808dRGWVotY8CqoYNG6p+a56n45AyanYZdV/pApuPYFJ6FjY26mXiS1OGePaUKogwtRKToijUr1+fOXPmFLpfwQVyixYtCA8P59ixYxw/fpyTJ08yZ84cli1bxooVK2jWrFlpqmWkqAv/vLw81fv79+8TEBBATk4O77zzDq6urlhbW6PRaFizZg3Hjx8vlzqVlKIoBAcHk5CQgJ+fH+3bt8fGxgYzMzMiIyOJjo42uvv/LCls1S6NRsOiRYtUPQmPKzhXiuv8+fMEBwfTrFkzgoODadKkCVZWVmg0Gj799FNVG9nb27Nu3TpOnTrF0aNHOXXqFPPnz2fZsmUsXLiwyHkPZTF69GjeeOMNVdqCBQsAmDx5sir98R4qIZ43T3sEhALsu54fRAghqoGXCnmWlE1tGNChcutSQjKcqfTKbf3U5s2bk5iYiJubW7GW8KxVqxZ9+/alb9++QP5qOZMnT+abb77hH//4h8l9Cla4uXbtmtG2q1evGqUV3DH/448/jLYlJyer5mMcO3aM27dvM2PGDN58801V3iVLljz1eEqiadOmgOk6F6QV5Ll06RLx8fEEBAQYPa9gx44dqvclbZ+Satq0KT///DNZWVlGQ4uuXr2KtbV1oY9Vf1zz5s356aefaNy4MS1btiwyb0FPRnx8vGqI1pOio6PJy8tj0aJFhrYDyMnJMepVAjA3N6dHjx6GVZQuXbrEqFGjWLlyJQsXLgRK1/tU1D6tWrUy6hEqaMfevXuXuCwhnlXxd5+ex1XWGxCi+mjTND9gyM5Vp3/xHtSxqpo6iQpXbrPbvLy80Ov1hIaGmtz++Ni3jIwMo+3t2rUDIDMzs9AyCpaBjY2N5fr1R49S12q1bNiwwSh/wQXosWPHVOnR0dHcvn1blWZunv/goyfnaBw5ckQ1nr48tGvXjsaNGxMZGUl6erohXafTsX79ejQajWElq4I79U/W6/Lly8TExKjSSto+JTVgwAD0ej1r1qxRpR8+fJi4uDjc3d0L7Vl4XMGk47CwMKMeIVCfKx4eHlhaWrJixQrD3I/HFbRLYX+/VatWGfXUmDr/XFxcqF27tirgLJhjUdQ5+aQ6deqYDFqFqEnMzYoOwF+0B8+WcvdPiGqjdq38gOHxG2l/6QXjCh/iLp5/5dYTMWjQILy9vdmyZQsXL16kX79+2Nvbk5aWxpkzZ7h58yYREREATJw4EVtbW7p27UqjRo3IysoiMjISjUbz1FVtPvzwQ8aNG8fYsWMZNmyYYQlTUxejLi4u9OrVi+3bt6MoCm3atCE+Pp6YmBiaN2+umlTbpUsXHBwcWLBgASkpKTRs2JD4+Hh2796Nq6srly9fLq+mwtzcnGnTpjF16lTee+89fHx8qFu3Lvv27ePs2bP4+/sbAqCWLVvSqlUr1q1bR25uLs7OziQmJrJ9+3ZcXV25cOFCqdunpLy9vYmKimLt2rUkJyfTrVs3bty4wdatW3FwcFCttFSUDh06EBgYyPLlyxk5ciSDBg3C0dGR9PR0Lly4wOHDhzlyJH9sZaNGjZgyZQqff/45fn5+eHl54eTkRFpaGrGxscyYMYO2bdsyYMAANmzYwKRJk/Dx8cHS0pKjR49y+fJlo96ROXPmkJaWRu/evXFycuLBgwfs27ePe/fu4eXlZcjn5ubGli1bmDt3Ln379sXCwoKOHTuqejqe5ObmRkREBEuWLKFly5ZoNBrc3d2NVo0qqZSUFHbtyl+Hu6BX6eDBg9y6dQvA0C4FNm/ebOiB0el0pKam8tVXXwHQpk0b3N3dy1QfIYrSp4jHomiAnT5mTw00hBDPmaDB0L8DfH8G2jaBQZ3VQcUzSpHvolIr18dBh4SE0KNHD7799lvWrFmDVqvFwcGBdu3aqS4wfX192bdvH9u3byczMxM7Ozvatm3LtGnTjB4K96ROnToRFhZGaGgoa9euxcbGxvAwNT8/P6P8s2fP5osvviA6Oprdu3fTtWtXli5dyr/+9S/VzH9bW1tCQ0NZtGgRmzdvJi8vj3bt2rFw4UIiIiLKNYiA/KVHFy9ezMqVK1m/fj1arRYXFxemT5+ueticubk5CxcuZMGCBURFRZGTk0Pr1q2ZOXMm8fHxRkFESdunJCwsLAgNDTU8bO7AgQPY2tri4eHBhAkTjCZvFSUwMJD27duzadMmNm7cSE5ODg0aNKB169Z8/PHHqry+vr40a9aMdevWsWnTJrRaLY6OjvTs2dPw3IkuXbowb948vvrqK5YuXYqVlRW9evVi+fLlBAQEqD7P09OTyMhIdu3axd27d7G2tqZVq1Z8/vnneHh4GPINHjyYuLg49u7dy/fff49eryckJKTIIGLChAlkZmYSHh5OVlYWiqKwc+fOMgcRSUlJLF26VJV24MABDhw4YDj+x4OIr7/+WnV+JycnG/YfMmSIBBGiQnVtqMHSDLQmpms1qA3tHGSJVyGqpT81y3+JGkGjlGSNVSGEEKIYXFfouFLISMDf/M34kwQSQP5w09WrVwPg7++PpaVlFddIiJplXv+Dxc47LVZuwD1OvsWFEEKUu7pFXAuP3v3srignhBCieCSIEEIIUe56NC58nPGJW5D4h3SCCyGqnqLRFPsl1CSIEEIIUe5m/NkM21qFb7+vLXybEEKIZ58EEUIIIcqdi52GDg6mt73kBO0c5K6eEEI8zySIEEIIUSG6NDQOFNo7QMRb5lVQGyGEMCbDmUpPggghhBAVYvpLZrjaP3rftgHsH2ZOQ2v5MRZCiOdduT4nQgghhCjQ1FbDb/7mfJ+oYKaBV1posJAHOwkhRLUgQYQQQogKY2mu4fWWEjgIIUR1I0GEEEIIIYSokWSuQ+nJnAghhBBCCCFEiUgQIYQQQgghhCgRGc4khBBCCCFqJBnOVHrSEyGEEEIIIYQoEQkihBBCCCGEECUiw5mEEEIIIUSNJMOZSk96IoQQQgghhBAlIj0RQgghytUDncKOywq374N3aw3OdnKnTwghqhsJIoQQQpSb7IcKf96Qx7n0/PdTYmHHX8x4o5V0fAshRHUi3+pCCCHKzd/26A0BBMDDPPjkR33VVUgIIYqgaDTFfgk1CSKEEEKUiysZCtsuKSbSK78uQgghKpYEEUIIIcrFkWTjAALgRfvKrYcQQoiKJ0GEEEKIcmFby3T6r7chJlGGNAkhnj2KpvgvoSZBhBBCiHLRq3Hh25acNt1LIYQQ4vkkQYQQQohycfxW4dt00hEhhBDVigQRQgghysWNPwrfFthJxgIIIUR1Is+JEEIIUS5edTad/pozDG4p96yEqBCZ92DOVvjxN+jYAj4bBs4Nq7pWzw1ZurX0qtW3+syZM+nRo0ex8iYnJ9OjRw+WLVtWwbXKV5K6BQYG4u3tXcE1KlpJ2ycuLo7x48czcODASm1XIcSzo7mt6XTLavVLI8QzRFHAfTr8OwKOXoKV38OAGfBQW9U1EzWA9ESIMtPpdEybNg2dTkdQUBC2tra8+OKLVV2tShcTE0NcXBzjxo0r9j4bNmzA1ta23IPGr7/+moMHD3L9+nX++OMP6tWrh4uLC35+fgwcOLBcyxKiwJ4E05Ono6/BD4l6Xmkh0YQQ5WpMKJy5rk67lgZ7T8OQ4t24FKK0qtU3+vTp0zl8+HBVV6PGSUpKIikpiXfeeYcRI0bg6elZY4OIFStWlGifjRs3EhkZWe51OX/+PE2aNGHkyJF88sknjBo1itzcXKZOncpXX31V7uUJceimwug9poOIPAVm/ywzq4UoV2kZsD7W9DbzanV5V6HkidWlV+k9EXl5eWi1WmrXrl3un21hYYGFhXSuVLbff/8dADs7u3L9XEVRyMnJoW7duuX6uc+zwMBAAJYvX15kvn/9619Gae+88w7vvvsu69atw9/fH3Nz8wqpo6iZgr/PI7uIERTxdyqvLkLUCOlZkGciODfTwMAOlV8fUeNU6BV3ZGQks2bNIiwsjLNnzxIZGUlqairTp0/H29sbRVHYtm0bO3bsICEhATMzM9q3b09AQIDR/IGoqCi2bNlCYmIiOp0OBwcH3NzcmDJlCvXr1wfy5x1ERUVx4sQJ1b6//vorixYtIi4uDmtrazw8PBg6dGih9V26dKlR+YGBgaSkpKjuGh85coSIiAh+++030tPTsbS0pEOHDowZM4bu3buXVzManDx5kq+++orz58+j0+lwcXFh2LBhvPXWW6p8586dY+vWrZw5c4Zbt25hbm6Oq6sr7777rsmhLMVtH1MCAwM5efIkALNmzWLWrFkA7Ny5kyZNmpCTk8PKlSvZt28faWlp1KtXj969ezN+/HicnJwMn3PixAmCgoIICQkhJyeH8PBwbt68yd/+9jfD8KC9e/eyefNmLl26RF5enuGYBg0aZFSvEydOsH79es6dO0dOTg6Ojo50796dDz74AHt7ewDCw8OJiYnh6tWr3L17Fzs7O3r16sX48eNp0qSJ6vMOHTrEunXruHLlCrm5udjb29O+fXuCg4NxdnZWtcPj505ISEihQ5UK8qWkpKj2KWi78mZhYYGjoyOXL19Gp9NJECHKjaIonLlddJ56hTyITghRSk0bQG1LyH0ietcr0PbvYGYGbZrA/w4FdwkqRPmrlNv2CxcuRKfT4ePjg7W1Nc7O+Ut4zJgxg++++w4PDw+8vb3RarXs2bOHiRMnMm/ePPr37w/Arl27mDlzJl27diUoKAgrKytu3brF4cOHuXPnjiGIMOXcuXNMmDCBunXrMnr0aGxtbdm7dy8hISFlPq7IyEgyMzPx9PSkUaNGpKWlERERwYQJE1i6dCldu3YtcxkFDh48yNSpU3FwcGDUqFHUrVuXvXv3MmfOHJKSkpg4caIhb0xMDNeuXWPQoEE4OTmRmZlJVFQUU6dOZc6cObz++uuGvGVtnzFjxtC5c2dWr16Nj4+P4Zjr16+PTqcjODiY06dP4+HhwahRo0hMTGTbtm0cPXqUdevW0ahRI9Xnbdy4kczMTN566y0cHBwM2xcvXsyqVavo06cPQUFBmJmZceDAAT755BOmTZvG8OHDDZ+xbds25s6dS8OGDRk6dChOTk6kpqby448/cuvWLUMQ8fXXX9OxY0dGjBiBnZ0dV65cYceOHRw/fpxNmzYZ8v3yyy989NFHtG7dGn9/f2xsbEhPT+fYsWPcuHEDZ2dnxowZg6IonDp1itmzZxvq0qlTp0Lbbvbs2cyfPx97e3vGjBljSC/qfC6pzMxM9Ho9GRkZ7N+/n59//pkePXpgZWVVbmUIodFo6NYIfiniORFXM+BqhkIrexkSIES5GLXQOIAokJie/99raRB7Hs78Nz+gEEb0Mkyp1ColiMjNzWXDhg2qIUwHDhxgz549fPrpp7z99tuGdD8/P/z9/fnPf/6Du7s7Go2GmJgYrK2tWbJkiWq4UlBQ0FPLnj9/Pnq9npUrVxqCl2HDhjF27NgyH9f06dOpU6eOKm3o0KEMHz6c1atXl1sQkZeXx7x586hTpw5r167F0dERgOHDhzNu3DjWrl2Lt7c3LVq0AGDs2LEEBwerPsPPz4+RI0eycuVKVRBR1vZ56aWXsLCwYPXq1XTq1AlPT0/Dtm+//ZbTp0/z7rvvMmnSJEN67969mTx5MqGhofzzn/9UfV5qaipbt26lQYMGhrSLFy+yatUq/P39VcGSn58fU6ZMISwsDC8vL6ytrbl16xb//ve/cXFxYdWqVdjaPlouZvz48ej1j7p+N23aZPT3c3d3Z8KECURERPDee+8BEBsbi16vJywsTFWv999/X9UO0dHRnDp1StUGRfH09GTJkiU0aNCg2PuU1Ntvv01mZiYA5ubmvPLKK3zyyScVUpao2f7RU8PwqMKfSq1VYNNFhU9fkh9sIcrsdibs+qV4eR9oYeOPEDKiYuskapxKmXnj6+trNAdi9+7dWFtbM2DAADIyMgyv7Oxs+vXrR3JyMomJiQDY2NiQm5vLoUOHUJTCf6SedOfOHc6cOUP//v0NF8gAlpaWjBw5sszH9fgF6P3798nIyMDc3JyOHTty/vz5Mn9+gQsXLpCamsqbb75pCCAg/zhGjx6NXq8nNvbR5KrH65Wbm0tGRga5ubn07NmThIQEsrOzgYpvnwMHDmBmZoa/v78qvW/fvrRp04aDBw+qLuoBvLy8VBfqAHv27EGj0eDl5aU6VzIyMnB3d+fevXucPXsWgP3796PVagkICFAFEAXMzB6d8gXtpNfryc7OJiMjgzZt2mBjY8O5c+cM+WxsbAD44Ycf0Ol0ZWiRkik4px5/6XQ6dDqdUfr9+/dNfsYXX3xBaGgoM2bMoHfv3jx48IB79+5V2jE8zZ07d3jw4IHhfXZ2NllZWYb3Dx8+NMy5KZCSklLk+9TUVNX3hJRROWX8cIOnqmPx7B9HVZaRlpZWLY5DyqiEMiwtSjR5Wqn9aDzhM3UcJShDPHsqpSei4A75465du8a9e/d47bXXCt3vzp07ODs74+/vz8mTJ/n444+xs7OjW7duvPzyy7z66qtYW1sXun9SUhIALi4uRttatWpV8gN5ws2bNwkLC+PIkSOqfxyQ371fXpKTkwHTdW7dujXw6Fghv92WLFlCbGwsd+4Yz2bMzs7GxsamwtsnOTkZR0dH6tWrZ7Le8fHxZGRkqIIGU+dKQkICiqLg6+tbaFkFX0Y3buRfybRt2/ap9Tt+/DgrVqzg/Pnzqi87QPX3HD58OLGxscydO5cvv/ySzp0706dPHwYPHlyuQ4+eNG/ePKKiokxue3IeyJAhQ5g5c6ZRvm7duhn+/8033+TTTz9l7NixhIeHm/y7VLYnA8aCgK1ArVq1cHBwUKU9PpfG1PvGjRtLGVVQxqW7Rd/gqW8Ff/2ThgbWz/ZxVHYZWu2j4SgNGzZU/XY8T8chZVRBGf6vwIp9PJWDLZrR/UtXRiH1roq2Es+eSgkiTK3EpCgK9evXZ86cOYXuV3CB3KJFC8LDwzl27BjHjx/n5MmTzJkzh2XLlrFixQqaNWtWLvUs6sI/Ly9P9f7+/fsEBASQk5PDO++8g6urK9bW1mg0GtasWcPx48fLpU4lpSgKwcHBJCQk4OfnR/v27bGxscHMzIzIyEiio6ON7v4/SwpbtUuj0bBo0SJVT8LjCs6V4jp//jzBwcE0a9aM4OBgmjRpgpWVFRqNhk8//VTVRvb29qxbt45Tp05x9OhRTp06xfz581m2bBkLFy4sct5DWYwePZo33nhDlbZgwQIAJk+erEp/vIeqKEOGDGHv3r388MMPRhPyhSiLdg00fJ9YeCAxp68ZDa1lKJMQ5WZxINStBQt3GW+zsoABbtDGCSYNAacGxnkEAAryvVRaVbYeavPmzUlMTMTNza1YS3jWqlWLvn370rdvXyB/tZzJkyfzzTff8I9//MPkPgUr3Fy7ds1o29WrV43SCu7M/vHHH0bbkpOTVfMxjh07xu3bt5kxYwZvvvmmKu+SJUueejwl0bRpU8B0nQvSCvJcunSJ+Ph4AgICjB56tmPHDtX7krZPSTVt2pSff/6ZrKwso6FFV69exdra2jB5uSjNmzfnp59+onHjxrRs2bLIvAU9GfHx8aohWk+Kjo4mLy+PRYsWGdoOICcnx6hXCfLnE/To0cOwitKlS5cYNWoUK1euZOHChUDpep+K2qdVq1ZGPUIF7di7d+8SlwUYelxMneNClMWk7maE/ZpncpuFGfi8KD/UQpQrC/P8eQ6LdoFR/K6B6M+qolaiBqmyp5F4eXmh1+sJDQ01uf3xsXIZGRlG29u1awdgmDRqSsEysLGxsVy//uiJjlqtlg0bNhjlL7gAPXbsmCo9Ojqa27fV6xcWLI/55ByNI0eOqMbTl4d27drRuHFjIiMjSU9PN6TrdDrWr1+PRqMxrGRVcKf+yXpdvnyZmJgYVVpJ26ekBgwYgF6vZ82aNar0w4cPExcXh7u7e6E9C48rmHQcFhZm1CME6nPFw8MDS0tLVqxYYZj78biCdins77dq1SqjnhpT55+Liwu1a9dWXYwXzLEo6px8Up06dcr9gj4nJ8fkHIm8vDzCw8MBcHNzK9cyhXixvoZejU1vWzhQg5ONBBFClLtdv5gIIIC2shKTqHhV1hMxaNAgvL292bJlCxcvXqRfv37Y29uTlpbGmTNnuHnzJhEREQBMnDgRW1tbunbtSqNGjcjKyiIyMhKNRvPUVW0+/PBDxo0bx9ixYxk2bJhhCVNTF6MuLi706tWL7du3oygKbdq0IT4+npiYGJo3b66aVNulSxccHBxYsGABKSkpNGzYkPj4eHbv3o2rqyuXL18ut7YyNzdn2rRpTJ06lffeew8fHx/q1q3Lvn37OHv2LP7+/oYAqGXLlrRq1Yp169aRm5uLs7MziYmJbN++HVdXVy5cuFDq9ikpb29voqKiWLt2LcnJyXTr1o0bN26wdetWHBwcVCstFaVDhw4EBgayfPlyRo4cyaBBg3B0dCQ9PZ0LFy5w+PBhjhw5AkCjRo2YMmUKn3/+OX5+fnh5eeHk5ERaWhqxsbHMmDGDtm3bMmDAADZs2MCkSZPw8fHB0tKSo0ePcvnyZaPekTlz5pCWlkbv3r1xcnLiwYMH7Nu3j3v37uHl5WXI5+bmxpYtW5g7dy59+/bFwsKCjh07qno6nuTm5kZERARLliyhZcuWaDQa3N3djVaNKonExEQCAwPx8PDA2dkZOzs70tLS+O6777h+/TpDhgwp1+WHhSjQ00nDsVTjK5q2DSSAEKJC2BUykmNO2RdHqSnkSdSlV6WPdw4JCaFHjx58++23rFmzBq1Wi4ODA+3atVNdYPr6+rJv3z62b99OZmYmdnZ2tG3blmnTphk9FO5JnTp1IiwsjNDQUNauXYuNjY3hYWp+fn5G+WfPns0XX3xBdHQ0u3fvpmvXrixdupR//etfqpUCbG1tCQ0NZdGiRWzevJm8vDzatWvHwoULiYiIKNcgAvKXHl28eDErV65k/fr1aLVaXFxcmD59umpsu7m5OQsXLmTBggVERUWRk5ND69atmTlzJvHx8UZBREnbpyQsLCwIDQ01PGzuwIED2Nra4uHhwYQJE4wmYhUlMDCQ9u3bs2nTJjZu3EhOTg4NGjSgdevWfPzxx6q8vr6+NGvWjHXr1rFp0ya0Wi2Ojo707NnT8NyJLl26MG/ePL766iuWLl2KlZUVvXr1Yvny5QQEBKg+z9PTk8jISHbt2sXdu3extramVatWfP7553h4eBjyDR48mLi4OPbu3cv333+PXq8nJCSkyCBiwoQJZGZmEh4eTlZWFoqisHPnzjIFEY0aNcLT05Nff/2VmJgY7t27h42NDW3btuX9999XLfErRHnyaqkh7JRxELH9koJH4aMLhRCl9XpX6OQMZx6NJsD/FfDuWXV1EjWGRinJmqlCCCFEIX5L19NhjfHCDeM7w+JXq/Se1TNLq9WyevVqAPz9/bG0tKziGonnTsY9WPodXLgJHm4wqn/+06pFsXzmWcznbQD/3N29Amvy/JFvdSGEEOXicLLpdCdZlUmIimNvDZ+8/fR8wiQZzlR6EqoKIYQoF/a1THdsS3e3EEJUPxJECCGEKBenb5sOFzIfmEwWQgjxHJMgQgghRLnQKaaHBfycIn0RQghR3UgQIYQQolz4uJoOIq4X/9EpQghRqRSNptgvoSZBhBBCiHKhx/SPbOeGlVwRIYQQFU6CCCGEEOXiTw2gzhNr/mmAf/eXnxohhKhu5JtdCCFEubCvrWHRK2bUMs9/b66Bue5mtH9BfmqEEM8mRVP8l1CT50QIIYQoN+93MsO7tYaTtxTcHDU0s5VfXiGEqI4kiBBCCFGuGllreKOVBA9CCFGdSR+zEEIIIYQQokSkJ0IIIYQQQtRIelm6tdSkJ0IIIYQQQghRIhJECCGEEEIIIUpEhjMJIYQQQogaSZ5EXXrSEyGEEEIIIYQoEQkihBBCCCGEECUiw5mEEEIIUbPczoSZm+HnOOjWCmaOgGYvVHWtRBWQ4UylJ0GEEEIIIWoWr/+D45fz//9UAhy6COcXgLl5lVZLiOeJDGcSQgghRM1xOuFRAFEgLgl+vFA19RHiOSVBhBBCCCFqDstCBmEciavcegjxnJMgQgghhBA1R/vmYGZiHPy3Ryu/LqLK6TWaYr+EmgQRQgghjPyWruCzI48Xv9IxNjqPtHtKVVdJiPLTurFx2okrcDe78usixHNKggghhBAq97UK7pvy2HFZ4XIGrDqn4BORV9XVEqL8jHjZOE2vwP4zlV8XIZ5TEkQIIYQwSLun0HltHr/nqtN/SoYrGdIbIaqJD7xMp8eer9x6iCqnaIr/EmoSRAghhDD47LCeyxmmt9WRRcFFdZGWaTq9rlXl1kOI59gzHUTMnDmTHj16FCtvcnIyPXr0YNmyZRVcq3wlqVtgYCDe3t4VXKOilbR94uLiGD9+PAMHDqzUdhVCVK2fkk33NrS2hyY2citOVBP/DDednv5H5dZDiOeY3FcSRnQ6HdOmTUOn0xEUFIStrS0vvvhiVVer0sXExBAXF8e4ceOKvc+GDRuwtbUt16BRURT27NnDjz/+yIULF7h9+zb29va0adOGsWPH0rFjR6N99Ho9GzduZPv27aSkpFC/fn0GDRpEUFAQderUKbe6ierlYZ6CvpARSwmZcDNLoZmtBBLiOafXQ/Qp09u+OQhhAVBHeiSEeJpnuidi+vTpHD58uKqrUeMkJSWRlJTEO++8w4gRI/D09KyxQcSKFStKtM/GjRuJjIws13o8fPiQGTNmcP36dV577TWmTp2Kj48PcXFx+Pv7s3v3bqN95s+fz3//+19atWrF1KlT8fDwYNOmTXz44Yfo9fpyrZ+oPj47pOe3301v0yuQnlO59RGiQmjz4I9CTuaHOtj6c+XWR1QpBU2xX0KtzD0ReXl5aLVaateuXR71UbGwsMDCQjpLKtvvv+dfRdjZ2ZXr5yqKQk5ODnXr1i3Xz32eBQYGArB8+fJC85ibm7Ns2TK6d++uSvfx8WH48OEsWLCA119/HTOz/HsCV65cYfPmzQwcOJAvvvjCkL9Jkyb8+9//Zu/evbz++usVcDTiebfxYuETpy004GqvgPyQiuedlSW4/wlifzO9ffdJeHdApVZJiOdRia7QIyMjmTVrFmFhYZw9e5bIyEhSU1OZPn063t7eKIrCtm3b2LFjBwkJCZiZmdG+fXsCAgKM5g9ERUWxZcsWEhMT0el0ODg44ObmxpQpU6hfvz6QP+8gKiqKEydOqPb99ddfWbRoEXFxcVhbW+Ph4cHQoUMLre/SpUuNyg8MDCQlJUV11/jIkSNERETw22+/kZ6ejqWlJR06dGDMmDFGF3Dl4eTJk3z11VecP38enU6Hi4sLw4YN46233lLlO3fuHFu3buXMmTPcunULc3NzXF1deffddxk4cKDR5xa3fUwJDAzk5MmTAMyaNYtZs2YBsHPnTpo0aUJOTg4rV65k3759pKWlUa9ePXr37s348eNxcnIyfM6JEycICgoiJCSEnJwcwsPDuXnzJn/7298Mw4P27t3L5s2buXTpEnl5eYZjGjRokFG9Tpw4wfr16zl37hw5OTk4OjrSvXt3PvjgA+zt7QEIDw8nJiaGq1evcvfuXezs7OjVqxfjx4+nSZMmqs87dOgQ69at48qVK+Tm5mJvb0/79u0JDg7G2dlZ1Q6PnzshISGFDlUqyJeSkqLap6DtSsvCwsLk+efg4EC3bt04cOAAd+7c4YUXXgDgu+++Q1EURo4cqcrv4+NDaGgou3fvliBCmGRvBTeyTG/TKfDZIYX/vlK5dRKiQgzuWngQUd+6cusixHOqVLf5Fy5ciE6nw8fHB2tra5ydnQGYMWMG3333HR4eHnh7e6PVatmzZw8TJ05k3rx59O/fH4Bdu3Yxc+ZMunbtSlBQEFZWVty6dYvDhw9z584dQxBhyrlz55gwYQJ169Zl9OjR2NrasnfvXkJCQkpzKCqRkZFkZmbi6elJo0aNSEtLIyIiggkTJrB06VK6du1a5jIKHDx4kKlTp+Lg4MCoUaOoW7cue/fuZc6cOSQlJTFx4kRD3piYGK5du8agQYNwcnIiMzOTqKgopk6dypw5c1QXhGVtnzFjxtC5c2dWr16Nj4+P4Zjr16+PTqcjODiY06dP4+HhwahRo0hMTGTbtm0cPXqUdevW0ahRI9Xnbdy4kczMTN566y0cHBwM2xcvXsyqVavo06cPQUFBmJmZceDAAT755BOmTZvG8OHDDZ+xbds25s6dS8OGDRk6dChOTk6kpqby448/cuvWLUMQ8fXXX9OxY0dGjBiBnZ0dV65cYceOHRw/fpxNmzYZ8v3yyy989NFHtG7dGn9/f2xsbEhPT+fYsWPcuHEDZ2dnxowZg6IonDp1itmzZxvq0qlTp0Lbbvbs2cyfPx97e3vGjBljSC/qfC6rtLQ0LC0tsbW1NaT99ttvmJmZ0aFDB1VeKysr2rRpw2+/FfLDKWq8KT00/C268N6IhScVhrZR6NtMeiPEc2z6Bvi/rYVvH+NReXURVU6eRF16pQoicnNz2bBhg2oI04EDB9izZw+ffvopb7/9tiHdz88Pf39//vOf/+Du7o5GoyEmJgZra2uWLFmiGq4UFBT01LLnz5+PXq9n5cqVhuBl2LBhjB07tjSHojJ9+nSjSadDhw5l+PDhrF69utyCiLy8PObNm0edOnVYu3Ytjo6OAAwfPpxx48axdu1avL29adGiBQBjx44lODhY9Rl+fn6MHDmSlStXqoKIsrbPSy+9hIWFBatXr6ZTp054enoatn377becPn2ad999l0mTJhnSe/fuzeTJkwkNDeWf//yn6vNSU1PZunUrDRo0MKRdvHiRVatW4e/vrwqW/Pz8mDJlCmFhYXh5eWFtbc2tW7f497//jYuLC6tWrVJdLI8fP141vn/Tpk1Gfz93d3cmTJhAREQE7733HgCxsbHo9XrCwsJU9Xr//fdV7RAdHc2pU6dUbVAUT09PlixZQoMGDYq9T1kcOnSI8+fP4+npiZXVo0mABROva9WqZbRPw4YNOXPmDFqtFktLywqvo3i+jO5gxt+iC3+onAL8+4Sevs3MK69SQpSn3Ifw3yLmrVmYQQ/XyquPEM+xUk2s9vX1NZoDsXv3bqytrRkwYAAZGRmGV3Z2Nv369SM5OZnExEQAbGxsyM3N5dChQyhK8R9edOfOHc6cOUP//v0NF8gAlpaWRkM3SuPxC9D79++TkZGBubk5HTt25Pz58nsAzYULF0hNTeXNN980BBCQfxyjR49Gr9cTGxtrsl65ublkZGSQm5tLz549SUhIIDs7G6j49jlw4ABmZmb4+/ur0vv27UubNm04ePCg0aRdLy8v1YU6wJ49e9BoNHh5eanOlYyMDNzd3bl37x5nz54FYP/+/Wi1WgICAlQBRIGCeQDwqJ30ej3Z2dlkZGTQpk0bbGxsOHfunCGfjY0NAD/88AM6na4MLVIyBefU4y+dTodOpzNKv3//fpGflZiYSEhICA0bNuTDDz9UbcvNzS00QCgILHJzc01ur2x37tzhwYMHhvfZ2dlkZT0aT/Pw4UPDHJ0CKSkpRb5PTU1Vfa9IGcUv48sj2TzN7WztM38cz2sZaWlp1eI4nukyHmgh5yGF0unhzLVn/zhqYBni2VOqnoiCO+SPu3btGvfu3eO1114rdL87d+7g7OyMv78/J0+e5OOPP8bOzo5u3brx8ssv8+qrr2JtXfhYxKSkJABcXFyMtrVq1arkB/KEmzdvEhYWxpEjR1QnO4CmHLu7kpOTAdN1bt26NfDoWCG/3ZYsWUJsbCx37twx2ic7OxsbG5sKb5/k5GQcHR2pV6+eyXrHx8eTkZGhChpMnSsJCQkoioKvr2+hZRV8udy4cQOAtm3bPrV+x48fZ8WKFZw/f1715QWo/p7Dhw8nNjaWuXPn8uWXX9K5c2f69OnD4MGDK3To0bx584iKijK57cl5IEOGDGHmzJkm8yYlJTF+/HgAFi1aZFTn2rVrc/fuXZP7Pnz40JDnWfBkgFkQ4BWoVasWDg4OqrTH596Yet+4cWMpo5Rl7E2pS35/Q+Hec1P3cD2Lx/E8laHVPgrKGjZsqPqteZ6O47kqw7Mb7PqFQn17FDq5PPvHUcPKqCiKDGcqtVIFEaYuQBRFoX79+syZM6fQ/QoukFu0aEF4eDjHjh3j+PHjnDx5kjlz5rBs2TJWrFhBs2bNSlMtI0Vd+Oflqbvs79+/T0BAADk5Obzzzju4urpibW2NRqNhzZo1HD9+vFzqVFKKohAcHExCQgJ+fn60b98eGxsbzMzMiIyMJDo6+plesrOwi1WNRsOiRYtUPQmPKzhXiuv8+fMEBwfTrFkzgoODadKkCVZWVmg0Gj799FNVG9nb27Nu3TpOnTrF0aNHOXXqFPPnz2fZsmUsXLiwyHkPZTF69GjeeOMNVdqCBQsAmDx5sir98R6qxyUnJxMUFEROTg6LFy/G1dW4293R0ZGEhAQePnxoNKQpLS0Ne3t7GcokTGpYxMJplmbwf33NCOz8TK8MLsTTrfsAPl4Lq38wvb1h+a5MKER1VW7rpzZv3pzExETc3NyKtYRnrVq16Nu3L3379gXyx3dPnjyZb775hn/84x8m9ylY4ebatWtG265evWqUVnDH/I8/jJ9AmZycrJqPcezYMW7fvs2MGTN48803VXmXLFny1OMpiaZNmwKm61yQVpDn0qVLxMfHExAQYPTQsx07dqjel7R9Sqpp06b8/PPPZGVlGQ0tunr1KtbW1obJy0Vp3rw5P/30E40bN6Zly5ZF5i3oyYiPj1cN0XpSdHQ0eXl5LFq0yNB2ADk5OUa9SpC/bGqPHj0MqyhdunSJUaNGsXLlShYuXAiUrvepqH1atWpl1CNU0I69e/d+6mcnJyczbtw4srOzWbx4Me3atTOZr3379hw5coTz58+r5vE8ePCA+Ph4unXrVpxDETXQlB5mbInL457WeFsdC5jaSwIIUQ00sIVZfoUHEX91r9z6CPGcKrdfBC8vL/R6PaGhoSa3Pz72LSMjw2h7wQVRZmZmoWUULAMbGxvL9evXDelarZYNGzYY5S+4AD127JgqPTo6mtu3b6vSzM3zJwo+OUfjyJEjqvH05aFdu3Y0btyYyMhI0tPTDek6nY7169ej0WgMK1kV3Kl/sl6XL18mJiZGlVbS9impAQMGoNfrWbNmjSr98OHDxMXF4e7uXmjPwuMKJh2HhYUZ9QiB+lzx8PDA0tKSFStWGOZ+PK6gXQr7+61atcqop8bU+efi4kLt2rVVAWfBHIuizskn1alTx2TQWlYpKSkEBQWRlZVFaGgof/rTnwrN+9prr6HRaIz+5t9++y25ubmyvKsoVIcXNEzpYToQdrWv3LoIUaFWfm86vW0TqCfPMhKiOMqtJ2LQoEF4e3uzZcsWLl68SL9+/bC3tyctLY0zZ85w8+ZNIiIiAJg4cSK2trZ07dqVRo0akZWVRWRkJBqN5qmr2nz44YeMGzeOsWPHMmzYMMMSpqYuRl1cXOjVqxfbt29HURTatGlDfHw8MTExNG/eXDWptkuXLjg4OLBgwQJSUlJo2LAh8fHx7N69G1dXVy5fvlxeTYW5uTnTpk1j6tSpvPfee/j4+FC3bl327dvH2bNn8ff3NwRALVu2pFWrVqxbt47c3FycnZ1JTExk+/btuLq6cuHChVK3T0l5e3sTFRXF2rVrSU5Oplu3bty4cYOtW7fi4OCgWmmpKB06dCAwMJDly5czcuRIBg0ahKOjI+np6Vy4cIHDhw9z5MgRABo1asSUKVP4/PPP8fPzw8vLCycnJ9LS0oiNjWXGjBm0bduWAQMGsGHDBiZNmoSPjw+WlpYcPXqUy5cvG/WOzJkzh7S0NHr37o2TkxMPHjxg37593Lt3Dy8vL0M+Nzc3tmzZwty5c+nbty8WFhZ07NhR1dPxJDc3NyIiIliyZAktW7ZEo9Hg7u5utGpUSdy7d4+goCCSk5MZMWIE169fVwWJkN+TUTC+1NXVlWHDhrFlyxamTp3Kyy+/TEJCAps2baJbt24SRIgi1bbQYGpexNl0SM5WaGIj44dFNfDzRdPp202PhBDVl8yJKL1yfRx0SEgIPXr04Ntvv2XNmjVotVocHBxo166d6gLT19eXffv2sX37djIzM7Gzs6Nt27ZMmzbN6KFwT+rUqRNhYWGEhoaydu1abGxsDA9T8/PzM8o/e/ZsvvjiC6Kjo9m9ezddu3Zl6dKl/Otf/1LN/Le1tSU0NJRFixaxefNm8vLyaNeuHQsXLiQiIqJcgwjIX3p08eLFrFy5kvXr16PVanFxcWH69Omqh82Zm5uzcOFCFixYQFRUFDk5ObRu3ZqZM2cSHx9vFESUtH1KwsLCgtDQUMPD5g4cOICtrS0eHh5MmDDBaGJVUQIDA2nfvj2bNm1i48aN5OTk0KBBA1q3bs3HH3+syuvr60uzZs1Yt24dmzZtQqvV4ujoSM+ePQ3PnejSpQvz5s3jq6++YunSpVhZWdGrVy+WL19OQECA6vM8PT2JjIxk165d3L17F2tra1q1asXnn3+Oh8ej9cEHDx5MXFwce/fu5fvvv0ev1xMSElJkEDFhwgQyMzMJDw8nKysLRVHYuXNnmYKIzMxMw6T5zZs3m8yzdOlS1SS1KVOm0KRJE7Zv386hQ4ewt7dnxIgRhmdyCFGYEW01zPoJHjxx30Grh+gEhTFu8oMrqoH7D4zTalnAi5UzmVeI6kCjlGSNVSGEENXewhN5TI4x/mnY+ZYZ3q4ShJYnrVbL6tWrAfD395dFDyrLuCWwfJ9x+oYP4Z1+lV8fUWU+GHbh6Zn+n0XhhQ8lronk10AIIYSKXW3TvQ1tG5hMFuL506+96fTfblRuPUSV02uK/xJqEkQIIYRQcW+mweyJH8zmNuBaX35FRTURWciy7QM6Vm49hHiOSRAhhBBCpZW9hsWDzKj3/x4z0twWNnqbYyYTEEV1EW/iaci2tcGjYp4TJER1VK4Tq4UQQlQP4zqbMepPGpKyobU9mD/ZNSHE88zKxOXP/YeQfAeayLi9mkRWZyo96YkQQghhknUtDW0aaCSAENXPn9sap+Xp4b+RlV8XIZ5TEkQIIYQQomb56E2wMDdOv2ximJMQwiQJIoQQQghRszR/Aca9apz+aufKr4sQzymZEyGEEEKImudf70LyXdhxLL9XYswrMO61qq6VqGR6ZLhmaUkQIYQQQoiax7YObP8H3MkCS4v890KIYpMgQgghhBA1VwPbqq6BEM8lCSKEEEIIIUSNJEu8lp5MrBZCCCGEEEKUiAQRQgghhBBCiBKRIEIIIYQQQghRIjInQgghhBBC1Eh6mRJRatITIYQQQgghhCgRCSKEEEIIIYQQJSJBhBBCiDK7fV9hTHQezst0vL41j5O3lKqukhBCPJVeoyn2S6jJnAghhBBlNmhLHmfS8/8/MUvhWGoeV983x762/PAKIUR1JD0RQgghymRstM4QQBS4mwu7rkpvhBBCVFfSEyGEEKLUUu8prDlnepttrcqtixBClJQ8sbr0pCdCCCFEqd2+D/pCtv3ZqVKrIoQQohJJECGEEKLUOrwATnVNbzudbjpdCCHE80+CCCGEEKVmptHwF1fT21rZVW5dhHgm/Z4FKXequhZClDsJIoQQQpTJH1rTY4qb28pYY1GD6fLA/0to5A9N3ofXZ0PGvaqulXiCXlP8l1CTIEIIIUSZmGtMr8JkaS6/uqIGW7YX1hyAvP83a+i7X2H6hiqtkhDlSYIIIYQQZZKrM52edk+WeBU12LoY47Sdxyq9GkJUlGc6iJg5cyY9evQoVt7k5GR69OjBsmXLKrhW+UpSt8DAQLy9vSu4RkUrafvExcUxfvx4Bg4cWKntKoR4/tx9YDo99b4EEaIGu5RsnKbNq/x6iCIpaIr9EmrynAhhRKfTMW3aNHQ6HUFBQdja2vLiiy9WdbUqXUxMDHFxcYwbN67Y+2zYsAFbW9tyDxrPnTvHnj17uHDhApcuXSInJ4eQkBCT5Zw9e5b169cTHx/PnTv5k/kaN27MoEGDGDlyJDY2NuVaNyGa2WgA44DhL9/qufS+Bgsz+fEVNUzGPdPzH5o6VH5dhKggz3RPxPTp0zl8+HBVV6PGSUpKIikpiXfeeYcRI0bg6elZY4OIFStWlGifjRs3EhkZWe51OXz4MOHh4WRnZz/1b3H9+nVyc3N54403mDRpEh988AEdOnRg1apVjB07ltzc3HKvn6jZhrc1HSRc+wMm/1DYUySEqMa+P2MqroaBHSu9KkJUlDL3ROTl5aHVaqldu3Z51EfFwsICCwvpLKlsv//+OwB2duW7PqOiKOTk5FC3biGLytdAgYGBACxfvrzIfL6+vowePZo6deqwf/9+zpw5U2jeIUOGMGTIEKP9W7ZsyaJFi/jxxx959dVXy155IYA8vcLE7wsPFMJ+VRjWVqF/c+mNEDXIzuOm05NlqddnjV6eWF1qJbpCj4yMZNasWYSFhXH27FkiIyNJTU1l+vTpeHt7oygK27ZtY8eOHSQkJGBmZkb79u0JCAgwmj8QFRXFli1bSExMRKfT4eDggJubG1OmTKF+/fpA/ryDqKgoTpw4odr3119/ZdGiRcTFxWFtbY2HhwdDhw4ttL5Lly41Kj8wMJCUlBTVXeMjR44QERHBb7/9Rnp6OpaWlnTo0IExY8bQvXv3kjRVsZw8eZKvvvqK8+fPo9PpcHFxYdiwYbz11luqfOfOnWPr1q2cOXOGW7duYW5ujqurK++++y4DBw40+tzito8pgYGBnDx5EoBZs2Yxa9YsAHbu3EmTJk3Iyclh5cqV7Nu3j7S0NOrVq0fv3r0ZP348Tk6PHk974sQJgoKCCAkJIScnh/DwcG7evMnf/vY3w/CgvXv3snnzZi5dukReXp7hmAYNGmRUrxMnTrB+/XrOnTtHTk4Ojo6OdO/enQ8++AB7e3sAwsPDiYmJ4erVq9y9exc7Ozt69erF+PHjadKkierzDh06xLp167hy5Qq5ubnY29vTvn17goODcXZ2VrXD4+dOYUOIHs+XkpKi2qeg7crCwaHsXeAFf58//vijzJ8lRAHfnXkkZBadJ+xUHv2byw0hUYP8cNZ0+qELlVsPISpQqb7VFy5ciE6nw8fHB2tra5ydnQGYMWMG3333HR4eHnh7e6PVatmzZw8TJ05k3rx59O/fH4Bdu3Yxc+ZMunbtSlBQEFZWVty6dYvDhw9z584dQxBhyrlz55gwYQJ169Zl9OjR2NrasnfvXkJCQkpzKCqRkZFkZmbi6elJo0aNSEtLIyIiggkTJrB06VK6du1a5jIKHDx4kKlTp+Lg4MCoUaOoW7cue/fuZc6cOSQlJTFx4kRD3piYGK5du8agQYNwcnIiMzOTqKgopk6dypw5c3j99dcNecvaPmPGjKFz586sXr0aHx8fwzHXr18fnU5HcHAwp0+fxsPDg1GjRpGYmMi2bds4evQo69ato1GjRqrP27hxI5mZmbz11ls4ODgYti9evJhVq1bRp08fgoKCMDMz48CBA3zyySdMmzaN4cOHGz5j27ZtzJ07l4YNGzJ06FCcnJxITU3lxx9/5NatW4Yg4uuvv6Zjx46MGDECOzs7rly5wo4dOzh+/DibNm0y5Pvll1/46KOPaN26Nf7+/tjY2JCens6xY8e4ceMGzs7OjBkzBkVROHXqFLNnzzbUpVOnToW23ezZs5k/fz729vaMGTPGkF7U+VyRcnNzDa8LFy7w5ZdfYmlpSe/evaukPqL6+S1dYcflp+e7+pQgQ4hq5aeLcPN309vSsyq3LkJUJKUEdu7cqXTv3l3x8fFRcnJyVNt++OEHpXv37sq2bdtU6VqtVhk1apTi7e2t6PV6RVEU5eOPP1bc3d0VrVZbZHkhISFK9+7dVWn+/v5K7969lWvXrhnSHj58qLz77rtK9+7dlaVLlxrV9/jx40afHRAQoAwZMkSVdv/+faN86enpyiuvvKL8/e9/f2rdCvNkWTqdTvHy8lL69++vpKWlqY7D399f6dmzp3L9+vUi65WTk6P4+Pgovr6+qvSStE9hjh8/rnTv3l3ZuXOnKn379u1K9+7dlQULFqjSf/zxR6V79+7K9OnTjT5j4MCByu+//67Kf+HCBaV79+5KaGioUdkfffSR4u7urmRnZyuKoiipqanKSy+9pPj6+ip//PGHUf68vDzD/5tqp6NHjyrdu3dX1qxZY0j7z3/+o3Tv3t2oXk8qyd+4wJAhQ5SAgIBi5w8ICChRfkVRlH379pn8+zzpv//9r9K9e3fDa9iwYcrPP/9corIq2u+//67k5uYa3mdlZan+zg8ePFDS09NV+yQnJxf5PiUlxfBdI2VUbBnb4vIUvtA+9fXWt9pSl1EZx1GVZTx8+FBZtmyZsmzZMuXmzZvP7XFIGY+V8dU+RcHH5EtvPvT5OY5nrIyK8u6oK8V+CbVSTaz29fU1mgOxe/durK2tGTBgABkZGYZXdnY2/fr1Izk5mcTERABsbGzIzc3l0KFDKErxlwC8c+cOZ86coX///obeDwBLS0tGjhxZmkNRqVOnjuH/79+/T0ZGBubm5nTs2JHz58+X+fMLXLhwgdTUVN58800cHR0N6ZaWlowePRq9Xk9sbKzJeuXm5pKRkUFubi49e/YkISGB7OxsoOLb58CBA5iZmeHv769K79u3L23atOHgwYPo9eqx0V5eXjRo0ECVtmfPHjQaDV5eXqpzJSMjA3d3d+7du8fZs/ldwfv370er1RIQEICtra1RnczMHp3CBe2k1+vJzs4mIyODNm3aYGNjw7lz5wz5ClYn+uGHH9DpClngvgIUnFOPv3Q6HTqdzij9/v37ZS7v7bffJiwsjLlz5/LXv/6VWrVqkZGRUfYDKUcNGjTAysrK8N7Gxkb1d65Vq5bRUK7Hh82Zet+4cWM0j41xlTIqroy+TTXUMuep/Ds++nf6LB7Hs1JGw4YNq8Vx1Pgyipg8rcnTw4305+M4nrEyKopeoyn2S6iVajhTixYtjNKuXbvGvXv3eO211wrd786dOzg7O+Pv78/Jkyf5+OOPsbOzo1u3brz88su8+uqrWFtbF7p/UlISAC4uLkbbWrVqVfIDecLNmzcJCwvjyJEjZGWpuxw15XjyJCfnrx1tqs6tW7cGHh0r5LfbkiVLiI2NNSzZ+bjs7GxsbGwqvH2Sk5NxdHSkXr16JusdHx9PRkaGKmgwda4kJCSgKAq+vr6FllUwufvGjRsAtG3b9qn1O378OCtWrOD8+fM8eKBeuP7xv+fw4cOJjY1l7ty5fPnll3Tu3Jk+ffowePDgCh16NG/ePKKiokxue3IeyJAhQ5g5c2aZymvRooWh/QcNGsTPP//M3//+dwDVEDghSquhtYZ1b5gxMkpPYVOr32wNb7o+0wsBClG+WjWGAR0gxsTNR3MNOBjfEBPieVSqIMLUSkyKolC/fn3mzJlT6H4FF8gtWrQgPDycY8eOcfz4cU6ePMmcOXNYtmwZK1asoFmzZqWplpGiLvzz8tQPfLl//z4BAQHk5OTwzjvv4OrqirW1NRqNhjVr1nD8eCErLVQwRVEIDg4mISEBPz8/2rdvj42NDWZmZkRGRhIdHW109/9ZUtiqXRqNhkWLFql6Eh5XcK4U1/nz5wkODqZZs2YEBwfTpEkTrKys0Gg0fPrpp6o2sre3Z926dZw6dYqjR49y6tQp5s+fz7Jly1i4cGGR8x7KYvTo0bzxxhuqtAULFgAwefJkVfrjPVTl5c9//jMODg5s3bpVgghRbka0M2PmYT0X7xpvq28FW98sRleFENXNuwNNBxHNXoC6VsbpQjyHym25jObNm5OYmIibm1uxlvCsVasWffv2pW/fvkD+ajmTJ0/mm2++4R//+IfJfQpWuLl27ZrRtqtXrxqlFdwxN7UaTXJysmr52GPHjnH79m1mzJjBm2++qcq7ZMmSpx5PSTRt2hQwXeeCtII8ly5dIj4+noCAAKOHnu3YsUP1vqTtU1JNmzbl559/Jisry2ho0dWrV7G2tjZMXi5K8+bN+emnn2jcuDEtW7YsMm/BnfT4+HjVEK0nRUdHk5eXx6JFiwxtB5CTk2PUqwRgbm5Ojx49DKsoXbp0iVGjRrFy5UoWLlwIlK73qah9WrVqZdQjVNCOlTXZ+cGDB7I6kyh3f+uo4ZMfjYemOtYBS3MZAiBqII8OptNfcavceoin0stXVKmVWx+zl5cXer2e0NBQk9sLhqcAJsdlt2vXDoDMzMKX8ShYBjY2Npbr168b0rVaLRs2bDDKX3ABeuzYMVV6dHQ0t2/fVqWZm+ffLXtyjsaRI0dU4+nLQ7t27WjcuDGRkZGkpz8aG6nT6Vi/fj0ajcawklXBnfon63X58mViYmJUaSVtn5IaMGAAer2eNWvWqNIPHz5MXFwc7u7uhfYsPM7T0xOAsLAwox4hUJ8rHh4eWFpasmLFCsPcj8cVtEthf79Vq1YZ9dSYOv9cXFyoXbu26gK7YI5FUefkk+rUqVPlF+mPn1OPi4qKIjs7m44d5WFHonx1cjT9K2wlq7qKmiqtkN8Bt8JvhgnxvCm3r/hBgwbh7e3Nli1buHjxIv369cPe3p60tDTOnDnDzZs3iYiIAGDixInY2trStWtXGjVqRFZWFpGRkWg0GsMFZmE+/PBDxo0bx9ixYxk2bJhhCVNTF6MuLi706tWL7du3oygKbdq0IT4+npiYGJo3b66aVNulSxccHBxYsGABKSkpNGzYkPj4eHbv3o2rqyuXLxdjHcNiMjc3Z9q0aUydOpX33nsPHx8f6taty759+zh79iz+/v6GAKhly5a0atWKdevWkZubi7OzM4mJiWzfvh1XV1cuXFCvOV2S9ikpb29voqKiWLt2LcnJyXTr1o0bN26wdetWHBwcVMvSFqVDhw4EBgayfPlyRo4cyaBBg3B0dCQ9PZ0LFy5w+PBhjhw5AkCjRo2YMmUKn3/+OX5+fnh5eeHk5ERaWhqxsbHMmDGDtm3bMmDAADZs2MCkSZPw8fHB0tKSo0ePcvnyZaPekTlz5pCWlkbv3r1xcnLiwYMH7Nu3j3v37uHl5WXI5+bmxpYtW5g7dy59+/bFwsKCjh07qno6nuTm5kZERARLliyhZcuWaDQa3N3dVZPjSyMlJYVdu3YBj3qVDh48yK1btwAM7QIwadIk7Ozs6NSpE40bNyY7O5tff/2V2NhYGjVqZHjAnRDlpYmN6SDidtnXBxDi+dTI3nT6K3ITR1Qf5XqfKCQkhB49evDtt9+yZs0atFotDg4OtGvXTnWB6evry759+9i+fTuZmZnY2dnRtm1bpk2bZvRQuCd16tSJsLAwQkNDWbt2LTY2NoaHqfn5+Rnlnz17Nl988QXR0dHs3r2brl27snTpUv71r3+RkpJiyGdra0toaCiLFi1i8+bN5OXl0a5dOxYuXEhERES5BhEA7u7uLF68mJUrV7J+/Xq0Wi0uLi5Mnz5d9bA5c3NzFi5cyIIFC4iKiiInJ4fWrVszc+ZM4uPjjYKIkrZPSVhYWBAaGmp42NyBAwewtbXFw8ODCRMm0Lhx42J/VmBgIO3bt2fTpk1s3LiRnJwcGjRoQOvWrfn4449VeX19fWnWrBnr1q1j06ZNaLVaHB0d6dmzp+G5E126dGHevHl89dVXLF26FCsrK3r16sXy5csJCAhQfZ6npyeRkZHs2rWLu3fvYm1tTatWrfj888/x8PAw5Bs8eDBxcXHs3buX77//Hr1eT0hISJFBxIQJE8jMzCQ8PJysrCwURWHnzp1lDiKSkpJYunSpKu3AgQMcOHDAcPwFQYSPjw8//PADO3bsICMjAwsLC5o1a8Z7773HqFGjijXkTIiSuJNjepW9nLLfuxDi+dTCEQJfheX7HqUNfQk6Fz2EV4jniUYpyRqrQgghxBNeC9ex77px+lg3DV8NlonVRdFqtaxevRoAf39/LC0tq7hGotwoCuw8DkfioWtLePslsJB/D88av/euFTvvprUuFVaP55GMWBVCCFEmF41XngZgXMUsdCbE80Gjgb/0yn8JUQ3J4t1CCCHKpJmN6fSlpyu3HkIIISqPBBFCCCHKZGAL0xOrf8+t5IoIIUQJKRpNsV9CTYIIIYQQZZJXyMw6v3byoyuEENWVBBFCCCHKpHsj42ChhS34tZOfGCGEqK7kG14IIUSZvP2iRtXr0LAubH1TVqERQjz79Jriv4SarM4khBCiTMzNNGwcYs5nLymk3FN4uamG2hbyiyuEENWZBBFCCCHKRfsXNLR/QYIHIYSoCWQ4kxBCCCGEEKJEpCdCCCGEEELUSHpZurXUpCdCCCGEEEIIUSISRAghhBBCCCFKRIYzCSGEEEKIGkmPDGcqLemJEEIIIYQQQpSIBBFCCCGEEEKIEpEgQgghhBBCCFEiMidCCCFEqaTfV9ifqNDMRkPfZjKuWAjx/MmTr65SkyBCCCFEie29puetHXpydPnvPVtqiPAxw8JMfpGFEKImkOFMQgghSuxvex4FEAC7ExS2xytVVyEhylNWDszaDF5zYOYmyLxX1TUS4pkjPRFCCCFKZObhPFJMXFOd/12CCFFNDPk/OPhb/v/vPgn7TsPhf1VtnUSFkCdWl570RAghhCiRBb+YDhbcZV6EqA5+OPMogCjwUxwcv1Q19RHiGSVBhBBCiBLJ0hqn9WgEHs7ykyKqgdnhptMf6kynC1FDyXAmIYQQxfZ7joLeREfEYBfphRDVxM9xxmm2deDPbSu/LqLC6eWrq9TktpEQQohiszJTMPWbW1tuSYnqwq6ucZqVJZjJJZMQj5N/EUIIIYotLQdMzYhoULvSqyJE+XughXu5xum/Z1V+XYR4xkkQIYQQotjOpZtOd3OUMQGiGthzEu4/NE7v0bry6yLEM65aBREzZ86kR48excqbnJxMjx49WLZsWQXXKl9J6hYYGIi3t3cF16hoJW2fuLg4xo8fz8CBAyu1XYUQlauwRVwT/5DlXUU1oBRyHpuaCCSqBT2aYr+EmoxiFWWm0+mYNm0aOp2OoKAgbG1tefHFF6u6WpUuJiaGuLg4xo0bV+x9NmzYgK2tbbkHjefOnWPPnj1cuHCBS5cukZOTQ0hISJUHp+L593ohE6hPpcFf21dyZYQob290A9vakPXEkKZfroAuDyzMq6ZeQjyDqlVPxPTp0zl8+HBVV6PGSUpKIikpiXfeeYcRI0bg6elZY4OIFStWlGifjRs3EhkZWe51OXz4MOHh4WRnZ9fIv4WoOFcyTKcfvKmQfl/u1ornXO1a4FDPON3SvPBeCiFqqEoPIvLy8sjNNTFpqRxYWFhgZWVVIZ8tCvf7778DYGdnV66fqygK9+/fL9fPfN4FBgYSGBj41Hy+vr7ExsayZcsWRo4cWQk1EzXFgRt6k+nHU2HQljy0eXKhJZ5jmw/BtTTjdG0eTFlT6dURFS9Poyn2S6hV6HCmyMhIZs2aRVhYGGfPniUyMpLU1FSmT5+Ot7c3iqKwbds2duzYQUJCAmZmZrRv356AgACj+QNRUVFs2bKFxMREdDodDg4OuLm5MWXKFOrXrw/kzzuIiorixIkTqn1//fVXFi1aRFxcHNbW1nh4eDB06NBC67t06VKj8gMDA0lJSVHdNT5y5AgRERH89ttvpKenY2lpSYcOHRgzZgzdu3cvr2Y0OHnyJF999RXnz59Hp9Ph4uLCsGHDeOutt1T5zp07x9atWzlz5gy3bt3C3NwcV1dX3n33XQYOHGj0ucVtH1MCAwM5efIkALNmzWLWrFkA7Ny5kyZNmpCTk8PKlSvZt28faWlp1KtXj969ezN+/HicnJwMn3PixAmCgoIICQkhJyeH8PBwbt68yd/+9jfD8KC9e/eyefNmLl26RF5enuGYBg0aZFSvEydOsH79es6dO0dOTg6Ojo50796dDz74AHt7ewDCw8OJiYnh6tWr3L17Fzs7O3r16sX48eNp0qSJ6vMOHTrEunXruHLlCrm5udjb29O+fXuCg4NxdnZWtcPj505RQ4gK8qWkpKj2KWi7snBwcCjT/kIUZuflwoOE0+nQdGkeG4eYyYPnxPNp6XeFb1scDQvHglxMCgFU0pyIhQsXotPp8PHxwdraGmdnZwBmzJjBd999h4eHB97e3mi1Wvbs2cPEiROZN28e/fv3B2DXrl3MnDmTrl27EhQUhJWVFbdu3eLw4cPcuXPHEESYcu7cOSZMmEDdunUZPXo0tra27N27l5CQkDIfV2RkJJmZmXh6etKoUSPS0tKIiIhgwoQJLF26lK5du5a5jAIHDx5k6tSpODg4MGrUKOrWrcvevXuZM2cOSUlJTJw40ZA3JiaGa9euMWjQIJycnMjMzCQqKoqpU6cyZ84cXn/9dUPesrbPmDFj6Ny5M6tXr8bHx8dwzPXr10en0xEcHMzp06fx8PBg1KhRJCYmsm3bNo4ePcq6deto1KiR6vM2btxIZmYmb731Fg4ODobtixcvZtWqVfTp04egoCDMzMw4cOAAn3zyCdOmTWP48OGGz9i2bRtz586lYcOGDB06FCcnJ1JTU/nxxx+5deuWIYj4+uuv6dixIyNGjMDOzo4rV66wY8cOjh8/zqZNmwz5fvnlFz766CNat26Nv78/NjY2pKenc+zYMW7cuIGzszNjxoxBURROnTrF7NmzDXXp1KlToW03e/Zs5s+fj729PWPGjDGkF3U+C1GVUu8p7L9edJ7bOfDXXXpujNNgaS4XW+I5c9VEL0SBPD1s/RmG9am8+gjxDKuUICI3N5cNGzZQu/ajhcQPHDjAnj17+PTTT3n77bcN6X5+fvj7+/Of//wHd3d3NBoNMTExWFtbs2TJEiwsHlU5KCjoqWXPnz8fvV7PypUrDcHLsGHDGDt2bJmPa/r06dSpU0eVNnToUIYPH87q1avLLYjIy8tj3rx51KlTh7Vr1+Lo6AjA8OHDGTduHGvXrsXb25sWLVoAMHbsWIKDg1Wf4efnx8iRI1m5cqUqiChr+7z00ktYWFiwevVqOnXqhKenp2Hbt99+y+nTp3n33XeZNGmSIb13795MnjyZ0NBQ/vnPf6o+LzU1la1bt9KgQQND2sWLF1m1ahX+/v6qYMnPz48pU6YQFhaGl5cX1tbW3Lp1i3//+9+4uLiwatUqbG1tDfnHjx+PXv9oKMamTZuM/n7u7u5MmDCBiIgI3nvvPQBiY2PR6/WEhYWp6vX++++r2iE6OppTp06p2qAonp6eLFmyhAYNGhR7HyGq0s/JCqYHM6ndug8X74CbY4VXSYjy9bR5D7HnJYioZuSJ1aVXKf3Nvr6+qgACYPfu3VhbWzNgwAAyMjIMr+zsbPr160dycjKJiYkA2NjYkJuby6FDh1BKMLHpzp07nDlzhv79+xsukAEsLS3LZZz44xeg9+/fJyMjA3Nzczp27Mj58+fL/PkFLly4QGpqKm+++aYhgID84xg9ejR6vZ7Y2FiT9crNzSUjI4Pc3Fx69uxJQkIC2dnZQMW3z4EDBzAzM8Pf31+V3rdvX9q0acPBgwdVF/UAXl5eqgt1gD179qDRaPDy8lKdKxkZGbi7u3Pv3j3Onj0LwP79+9FqtQQEBKgCiAJmjz1xtKCd9Ho92dnZZGRk0KZNG2xsbDh37pwhn42NDQA//PADOp2uDC1SMgXn1OMvnU6HTqczSn9e547cuXOHBw8eGN5nZ2eTlfXooU4PHz40zLkpkJKSUuT71NRU1feElFF+ZbjWK975b20JzvWe3eN4VstIS0urFsfxXJfRy5WiaNs+Gob7TB9HNSxDPHsqpSei4A75465du8a9e/d47bXXCt3vzp07ODs74+/vz8mTJ/n444+xs7OjW7duvPzyy7z66qtYW1sXun9SUhIALi4uRttatWpV8gN5ws2bNwkLC+PIkSOqfxwAmnIcM5mcnAyYrnPr1vkPwCk4VshvtyVLlhAbG8udO3eM9snOzsbGxqbC2yc5ORlHR0fq1TNe6aJ169bEx8eTkZGhChpMnSsJCQkoioKvr2+hZRV8Gd24cQOAtm3bPrV+x48fZ8WKFZw/f171ZQeo/p7Dhw8nNjaWuXPn8uWXX9K5c2f69OnD4MGDK3To0bx584iKijK57cl5IEOGDGHmzJkVVpeK8mTAWBCwFahVq5bR/I7H59KYet+4cWMpo4LKcGtUixfr67h0l0KZaeCL/mbUs9I8s8fxLJWh1WoN7xs2bKj67XiejqPalPG/vrDtCCa93A7L9199Po6jGpYhnj2VEkQ82QsB+Svv1K9fnzlz5hS6X8EFcosWLQgPD+fYsWMcP36ckydPMmfOHJYtW8aKFSto1qxZudSzqAv/vLw81fv79+8TEBBATk4O77zzDq6urlhbW6PRaFizZg3Hjx8vlzqVlKIoBAcHk5CQgJ+fH+3bt8fGxgYzMzMiIyOJjo42uvv/LDF1rkD+32bRokWqnoTHFZwrxXX+/HmCg4Np1qwZwcHBNGnSBCsrKzQaDZ9++qmqjezt7Vm3bh2nTp3i6NGjnDp1ivnz57Ns2TIWLlxY5LyHshg9ejRvvPGGKm3BggUATJ48WZX+eA+VEBVpQmcNH8YY9wgPfRF8XjTj5aYaXOxkfIB4TnVtBU71IeWJSLmBDfz4fzKpWojHVNnD5po3b05iYiJubm7UrVv3qflr1apF37596du3L5C/Ws7kyZP55ptv+Mc//mFyn4IVbq5du2a07erVq0ZpBXfM//jjD6NtycnJqvkYx44d4/bt28yYMYM333xTlXfJkiVPPZ6SaNq0KWC6zgVpBXkuXbpEfHw8AQEBRg8927Fjh+p9SdunpJo2bcrPP/9MVlaW0dCiq1evYm1tbZi8XJTmzZvz008/0bhxY1q2bFlk3oKejPj4eNUQrSdFR0eTl5fHokWLDG0HkJOTY9SrBGBubk6PHj0MqyhdunSJUaNGsXLlShYuXAiUrvepqH1atWpl1CNU0I69e/cucVlClIdR7c34MCbPKN2xDvy1vazIJKqBlg2Ngwi9IgFENZUnT6IutSr7xvfy8kKv1xMaGmpy++Nj5TIyMoy2t2vXDoDMzMxCyyhYBjY2Npbr1x8tKaLVatmwYYNR/oIL0GPHjqnSo6OjuX37tirN3Dz/qZVPztE4cuSIajx9eWjXrh2NGzcmMjKS9PR0Q7pOp2P9+vVoNBrDSlYFd+qfrNfly5eJiYlRpZW0fUpqwIAB6PV61qxZo0o/fPgwcXFxuLu7F9qz8LiCScdhYWFGPUKgPlc8PDywtLRkxYoVhrkfjytol8L+fqtWrTLqqTF1/rm4uFC7dm1VwFkwx6Koc/JJderUMRm0CvGseqGuhlomHtq74SJkPpBnRIhqwEKCYSGKo8p6IgYNGoS3tzdbtmzh4sWL9OvXD3t7e9LS0jhz5gw3b94kIiICgIkTJ2Jra0vXrl1p1KgRWVlZREZGotFonrqqzYcffsi4ceMYO3Ysw4YNMyxhaupi1MXFhV69erF9+3YURaFNmzbEx8cTExND8+bNVZNqu3TpgoODAwsWLCAlJYWGDRsSHx/P7t27cXV15fLly+XWVubm5kybNo2pU6fy3nvv4ePjQ926ddm3bx9nz57F39/fEAC1bNmSVq1asW7dOnJzc3F2diYxMZHt27fj6urKhQsXSt0+JeXt7U1UVBRr164lOTmZbt26cePGDbZu3YqDg4NqpaWidOjQgcDAQJYvX87IkSMZNGgQjo6OpKenc+HCBQ4fPsyRI/ljWBs1asSUKVP4/PPP8fPzw8vLCycnJ9LS0oiNjWXGjBm0bduWAQMGsGHDBiZNmoSPjw+WlpYcPXqUy5cvG/WOzJkzh7S0NHr37o2TkxMPHjxg37593Lt3Dy8vL0M+Nzc3tmzZwty5c+nbty8WFhZ07NhR1dPxJDc3NyIiIliyZAktW7ZEo9Hg7u5utGpUSaWkpLBr1y7gUa/SwYMHuXXrFoChXYQojb5N4Icb6rQ/HsI3vylM6Cp39cRz7t4D4zRLE5GzEDVclQURkP8grh49evDtt9+yZs0atFotDg4OtGvXTnWB6evry759+9i+fTuZmZnY2dnRtm1bpk2bZvRQuCd16tSJsLAwQkNDWbt2LTY2NoaHqfn5+Rnlnz17Nl988QXR0dHs3r2brl27snTpUv71r3+pVgqwtbUlNDSURYsWsXnzZvLy8mjXrh0LFy4kIiKiXIMIyF96dPHixaxcuZL169ej1WpxcXFh+vTpqofNmZubs3DhQhYsWEBUVBQ5OTm0bt2amTNnEh8fbxRElLR9SsLCwoLQ0FDDw+YOHDiAra0tHh4eTJgwwWgiVlECAwNp3749mzZtYuPGjeTk5NCgQQNat27Nxx9/rMrr6+tLs2bNWLduHZs2bUKr1eLo6EjPnj0Nz53o0qUL8+bN46uvvmLp0qVYWVnRq1cvli9fTkBAgOrzPD09iYyMZNeuXdy9exdra2tatWrF559/joeHhyHf4MGDiYuLY+/evXz//ffo9XpCQkKKDCImTJhAZmYm4eHhZGVloSgKO3fuLHMQkZSUxNKlS1VpBw4c4MCBA4bjlyBClNZ/BpjRdb3x3Kozt6UnQlQDienGaTam5+uJ51+e3PcoNY1SkjVThRBCCMD83zqjZ0a87wYrBlfpvannjlarZfXq1QD4+/tjaWlZxTWq4W5nQkN/4/RXO8HemZVeHVHx+gUVfynZH5fKzbfHycA/IYQQJXIt0/RD52RVJvHcq1MLLEwMXdKWfYivENWNBBFCCCFK5MebppeJ7t1YggjxnLOpA84mlsy+bbxqnxA1nQQRQgghSiSxkAXFektPv6gO3htgnPbSi5VeDVE59BpNsV9CTYIIIYQQJXI313R6HUv5kRXVwGRv6N/h0Xs3Z5j9TtXVR4hnlMyAE0IIUSLmhdx+0ubJEvuiGrCtAzH/hNMJ8EAHPV3lQXNCmCBBhBBCiBLp8IIGUC/sV98Kkw+hE+K51bllVddAVII8CRBLTe4ZCSGEKJFhbTR0fEGdNqOPGeZm8mMshBA1hfRECCGEKJE6lhp+GmnOuvMK1/9Q8GplRv/mEkAIIURNIkGEEEKIErOtpWFiVwkchBDPN11VV+A5JsOZhBBCCCGEECUiQYQQQgghhBCiRCSIEEIIIYQQQpSIzIkQQgghhBA1kizxWnrSEyGEEEIIIYQoEQkihBBCCCGEECUiw5mEEEIIIUSNpJPRTKUmPRFCCCGEEEKIEpEgQgghhBBCCFEiMpxJCCGEEELUSDpkPFNpSU+EEEIIIYQQokQkiBBCiEr2QKfwWayOTiu0eG7W8tNNfVVXSVQBRa9waVk8tkussVlVl9TvU6q6Ss+cvJQs7o7dya0OS7jz7rformdUdZWEEP+PRlEUpaorIYQQNUnQHh3LTj0KHOpYwG+BlrjYS7d6TXJh0W+c+//OPEowg1ciB+HQ/YWqq9QzJq3rcrS/phrem7s2oNHFCWjM5R6oKB9/Cr5d7LwXQh0rsCbPH/lXKIQQlUivKKw9q+55yNHBpt+kN6KmubYpQZ2gh2ubr1VJXZ5FD0+lqAIIgLzLd3h48HoV1UhUR1pN8V9CTYIIIYSoRBrAytw4vbYsc1HjmFsZ/wSb15af5QKawv5RyD8WIZ4J8m0lhBCVSKPRMKmn+qvXsS78tYN8Hdc0Lwa0Vb03r2NOq1Gtq6g2zx7LPzli9VorddpLTbH6c/MqqpEQ4nHyqyWEEP+PXlH411E9bVfq6LxWx9pzxRti9ECnMC02j1YrdLz0jY5dV4reb2Y/c/7mpqFeLahfGwK6mOFoLX3lNY3zcBcavt2Ch3U0PLSF1h+3p14buyqpi6Io3Jx3ml/abuFUp23cWhVX/mVo8/j9f3/kWuvl3Oi5nuzt8U/dp8G3I7DydEVjUwuzhtbU9evw1H0ebDlDZvcvyXD9gvsh+1B0eUXm1645Sk7nz7nf9v94+Pl+Kmyq6OJ90OEf0H4aLPqu6LxZOTBxOTQZAw6joZE/vDMfbqZXTN1qMK1GU+yXUJOJ1c+gEydOEBQUREhICN7e3lVSh7i4OBYsWMDFixfJysoiICCAcePGVUldhKgs/z6uZ2qsOgCI8jHDq3XR91uC9+cR9uujr1JzDfzyrjmdG5r+0dn8Wx5+O9QXNkteNyeom4lxTqLaOrngN06FXnyUoAHPr/vh1LvyJ28mLzhLwodHVGntdryKw19cyq2M9H/EkjHv2KMEMw3NDo+k9ktNCt0ne8kJMifsVqXV3zyUusNNBxPagwlkDVgBj13a1J4+kLr/fM1kfl3kOR68uUKVVus/b2H50cCnHU7JrD8Eo5eq0756H8YOMJ1/xL9hy0/G6V1awqn/lG/dajjnD4ofmF1fJIsePE56IoQRnU7HtGnTSExMJCgoiNmzZ/PKK69UdbUqXUxMDMuWLSvRPhs2bCAyMrLc63Lu3Dm++OILxowZQ79+/ejRo0eh5Vy8eJEFCxbw17/+lYEDBzJw4EBGjx5NeHg4Op2u3OtWnXxtYnLz1xeefp/lyTx5CmyOK7w34pvzJsopZq+HqD4u77yhTlDgypNpleT2N5eN0742TiuLrG9+UyfoFbI2XChyn5yvzxinfXO20PwPN/yqCiAAHn7za6H5dV+fKFZamX1z2ESaiSABIPchbDtietuvCXBOJpaLZ4MEEc+gbt26cfjwYTw9Pauk/KSkJJKSknjnnXcYMWIEnp6evPjii1VSl6oUExPDihUrnp7xMRs3bqyQIOLw4cOEh4eTnZ391L/F2rVriYyMpF27dkycOJGgoCDs7Oz4/PPPmTx5csV11VcD9ayM0+xMpBntV8tUWuFd37YmthWnHFG9WFobTxCuZWtZBTUBcxPlmtuZOLHLwMzW+PPMTP3jeYzGxD9KU2mPttUuVlqR2+wKz19qtnWM0+qZSAOwMIe6hRyjRgP16pZfvYQoAwkiniH37t0DwMzMDCsrK8zNq2Zow++//w6AnV35js1VFIX79++X62c+7wIDAwkMDHxqPl9fX2JjY9myZQsjR44sMu+IESPYvXs3n332Gb6+vowYMYIvv/ySN954gyNHjnDo0KHyqn6183EPM8weu76vawETuzz9a/IfvdR5GtaFv3UsPIiY1NNMtUKTuQY+6iVDmWqaToFtVO8tbSxo59eySurS5ONOPH7ym9Uxxyn46fMPSqL+tF6q92b1a1MvoFOR+9hM+XP+P5ACVubYfNCr0PxW43qheSIIqD21X6H5Lf/eD+o8FkCZabCcUs5DmQA+fB0sH/s3bmGen2aKhTl8VMhQ5hEvQwt5VkF50pbgJdQkiCgnkZGR9OjRg6NHj7Js2TKGDBnCn//8Z/z8/PjuO+MJVN7e3gQGBnLx4kWCg4Pp378/77zzDpA/J8LUcBVFUfj2229577336NevH/369WPEiBEsXaoeZ/nw4UNWrVrF8OHD6dOnDwMGDODDDz/k4sWLPM3jF7WzZs2iR48e9OjRg+TkZABycnIIDQ3lL3/5C3/+858ZPHgwM2bMICVF/aTVx49hy5YtDBs2jD59+rB+/XpDnr179zJ27Fjc3d15+eWXee+999i/f7/Jep04cYJJkybh4eFBnz59+Mtf/sLs2bPJyMgw5AkPD2fixIm88cYbvPTSSwwePJjPPvvMUPfHHTp0iMDAQDw8PHj55Zfx8vJi6tSpXL9+3dAOUVFRAIY2KGoIUUG+lJQUTp48qdrHVPkl5eDgQJ06hdy1ekKXLl2wsjK+i/Xqq68CcOXKlTLXp7p609WMb7zMaGYDtcyhwwugL0bHzVg3DUNaQW1zaFAbPumloXERE6V7NTHjKy9zGlnnX7dpNDDhOx3hF8pvSNPeeB3dFmVTZ3oWdT/Lovm/spkX+6DcPl+UXcvBTWgzwBGbBw+wzntA19EtqediU6bPfJCaw68jYvneYRM/v7SL3w+kPn0nwLanI3avNEFjZYZlw9q0XPRnbLo4FLnPvSOpXOq7lXP1l5PwVhQPE7MKzas8zOPhuXTM7K3AyhxNHQs0FhoyF/+Koiv8vLd6uTm1fdpBbQs09rWpN8OdWj2bFppfY18bi/4twcoCjUNdas8djNVfuxaa36xTUyw/HAD1akNdS8z/2gPzN9oXedwAeUti0Lr+L9p6H6CtPwlt44/Jm7YVRVvIkNE+bWCqF9T6f71PdSzhUiF/m4fa/InVdnXz81uYQZ1a8GZPWPv3p9ZNiMoiiy2Xsy+//JKcnBx8fX2B/ODif//3f3n48KHRJOlbt24xfvx4Bg0axCuvvPLUu/QzZsxgz549dOzYkTFjxmBra8u1a9f4/vvvCQoKAvLnM/z973/nzJkzeHp6Mnz4cLKzs/n2228ZO3YsK1asoH37wr8gx4wZQ+fOnVm9ejU+Pj507Zr/5Vu/fn10Oh3BwcGcPn0aDw8PRo0aRWJiItu2bePo0aOsW7eORo0aqT5v48aNZGZm8tZbb+Hg4GDYvnjxYlatWkWfPn0ICgrCzMyMAwcO8MknnzBt2jSGDx9u+Ixt27Yxd+5cGjZsyNChQ3FyciI1NZUff/yRW7duYW9vD8DXX39Nx44dGTFiBHZ2dly5coUdO3Zw/PhxNm3aZMj3yy+/8NFHH9G6dWv8/f2xsbEhPT2dY8eOcePGDZydnRkzZgyKonDq1Clmz55tqEunToXfNZs9ezbz58/H3t6eMWPGGNLr169f5N+1sqSlpQHQoEGDKq7Js0uvKHx2SM/N7Pz3x1Nh8NY8rgWaU9ui8KDgHwf1RF3N///cPPgoRqFHY4V+zUzv88cDhb/vzSMjt6BciL8Dfjt0uNa3oGvjst3fuXZHj/faHB4+Nnf7ZqbCP/Y8pJGNGe91r5ohM0Lt3LxzpEYlYYYGtHBx3nkadnekUf/Gpf7M0389yN2YWwD8cfx3Tnp/j/slH6ycih4CEz/qAJn7kwDQpuVyNfhn6g9ujlVz00FNXsYDrr4egT7zYX5ZEQlob2TT5hc/k/l/DzlMxvxHcw0UIC9HR8a8Y5jVtaBByMsm98v8x/fkbs2fN6Hk6vhj+gFquTtj1beFyfz33gtHuyt/ZSnlgY7cGfuxGt4J85amv/d020+j/f/2PTqu9cfRtm1Irf81PREbQB95Gv2EDU+k5qD/Yi/UqYX5rDeNd9p7Fv6/nY/eZ+VCwEpo1RBeeaLHJ2QzzH/ihpXuIew8Dl/thwlvFFo3ISqTBBHlLCMjg02bNmFjk//F6+vri5+fH//973959dVXqV37UTdrUlIS06dP56233nrq5+7bt489e/bwxhtvMGvWLMzMHl1k6PWP7uJs3ryZX375hS+//JI///nPhvSCYS0LFixg+fLlhZbz0ksvYWFhwerVq+nUqZNqXsa3337L6dOneffdd5k0aZIhvXfv3kyePJnQ0FD++c9/qj4vNTWVrVu3qi5cL168yKpVq/D392fixImGdD8/P6ZMmUJYWBheXl5YW1tz69Yt/v3vf+Pi4sKqVauwtbU15B8/frzq2Ddt2mR0t97d3Z0JEyYQERHBe++9B0BsbCx6vZ6wsDBVvd5//31VO0RHR3Pq1Kliz03x9PRkyZIlNGjQoMrmsxTm/v37rF+/HhsbG/r371/V1XlmnbwFlzPUabfuQ+wNhcEtCw8iNl807q7YEqenXzPTQ5T2XlUMAcTj9ApsvagvcxAR8ZtOFUA8bvMZrQQRz4gbEYkm00obRDy8nWsIIAroc/JIi7pJ84A2hewFuowHZOxNUqUpD/K4s/M6ThNND2n647vrhgCiQM7J2zy4nIGVq71R/uwthfeEZ22OKzSIyNl8Xp2gQM6W30wGEUr2A7S7n1g29mEe2ojfMJ/c1+Tn6zafMpF2suggYkvhE6/1m4+bDiK2FDJRestR4yBis4lJ2Ib8P0kQUc7uy9KtpSbDmcqZr6+vIYAAsLGxYejQofzxxx/88ssvqrx2dnbFXsJ1z549AEyePFkVQACq93v27MHFxYU//elPZGRkGF46nY7evXtz+vRpcnNNXL0Uw4EDBzAzM8Pf31+V3rdvX9q0acPBgwdVF/UAXl5eRne+9+zZg0ajwcvLS1XHjIwM3N3duXfvHmfP5q++sX//frRaLQEBAaoAwtSxFwQQer2e7OxsMjIyaNOmDTY2Npw7d86Qr+Dv88MPP1TqakX37983Ol6dTodOpzNKL8+5I3l5eXz22WckJSXxySeflPtcl7K4c+cODx48GmKTnZ1NVtajIREPHz40zNEp8OTQuSffp6amqiaPl6QMh8LmU95T1+HJMurXMr5itzV7dIH15HG8UMRN4Rfqasp8HC8UMZSq4PPLWkaBivx7VPcyzGyNf4JrNXg00bikZZjVNUdj4onXtRweDW80dRxaTR5mNsaBpYVD7UKPw+IFE8MrLcwwt7cyWYZZof+4wMzBqtC2MjPxj8XshTqm/x7koTExeVvjULfQ49C8YG2c/4X834jC/uYF203R2auP0/A3f8H49wsgu7bGqAy9Q+Gfr69v/Uycu1VRhnj2SE9EOXNxcTFKa9kyf6JcUpL6Tk/Tpk2LPXn6xo0bvPDCCzg4FD1GNSEhgQcPHjBo0KBC82RkZNC4ccnvdCUnJ+Po6Ei9evWMtrVu3Zr4+HgyMjJUQUOLFsZ3ixISElAUxTDky5SCL5cbN/KXO2zbtm2heQscP36cFStWcP78edWXF6D68ho+fDixsbHMnTuXL7/8ks6dO9OnTx8GDx5coUOP5s2bZ5hn8aQn/15Dhgxh5syZZS5Tr9cze/ZsYmNjmTBhAq+/XshEviryZID5eAAOUKtWLaNz3snJqcj3T57bJSmjpb2GUe01fP3box/DN1pqGNxRPZHxyTJC+loyMkpPwV6NrSG456OLiSePo38LDe7NNRy8oe7BaFEP3nMzK/NxvN3RgvYHzPj/27vv8CiqtoHDvy3plUAgCSWh914CiAEEBAkoSF5ApSsISBP87C9NVNBX6b2K9CK9CGIo0sGAgHQIhBICIb1vdr4/YjbZ7KZsCCTIc19XLtizM3POzLZ55pznzN9hxkG9vRWMfjnjJOtJ6kj3NF+Pf3sddT6qy5H3/oB/XibrYtZU7Jsx+5qldWgdrCg/uiY3vsmYAtWpXjHcO2fc4Tm7/Sj9f3UIGZdxocu+VjGKd/VBba0xux9KKQX7lzyJP5xxold8cC20JezwwDjAcHNzw/qLZoS+ucU0yUijwu3zZjhkc6ycvnyZiHd+If3DpfZwxGFgA5w9jE/K0/dD+bQVCZ9n5CGqq5fEOqA2Kmsrs/uhH+GHbuVpiEpIK9Sqsf6sbY7HShnWGv2yoxCZ5WKPRo3Nf40vDBpe8yFtYc5vacOY0jnb4fjR62lJUZnr+CIAun0PWS7KYWuN+pOuReK9Wxh1iKJHgohClHloU0GqVKkSH374YbbPP8sx+tnto0qlYsaMGSa9KukqVqxoUT0XLlxg2LBhlClThmHDhuHl5YWNjQ0qlYrPP//cqIfE1dWV5cuXExQUxPHjxwkKCuLHH39k/vz5TJ8+Pce8hyfRp08fXnvNuBt62rRpQFoPU2bu7k8++4Zer+err75ix44dDBw40ChPQ2RvWQc17X0Ujt5TaFBKRe8auXd196ymxttZxbrLeorbqni3tgpPx+zXO3xHITJJQQUUs4OaxVV0qKhiYD0NbnZP3rVuZ6XiyFB7lpxM4dSdVJJSoUoJNf0bWVG5hHRAFxUerT3waOvJ/d/uoWgVyvetgENZ0yvjlqj8VX1cGpfg0d57OFRxpnS/Sqitcn/Ny41tgGPDEkTuDsG2ojMlB1RFbZP9RS6VWkXFPW/w+KdLJF4Ix7FlaVwCKmW7vOMblSlzvBcxq/7+5z4OKlQaFU7v1MCmfqls17N/qxbJJ+4Sv+BPlORUbFp55zjFq91nrdDU8yRl52XU5Yth825jVHbZD99TVy2F3Zn/Q7fkOEp8MtrejdHUzT5xG0BVsSTas/9Fv/gwyr1IUIHKyQ71O01QNfA2XSFFB1N3pd1AxkYLxRygc30Y3w28zPwed/GF45Nh1SHQpaYFE4520Lc1VC+TY9uE5RJkNFO+SRBRwIKDg03Kbt68CaT1PORXuXLlOHDgAOHh4Tn2RpQtW5aIiAgaN26c7Ql6fpUuXZqjR48SExNjMrToxo0bODg4GJKXc1K2bFmOHDmCh4eHoZcmO+k9GVeuXMHb28yX8z92795NamoqM2bMMDrOCQkJRr0Q6TQajWH2JICrV6/Sq1cvFi9ezPTp04G0QMdSOa1ToUIFKlSoYFSWfhx9fX0trisn6QHEtm3bePfdd+Vu4xbQqNN6I3rlPkGLkWZeKpp55d6zGJ2k0Gmdjqh/OsseJ8C9OIVPm2tRF+DYXBdbFR++XLDz/IuCde6bvwjdcx8VKlTJKi5Pu0SJBu54vZr/3wqAkq+XpeTrZXNfMAs3/3K4+ZtPWDZHbW9FiSG187y8bSMPbBtZ1gueuOsqcdOOGx4nrLmAuoQ9rjOzzwuwfq0q1q/l3nudTu1THOuJluWxqcoVN5/7YM6U7TA90yyNoVHQrLL5ACJdo0ppf0IUYXJJqoBt2LCB2NhYw+PY2Fg2btyIk5MTDRs2zPd2069gz5gxwyTvIPM4RH9/f8LDw1m5cqXZ7WQdg2iJVq1aodfrWbZsmVH54cOHuXz5Mn5+fnkKXNKTjmfPnk1qqulY8sxtbNOmDVZWVixcuNDouKZL3/f0YWFZb6S2ZMkSk+OVeVrYdD4+Ptja2hIdHW0oS8+xiIqKynWfMq+TeRuFQVEUJk2axLZt2+jfvz9Dhgwp1PYIY4G3FEMAke56BJwLk5sAvmju7rqTp7IXWcKmy2bKcp+uvEjZfNq0bNNTuCu2EM+Y9EQUMFdXV/r27WtImN62bRuhoaF8+eWXTzR8qW3btrRr144dO3YQEhKCn58fTk5O3L59m6NHj7Ju3ToA3nrrLY4fP8706dM5efIkjRs3xsHBgdDQUE6ePIm1tTXz58/PVxs6d+7M9u3b+emnn7h37x4NGjQgJCSEDRs2ULx4caOZlnJSs2ZNBg0axIIFC3j77bdp27Yt7u7uPHr0iIsXL3L48GGOHUubyaJUqVKMGTOGKVOm0LNnT/z9/fH09CQsLIwDBw4wduxYqlatSqtWrVi1ahUjR46ka9euWFlZcfz4ca5du2bSOzJp0iTCwsLw9fXF09OTpKQk9u7dS1xcHP7+/oblateuzbp165g8eTItWrRAq9VSq1atHHuUateuzZYtW5g7dy7ly5dHpVLh5+eX53s8ZOf+/fvs2LEDSOv1ATh48CAPHqTNxJJ+XACmT5/O1q1bqVKlCuXLl2fnzp1G2ypTpsxTG7IlcudpJmdSo4KSOSRDi38n21J2xN8xHldv5/Fk3xX/Nhov0w+Mxst8knKR5elqWpZTL4QQzwkJIgrY8OHDOXPmDOvXr+fx48eUK1eOSZMmFUhC69dff039+vXZsmULCxcuRKPR4OXlZZSUq9VqmTZtGhs2bGDnzp2GgMHd3Z2aNWvSqVOnfNev1WqZNWsWixcvZu/evQQGBuLk5ESbNm0YOnSoRcnagwYNokaNGqxZs4bVq1eTkJCAm5sbFStW5KOPPjJaNiAggDJlyrB8+XLWrFlDSkoK7u7uNG7c2HDfiXr16vHdd9+xaNEi5s2bh42NDU2aNGHBggUMHDjQaHsdO3Zk27Zt7Nixg4iICBwcHKhQoQJTpkyhTZs2huXat2/P5cuX2bNnD/v27UOv1zNu3Lgcg4ihQ4cSFRXF+vXriYmJQVEUtm7d+sRBxN27d01uKhgYGEhgYKBh/9ODiL///htIGwI2duxYk2116tRJgohC1MRLTefKKrZdzeh5GNpQnWMOhfh3qjG6Jof7HkKvS3sv2JW0NUqsFuAwuBFxi4LQ3/1nWKpWjdNYv8JtlKU+fx32XYCEf2ZsK+YAo2Wa1qIiGfnuzS+VknX8h8iXbdu2MWHCBObNm2cYZy+EEObo9AobLuo5G6bwUhk1/pVU+crBEc+35NgUfv/gGHcPh4EGavWrhO9ndQu7WUVO6qN4En7+C31kInb/qYFVrZKF3STLXX8Aq46k3YG6dwvpiShCVKMe53lZZZrcrDUz6YkQQohnTKtW0bOmhp7m7+MlXhAnvzvP3cMPARWkwvnF1ylZvwTlOzxZYvW/jaaEPY4fNi3sZjyZiqXgv10LuxVCFChJrBZCCCEKQUhgqJkyucGWEM+UyoI/YUSCCCGEEKIQOJY2vRuzY+knu0+EEEI8K5ITIYQQQhSCe0cfsue9w6QmpU1D7Vjajtd/aY1d8adzI1IhhCnVhxbkREyVnIjMpCdCCCGEKARezdx5Y0dr9K3i0LePodPmlhJACCGeG5JYLYQQQhQSx9L2KE0SALB2tCrk1gjxApKZ8fJNeiKEEEIIIYQQFpEgQgghhBBCCGERCSKEEEIIIYQQFpEgQgghhBBCCGERCSKEEEIIIYQQFpHZmYQQQgghxItJZmfKN+mJEEIIIYQQQlhEggghhBBCCCGERSSIEEIIIYQQQlhEciKEEEIIIcSLSVIi8k16IoQQQgghhBAWkSBCCCGEEEIIYREZziSEEEIIIV5QMp4pv6QnQgghhBBCCGER6YkQQgghCsmjU+FY77ZDsVGIaxeHa3nXwm7SU5N0OIT41RdQu9jgMLA+Wh/Xwm5S4bl6Dxb9Bokp0KcVNKxY2C0SwmIqRVGUwm6EEEII8aK5tT2EPz44Bv/8Clu7WPHajnY4lnMo3IY9BfHr/+Zxj18M+6oqZkup0++iLV+scBtWGM7fgmafQWxi2mONGnZ8Ae3rF267XlCq/4vK87LK9y5PsSXPHxnOJIQQQhSCv+dcMpxUAyRHpXDl5+uF16CnKGbyEaN9VSISiZ37Z+E1qDDN2JkRQACk6uG7zYXWHCHyS4IIIYQQohAkR6WYKUsuhJY8ffqIRJMyJSKhEFpSBETE5q1MiCJOggghhBCiEHi/UdakzOeNcoXQkqfP/q2aJmV2ZspeCG+9nLcyIYo4SawWQvzr3IlRmPmnnpAY6FxRxVvV83a95NxDPUN/03M7Gtp4q5jdRo2d1dOZ/u/kXT0LTulQFHivoZamZeWaTlGVHKfj/JpgHl2KolSdYtTs7o3WRvPE263zYU2ibkYT8utd0CrUGVYTj5dKFkCLny59TDIRs86QdPYhds08cRlcB7VNzqcTzuP90EcmEv/zOVCrsH+7FravlM9TfSmHb5G45DRoVNgOaoxVozK5t/HqQ1JmHUJ5HI+2Z320/k8nYFHik2DsBtj8J7jaw/g3UXXKJbfhzaYw5vW0xOpUPbzjl/Y4J+ExMHMHXLoLr9SGd9uA5snfgwKZ4fUJSGJ1EXTq1CkGDx7MuHHj6Ny5c6G04fLly0ybNo1Lly4RExPDwIEDef/99wulLUJY4nGCQu2fUrmXaXTA+OZqxjXP+ST9ToxC+YWp6PQZZdXd4O8BBX+t5VBwKq8sSzbUpVHDnj7WvFJBTgqKok19jxAa9Njw2LtlKTrObPzE272x8RZHPzxheKx10PLajrY4V3B64m0/LYqicPulNSQevW8oc+xSkdKb3shxvdTweB7UXoD+fsYH03liS5z/m/MV+OQ9V4l+7SfQ/3OqYqXB5cB7WDXLvsdGfzOc+Pr/g6iMIVQ2C3tg9V7THOvKD8V3HJy4YVy45gNUPXKoa/ef4P8N6P/5ArDWwoGvoGlV88snp0C9MXDxTkbZwHawYMiTNV4AoPrYgsTq7ySxOjO59CVM6HQ6Pv74Y27fvs3gwYOZOHEir7zySmE365nbv38/8+fPt2idVatWsW3btgJvy/nz5/n+++8ZMGAAL7/8Mo0aNcq2nvj4eBYsWMCHH35Ix44dadSoEYMGDSrwNhVVqy8pRgEEwNTTevS5XC+ZdFRvFEAAXHwMFx4V/HWW6cd0RnWl6mHaUV2B1yOeXOjZCKMAAuDWgQdEBj/5GPZLCy8bPdbF6bi68kY2SxcNCUfuGQUQALGbr5N8PTLn9VZdMAogAGJ+PE5u1zETph7OCCAAUlJJmHE0x3VSFh4zCiAAkv8XmOM6+aGcuWUaQAB8tTnnFaduzwggAJJ1MHNn9svv/NM4gABY+js8jslzW4V4GiSIKIIaNGjA4cOH6dixY6HUf/fuXe7evctbb71Fjx496NixI5UrVy6UthSm/fv3s3DhQovWWb169VMJIg4fPsz69euJjY3N9bWIjIxkwYIF/P3331SuXBnNC9blHWeaq0qCzvg8xJzoZPMLmNvek4ozkztrrkwUPl1CqtnylGzKLdp2vOk2dPFFO5hUsvlA6HP5oOjNvMGV+JRcP5hm68vtwxKXZPk6+WGuHoD43NpnmmSe7bayW16XCklP4cvphaSy4E9kJkFEERIXFweAWq3Gxsam0E7+wsPDAXBxKdhuO0VRiI+PL9BtPu8GDRqUp16CgIAADhw4wLp163j77bdzXLZEiRLs2LGDX3/9lenTp2NtbV1QzX0udK+qwjbLCKS3qqnQqnP+AfiokenXoZstNPYoyNal6Vvf9LPdp96LFew9LzwbuuHkZWdU5lbZiRLVnJ942+W7eRsXqKB8V2/zCxcR9q3Koi1rPNzKpp47tnXcc16vew2yfjDt36mFSpPzaYhtX9P8Aps+OeccaHs1giyfd22fRjmuky9NK0FpM/e5GNQ65/X6tMpbWbpOjaCYo3FZu7rg6ZZbC4V4qiSxuoBs27aNCRMmMHv2bM6cOcO2bdsIDw/H29ub/v370759e6PlO3fujKenJ6NHj2bWrFmcO3cOFxcXtm7dmm1OhKIobN68mc2bN3PjRloXqpeXF61bt2bw4MGG5ZKTk1mxYgW7d+/mzp07WFtbU79+fd5//32qVauW434MGjSIP/9Mm7t7woQJTJgwAYCtW7fi5eVFQkICixcvZu/evYSFheHs7Iyvry9DhgzB09PTsJ3M+5CQkMD69eu5c+cO/fr1M+RW7Nmzh7Vr13L16lVSU1OpVKkSvXv3pm3btibtOnXqFD///DPnz58nISEBd3d3GjZsyIgRI3B1dQVg/fr17N+/nxs3bhAREYGLiwtNmjRhyJAheHl5GW3vjz/+YPny5Vy/fp3ExERcXV2pUaMGw4YNw9vb2+g4NGqU8eOTU55K+nL37983Wif92D2J4sWL53lZa2trSpUq9UT1Pc98XFRs66pm8F4992OhRnEY3yz3K0gNPNQMqqNn8TlIVcDJClZ0VKFSFfzVp561tfx+Q8+686mo1TC0sZa+9eXruCjSWKmp168ipxdeJSVOh2cDN1qOrVMg74uaw6oTfTGCW3vuoGgU6o2sQ8kmJfK1LV1UMiE/nCfm5EOcm7hTZkwttM55u4AQs/8uj+ZdQNErlBhYA+d2prNGpVNZayi9owv339pJys0orMq74Pnza7nWoa1QjBJbuhMxdBf6+7Foa5TAeVzuMxLZvFOXpG2XSPn9Oio7K+w+b4lNQK0c19FfCEXdsAz62xFgb411vyZYfW76u5KZcieC1O/3oP/7HioFsNKgfrkS6g/borLL5jim6qHfyzBzL8QkgFoNflVhVHvzy6fr8RJsOg6HL4KDLYztnpZsnR0XBwicAO/OTkus9nKDT9/MuQ4hngH51SpgM2fOJCEhgYCAACAtuPjiiy9ITk42Ofl88OABQ4YMoW3btrzyyiu5XqUfO3Ysu3btolatWgwYMAAnJyeCg4PZt2+fIYjQ6XQMHz6cv/76i44dO9K9e3diY2PZtGkT7777LgsXLqRGjRrZ1jFgwADq1q3L0qVL6dq1K/Xrp13xKVasGDqdjmHDhnH27FnatGlDr169uH37Nhs3buT48eMsX77c5OR19erVREVF0aVLF4oXL254fs6cOSxZsoTmzZszePBg1Go1gYGBfPrpp3z88cd0797dsI2NGzcyefJkSpYsSbdu3fD09CQ0NJRDhw7x4MEDQxCxYsUKatWqRY8ePXBxceH69ets3ryZkydPsmbNGsNyp0+fZvTo0VSsWJH+/fvj6OjIo0ePOHHiBCEhIXh7ezNgwAAURSEoKIiJEyca2lKnTp1sj93EiRP58ccfcXV1ZcCAAYbyYsVewDuyFrK5ZxTSh2ifegAdftFzrq8KK032J37TT+tZ8FfG45gU+M82hXN9Fcq7FmwgMeOYjoWnM4ayTD2qo089DVVKSOdwUXNpcwiHvjlveHz3RDiJUSk4etjlsFbehPx0jccrg0m/rh884S/KvuKFcw1Xi7d17rU9RB8NAyBi910ifr9P/UP+ua4X8/sdrrbbZhhWFLnhOhW3dcTF3yfbdR59cZjkC2k91skXwrnXcwc+Z3vn2qsQt+BPUq9HAJBy6j6P2q+m1LlBqKyy74WL6bWelC0XAVBikkmaewK7oU2zXSf5670kf5kpv8DFFm3/Jqi02dehxCaS0nwKhKS1LX2AVeruC+iP3sBq2zDzK763CH4+nPE4VQ+BF+HdRbByaLb14f81HL70zw4mwooDMKRD9ssDnLoOp//Jv7h6HzpOghNToI5PzusJ8RRJEFHAIiMjWbNmDY6OaV2PAQEB9OzZk6lTp9KuXTtsbW0Ny969e5cvv/ySLl265LrdvXv3smvXLl577TUmTJiAWp3xZa3PlKC1du1aTp8+zcyZM2nWrJmhPCAggB49ejBt2jQWLFiQbT1NmzZFq9WydOlS6tSpY5SXsWnTJs6ePUvv3r0ZOXKkodzX15dRo0Yxa9YsvvrqK6PthYaGsmHDBtzcMrpdL126xJIlS+jfvz8ffPCBobxnz56MGTOG2bNn4+/vj4ODAw8ePOB///sfPj4+LFmyBCenjG70IUOGGO37mjVrsLMz/mH38/Nj6NChbNmyhb59+wJw4MAB9Ho9s2fPNmrXe++9Z3Qcdu/eTVBQUJ5zUzp27MjcuXNxc3MrtHwWkTbL0qarxuOsLz+GvbcUOlbIPhiY8afepCwuBX66oGf8SwU71GjGMeNx7/EpsPjPVKa8KkFEUXNu1U2jx6nJev5efwu/L2s/8bZvzjNOrNYnpnJ72TVqfWfZ0JuYU48MAUS66D8eEBMUjlP9nHsxw2adM85LUODhrPPZBhEpwVHEbTNOJk6+EE787yE4tMt+KFbq3WgSfrlkVKa7HE7inhvY+ZvP80q9G0XyL38bl11+RMqeq1j7m+9VT5lx0LggKhHdTyex/vLVbNum33zGEEBkpWw/h3LzEaryxj1ESngMrDxifoNrjqFM64XK3cyQt9PXMwKIdEcuw5/XoUHFbNvIjB3Gj5NSYMFemDUw+3VE3kiqQ77JL1YBCwgIMAQQAI6OjnTr1o3o6GhOnz5ttKyLi0uep3DdtWsXAKNGjTIKIACjx7t27cLHx4fq1asTGRlp+NPpdPj6+nL27FkSE80kaeVBYGAgarWa/v37G5W3aNGCKlWqcPDgQaOTegB/f3+jE/X0NqpUKvz9/Y3aGBkZiZ+fH3FxcZw7dw6A3377jZSUFAYOHGgUQJjb9/QAQq/XExsbS2RkJFWqVMHR0ZHz5zOuJKa/Pr///js63bNLYoyPjzfZX51Oh06nMyl/UXJHHj9+TFJSRkJhbGwsMTEZM44kJycbcnTS3b9/P+fHDx5iLlUzOTXnOlJMY4i05/WmdYSGhhrNKmPpfqSYycmNiDaeueZJ64Dcj5XUkXsdqSmm7ya9Tl8gdSQnmibG6pMz3oh5rUOfzZtXSdHneqyS400TelMSMhKDs+6Hkl1dyRlvarOvR1wiZj+YKfrsj5VOD2Zmb1KSU7N9zc21T0lJzfn1MPeBNGpjqlEdAKTqzTUtjV5J65XA9DV/dP+B+XWSdaZ1kOk1N9fGFJ3ZOv5tn0FRdElPRAHz8fExKStfPu2GOnfv3jUqL126dJ6Tp0NCQihRokSuY+Nv3rxJUlKS2byCdJGRkXh4WJ4teu/ePdzd3XF2Nr26UrFiRa5cuUJkZKRR0FCunOlc3jdv3kRRFMOQL3PSv1xCQkIAqFo1m/mzMzl58iQLFy7kwoULRl9egNGXV/fu3Tlw4ACTJ09m5syZ1K1bl+bNm9O+ffunOvTou+++Y/v27Wafy/p6derUifHjxz+1thQVWQPMzAE4pOV3ZH3PZ869Mfe4caWStCmXyr7bGT9oZZygQ3lVjnW8W1vP+CPGJyDWauhdQ41nceM6sn5+LN2PdxtoGBeYEcBaaeCDFsYTGTxpHZD7sZI6cq+j+ptlOfJ9xtVwlRqqdSlbIHVU6F+Fi2PPZGxbo6JsrwoW74fiq+BQqxhx5zOupjvUKYZT4xI4Z8ndyHqsPIfU5cav94zKSr2f0cuSdT+sKxfDzq80CQczfs+03s5GvRBmXw83iGvjQ9K+YEO5powTth0qorLWZnusrNpWJOW364ZydWlnrDtUwcPOyrQOgHd9Sck8nautFVa9GqHO4fVQd6lH6v9thPA4slK9XAlVlVLGdQCqki7QqR5sCzJZB/96qDxcjepIV8K/GdT2hnO3Mgpre4NvFZM6INNr/m4b+OinjCc0auj/itk6/m2fQVF0SRBRiDIPbSpIlSpV4sMPP8z2+Wc5Rj+7fVSpVMyYMcOkVyVdxYo5dOuaceHCBYYNG0aZMmUYNmwYXl5e2NjYoFKp+Pzzz416SFxdXVm+fDlBQUEcP36coKAgfvzxR+bPn8/06dNzzHt4En369OG114wTEKdNmwak9TBl5u6e80wnImcbXlcz/oieg3cUapZQMb65Glttzn3W/22m4moEbLiSdhGxUjFY8KqG6sULvq/7y5ZanGxUrDmnw81Oxf+10FLXQzqGi6K6vSugsVZzZdsdrBy01O1dAY96BTMrTsVRNQi7FMmtPSHwT2J1sUaWJ1ar1Cpq72nPrXF/EnMqHKfGJfCZUD9Pyd+ub5Sn/NpXeTjnPOgVig+qgdtbOU8j7di1EinXo9DHpmDX3JOSs9ugss79gpjd2zXRXX2MPjIJ68aeFJvfEVXWqdSycFr/FvETfiflwE20NUthP/4VVFkCiMysJ3dCVdwe3S/nUJVyxPqztqgr5/x9qirmgPbAR+gnbkd/4X7a8BaNGrVfZTTjcxgtsGooTNgEO86kTetqbw0d68K4rjlUpoJf/wsjFsO+v8DGCro2SbtvRE4XFUe/DnbW8PMBcLJLu8N1djenExaS8Uz5JUFEAQsODjYpu3kzbUxt6dKl873dcuXKceDAAcLDw3PsjShbtiwRERE0btw42xP0/CpdujRHjx4lJibGZGjRjRs3cHBwMCQv56Rs2bIcOXIEDw8PQy9NdtJ7Mq5cuYK3d/bjbXfv3k1qaiozZswwOs4JCQlGvRDpNBoNjRo1MsyidPXqVXr16sXixYuZPn06QL5mX8lpnQoVKlChQgWjsvTj6Ovra3FdInuutiqmvWJZHsPKvxVWXsx4fCUCUvUKT+MHRq1W8WFzLR82l6/g50GtHj7U6uFT4Nu9vOQaN3fdAzSQCmemXaRUay/call+ocfG054qC1rkqx3FuleiWPdKeVr28fcnefjxIcPj+H0h2d47IrO4FeeIfDdjXH9S4C10t6PRVsw5IFO72uE4NfcE8XQqjRrrT9ti/WnOszGZ1FPTC/Vay27KqXK0he/fSvuzhF6BPWch+p9hqxPXQ3QCTB2Q/ToqFQx9Le1PiCJCLn0VsA0bNhAbmzG2OTY2lo0bN+Lk5ETDhg3zvd30K9gzZswwyTvIPA7R39+f8PBwVq5caXY7WccgWqJVq1bo9XqWLVtmVH748GEuX76Mn59fngKX9KTj2bNnk5pqOs4zcxvbtGmDlZUVCxcuNDqu6dL3PX1YWNa7ny5ZssTkeEVGRppsx8fHB1tbW6Kjow1l6TkWUVFRue5T5nUyb0M8P+adNX6f6BVY8FfB361aiHRXV143eqxPUbi+9mY2SxcNkXP/MnqsJKcStfRCruvFzTPOCUSvELfgz4Js2vNj9aGMACLdgr3Gd7EW4jkgl8EKmKurK3379jUkTG/bto3Q0FC+/PLLJxq+1LZtW9q1a8eOHTsICQnBz88PJycnbt++zdGjR1m3bh0Ab731FsePH2f69OmcPHmSxo0b4+DgQGhoKCdPnsTa2pr58+fnqw2dO3dm+/bt/PTTT9y7d48GDRoQEhLChg0bKF68uNFMSzmpWbMmgwYNYsGCBbz99tu0bdsWd3d3Hj16xMWLFzl8+DDHjh0DoFSpUowZM4YpU6bQs2dP/P398fT0JCwsjAMHDjB27FiqVq1Kq1atWLVqFSNHjqRr165YWVlx/Phxrl27ZtI7MmnSJMLCwvD19cXT05OkpCT27t1LXFwc/v4ZV7xq167NunXrmDx5Mi1atECr1VKrVq0ce5Rq167Nli1bmDt3LuXLl0elUuHn52cya5Sl7t+/z44daVfx0u8RcvDgQR48SEvSSz8u6dauXWvogdHpdISGhrJo0SIAqlSpgp+f3xO159/IXCfSU7hFhBA5K+pvOnPNy0uT5QOWQY5F0SKHPt8kiChgw4cP58yZM6xfv57Hjx9Trlw5Jk2aRIcOucwBnQdff/019evXZ8uWLSxcuBCNRoOXl5dRUq5Wq2XatGls2LCBnTt3GgIGd3d3atasSadOnfJdv1arZdasWYabzQUGBuLk5ESbNm0YOnSoRcnagwYNokaNGqxZs4bVq1eTkJCAm5sbFStW5KOPPjJaNiAggDJlyrB8+XLWrFlDSkoK7u7uNG7c2HDfiXr16vHdd9+xaNEi5s2bh42NDU2aNGHBggUMHGg8BV7Hjh3Ztm0bO3bsICIiAgcHBypUqMCUKVNo06aNYbn27dtz+fJl9uzZw759+9Dr9YwbNy7HIGLo0KFERUWxfv16YmJiUBSFrVu3PnEQcffuXebNm2dUFhgYSGBgoGH/MwcRK1asMJrZ4t69e4b1O3XqJEGEGUPqqjl8N+NKoFoF79eRzlrx9FTpXZFT484YHqut1VTskfMQz8LmOrQuDz/KmEZVZaPBpX/NXNdzHNKQx3+EZBSoVTi+3+BpNLHoe+tlmLQBIjMlcr/fLu1mdUI8R1RK1vEfIl/S71g9b948o7sVCyGeHxsu61l8TsFWC8Pqq2jjLT/q4ulRFIWTA/8geM+dtMTqUbWpMvLJ7z/xtEUtOU/06kto3GwpNrohdr55m0UnfsNF4pecAWsNjsMaYdu2Qq7r/GtduA1TNsGdcHi9MQzvmHNitXhqVJ+a5k1mR5lsOtX8i0x6IoQQ4h8BVdUEyIQn4hkJ+e4cCYuvUuqfx/fHnMKjaSmcfUsWarty4zKgFi4Dalm8nn1AdewDqj+FFj2HapaD5SNzX06IIkwuswkhhBCFIHTJFeOCVIUHP10rnMYI8aJSWfAnjEgQIYQQQhQCtZl7K6is5WdZCPF8kJwIIYQQohDcX3SZKwMPGx6r7TQ0OPU6DjWe3Q1BhXjRqT6zICfiW8mJyExyIoQQQohC4PleVVTOWk5NDkRvB37T/CWAEOKZk3FK+SVBhBBCCFFIinctx73ItKmFHerlfPdmIYQoSmTwpRBCCCGEEMIiEkQIIYQQQgghLCLDmYQQQgghxItJUiLyTXoihBBCCCGEEBaRIEIIIYQQQghhERnOJIQQQgghXkwqGc+UX9ITIYQQQgghhLCIBBFCCCGEEEIIi0gQIYQQQgghhLCIBBFCCCGEEEIIi0gQIYQQQgghhLCIBBFCCCGEEEIIi8gUr0IIIYQQ4sUkM7zmm/RECCGEEEIIISwiPRFCCCFEIUmJTMbhhBq9Heh1erAq7BaZl3Q2jKTTD7Dx9cSmZonCbk7hOnML/gyGppWgRunCbo0QhUaCCCGEEKIQRJ0O59SreygRaQ3AqUO/0uRAB6xcrAu5ZcbCPz9IxLfHDY/dJr6E23+bF2KLCtHHq+H7HRmPv/4PfP5G4bVHFAAZz5RfMpxJCCGEKARXP/sTXWSK4XHsuUhC5l8pxBaZSgmOImLKCaOyxxOPorsfW0gtKkTXH8D/dhqXjf8FHkQVTnuEKGQSRAghhBCFIO6y6cln3MWidUKacuUx6BXjQp2elGuRhdKeQnX5PihZjkVKalpwIcQLSIIIIYQQohC4tfIwLWttWlaYbJp4orI3TtRQu9hg06BkIbWoEDWtBHZZhpoVc4D6PoXSHFFAVBb8CSOSEyGEeG5FJyn8clUhLkVBBVhrVHStrKK43dP5tk/SKWy5lMqjeHi9qoYyLvKrUpSlJuu5cTCMhIhkKviVxLGUbd7WS0rl1m/3SYxIwruNJw6e9k+lfVW+b0jMtSjCz0QACt5vl8erV4WnUheAkpJK9PZgUu7G4uTvg015l1zX0bjaUmL6KzwaHYgSk4zGw56Si19D7ZB73oaiV0j69Rq6q4+xaVsBqxruBbEbZurRk7r7Isq1R2jaVUVdPW+BmBIei/JLENhoUb1ZH5VjLu8PN0eY1QdGrYCYRPBwgaWDTAMLk4oU2HMGLt+DV2pBLe+87VhcImw6DvFJ0NUX3HN/vYR4llSKkrVvTgghir6bkQovrU7lfpxxeTFbONBDQ233gj3Bj05UaLEkiXMP0r4ybbWw7W1r2lbUFGg9omAkx+nY8N5xwq+mjd3XWKvp9GN9yjXNeWah5JgUtvc4QMSV6LT1bNS0W9Cc0i8V/JX3RycecrDnflLjUwFwrODIK9vbYeNmU+B16RN1XG/1C/HH/xl6o1Xjs74DLl0q5rhe/O+3uO//C0qiDgCrmsUpc/gdNC45t1FRFMI7rSZp57W0AhW4zvXH4f2GT7wvRvXo9ST5LyB198V/6lFhvaAHVu81y3m9syHoWv0AkfFpBWWLoT3yKaoyxbJf6cR1aPttWgABUN4djo2Hkrmc3HeZDFsy5ZXMfA+Gdcx5ndAIaPYZBIelPXa2h33joVGlnNcTFlP9Nz7PyypfPZ0LCs8rGc5UBJ06dYpGjRqxbdu2QmvD5cuXGTJkCK1bt6ZRo0bMnz+/0NoihDnfndSbBBAAEYkw8ai+wOtbEpRqCCAAEnXw2W8pOawhCtPFbXcNAQSk9UocmZl70vKV9cGGAAIgNUnPqf+dfyptPD/5nCGAAIi9Ecv1n649lboi11zNCCAAdHru/d/hXNcL/+yQIYAASLkQTvTiv3JdL2nvjYwAAkCBqM/2oSTpsl8pH1J/vZQRQAAoCsmfbkNJzrme1AnbMwIIgJAI9D/uzbmysRsyAgiAmw9h5p6c19l/3jiAAPhiFSQk5bze9B0ZAQRAdDyMW5PzOkI8YzKcSZjQ6XR8/PHH6HQ6Bg8ejJOTE5UrVy7sZj1z+/fv5/Lly7z//vt5XmfVqlU4OTnRuXPnAm3L+fPn2bVrFxcvXuTq1askJCQwbty4bOtJTk5myZIl7Ny5k4cPH1KyZEk6d+5Mv3790Gr/HR/7nPI6r0cWfAfrtcemgcm1x9KRW1RF3TG9uhh1JyHX9aJvm0am5soKQuwt0xmOYm/GPJW6ksx8YJJvRKMoCipV9r12KdcizJSZbisr3XXT9ZSIRPSPE9B4OuW6fl4p1x+ZFobHQWQClMy+HuX6wzyVGblmJoHaXJnR8/dNy6LjISwKvHPo3boeaqZMErifChmVmm/SE1EENWjQgMOHD9OxYy7dnU/J3bt3uXv3Lm+99RY9evSgY8eOL2wQsXDhQovWWb169VPpQTp8+DDr168nNjY2T6/FZ599xqJFi2jUqBGffPIJDRs2ZN68eUyaNKnA21ZYOvhk/83fPofn8l1fJdNhS+bKRNFgbthSuea53yStzMul8lRWEDzMJFZ7vOL5VOpyal/OtOzVsjkGEAD2HcqblDmYKcvKtm15UBtvW1unVIEGEACadlUhyz6o65dBlUMAAaBuX8OkTNW+Zs6VdahrpqxOzuu0rQuaLKda1cvkHEAAtK+XtzIhCpEEEUVIXFza1S61Wo2NjQ0aTeGcoISHhwPg4lKwSVyKohAfn/exhy+CQYMGMWjQoFyXCwgI4MCBA6xbt4633347x2X/+OMPDhw4wDvvvMPYsWPp0qULY8eO5Z133mH79u2cPXu2oJpfqEY0UPFubRXaLOdAXSrCf5sV/Fdbp6oaPmiiweqfj2Xr8ipmdCyitxcW+LRwp8nACmis094LJWs40/KjarmuV8avFD7tvVBbpb2xvF4qSdP/mjl5LAB1/lsP92buKCgoaoWKAypS9g3Tk/2C4PhyaTy+bYbKNu0NbFXOEa8fWuS6nvu0V7Bp7pX2wFqD62dNcHg993H5+vAEbN+oisopLenYqp4HbqvfzHZ5RVFI3nmJ+M92Ezd8Kwn/O0jq7chc61FXLYX1op5QwgEAlaczmoC6KPHJOa6nGtUWGnqnXYW20qDqXAcexqDf8RfZpop+8x94o0Ha/7Vq6NIQeudyDH1Kwk/Dwd057XEpFxj9eq77Rf9XoMdLaQGISgVdmsCknL/7hXjW/h3jGoqAbdu2MWHCBGbPns2ZM2fYtm0b4eHheHt7079/f9q3b2+0fOfOnfH09GT06NHMmjWLc+fO4eLiwtatWzl16hSDBw82Ga6iKAqbN29m8+bN3LhxAwAvLy9at27N4MGDDcslJyezYsUKdu/ezZ07d7C2tqZ+/fq8//77VKuW84/ooEGD+PPPPwGYMGECEyZMAGDr1q14eXmRkJDA4sWL2bt3L2FhYTg7O+Pr68uQIUPw9My4gpZ5HxISEli/fj137tyhX79+huFBe/bsYe3atVy9epXU1FQqVapE7969adu2rUm7Tp06xc8//8z58+dJSEjA3d2dhg0bMmLECFxdXQFYv349+/fv58aNG0RERODi4kKTJk0YMmQIXl5eRtv7448/WL58OdevXycxMRFXV1dq1KjBsGHD8Pb2NjoOjRo1MqyX0xCi9OXu379vtE76sXsSxYsXz/Oyv/76KwBvvfWWUflbb73FypUr2bVrF3XrPp2TomfJSqNidEM16y6nEpPpfOHgXQiNgwquBVvf9supzD+Viu6fUU13otPOI0TRpCgKoeejSE1Oe8HC/o7m7613adQ/+9mP9KkKu/v9wf3jGUNkyrYshV3xgk90Boj5M5yUX+/jnKwHBaJX3SJ5ZC1sStkVeF2pcSmELziPkpiWg5FyO5ZrrTZR9fzbWJXMPlk0YX8IScf+GZKTnEr8thvoP2uG2in7GYlifjhK9EcZ+QXWLcpS4kA/VOrsez3i+m8g+ac/jese9xtOe9/FqnnOsxlZDWgKVhqS+61EuR9Nyhc7SF0bhO2RUagcTF875UE0qc0mw+3HaQV6Pcq2v1C2peV6qHo3Rbt8gGlFzvbg4Zr2f50eNp+G95fAwvdybB/vtIStJ2HdkbQb0w2cA5fvwvd9s19nxg5YmylnJSIO7IvWncz/PWQ8U35JEFHAZs6cSUJCAgEBAUBacPHFF1+QnJxscvL54MEDhgwZQtu2bXnllVdyvUo/duxYdu3aRa1atRgwYABOTk4EBwezb98+QxCh0+kYPnw4f/31Fx07dqR79+7ExsayadMm3n33XRYuXEiNGqbduOkGDBhA3bp1Wbp0KV27dqV+/foAFCtWDJ1Ox7Bhwzh79ixt2rShV69e3L59m40bN3L8+HGWL19OqVLG3f6rV68mKiqKLl26ULx4ccPzc+bMYcmSJTRv3pzBgwejVqsJDAzk008/5eOPP6Z79+6GbWzcuJHJkydTsmRJunXrhqenJ6GhoRw6dIgHDx4YgogVK1ZQq1YtevTogYuLC9evX2fz5s2cPHmSNWvWGJY7ffo0o0ePpmLFivTv3x9HR0cePXrEiRMnCAkJwdvbmwEDBqAoCkFBQUycONHQljp1su+6njhxIj/++COurq4MGJDxA1SsWA6zfTwFFy5coGTJknh4GA+V8PDwwN3dnb///vuZtudpmnxCbxRAADxOhB9P6ZnVtmB78r78PcUQQABcDVdY/KeOj16S3oii6M7Jx9w+Gm5UdnLxDer0KIe1vfmfvjsHQ40CCIA/Z1yk2jsV0NoUfM/wtfFn0CfpDacwSSHxhMy7TKVx9Qq8rsiVl0nJkm+R+jCB8Hnn8RjbJNv1wj8/aHSzueTzj4hZcQGXIfXNLq8kpBAz4YBRWfIfIST9eg3b18wPxUy9GGYSQAAQn0LixH1Y7TZzQp9FytidRu3U/3UP3arTWA1sbrKsfs7+jAACINW450H5+RjKJx1Q1cxy8edGGCwINC5btB8+7gSVc5hWNuhGWgCR2bTt8NEbUMrVdPnEZBi31rjswAXYFQSdGpkuL0QhkSCigEVGRrJmzRocHR2BtGEoPXv2ZOrUqbRr1w5b24x5qO/evcuXX35Jly5dct3u3r172bVrF6+99hoTJkxArc64BKrXZ5zZrF27ltOnTzNz5kyaNcuY4i4gIIAePXowbdo0FixYkG09TZs2RavVsnTpUurUqWOUl7Fp0ybOnj1L7969GTlypKHc19eXUaNGMWvWLL766iuj7YWGhrJhwwbc3NwMZZcuXWLJkiX079+fDz74wFDes2dPxowZw+zZs/H398fBwYEHDx7wv//9Dx8fH5YsWYKTU8Y41yFDhhjt+5o1a7CzM76C5+fnx9ChQ9myZQt9+6Zd9Tlw4AB6vZ7Zs2cbteu99zKuJjVt2pTdu3cTFBSU59yUjh07MnfuXNzc3AotnwXg0aNHlC9vfsyyu7s7YWFhZp8rDI8fP8bBwQEbm7SrhbGxsSiKYnidk5OTiYmJMeqJuX//vqHXKySbHNTb0RknBU9aR/rj21GupvVEKQVaR+bHoaGhlCpVyjBmXeqwrI6IO6ZvDl1iKomRKaDVm60j7p5p4nVKrI6UmBQeRTws8P2ICzZtY8KtjCTugjxWySGmSdwAsVcfkZSUlG0dKbdN2xj5931cyAgiMtepj0xEyRrZA4nXH5P+65e1jiRzydH/SL0VaXa/Mr/miqKgD4kwuZ6cdPUB6SF+5mOlZA4gsqGEPOZBcbXRax79dzDO5oY6hYRDZY/sX4/bZvZPlwr3HhOqJJq+r+J02ESbuah4++Fz9Rks6DpE0SOd8QUsICDAEEAAODo60q1bN6Kjozl9+rTRsi4uLnmexWfXrl0AjBo1yiiAAIwe79q1Cx8fH6pXr05kZKThT6fT4evry9mzZ0lMTCQ/AgMDUavV9O/f36i8RYsWVKlShYMHDxqd1AP4+/sbnaint1GlUuHv72/UxsjISPz8/IiLi+PcuXMA/Pbbb6SkpDBw4ECjAMLcvqcHEHq9ntjYWCIjI6lSpQqOjo6cP58xRWP66/P777+j0xXsdIM5iY+PN9lfnU6HTqczKX+S3JHExESsrc13e9vY2OT79X8a3NzcDD8ykPbaZH6dra2tTYZyZf5R6VTBfDd0p4oZ74snrSP9cecqpleiO/1TVlB1ZObh4WGU9Cp1WFZHhRYehryGdMUrOeLsZZdtHWValkKVJcmmRG1X7ErYPpX98HjddJhOyU5lCrSO9MfO/j4mdQG4d6uaYx0OnU3vI1Gyp3GPbOY6NZ5OWDXIcuKnVePYuWq2ddi1roTK1fyN3qw7VzepA4xfc5VKhbZTLZN17bplBDqZj5W6cy7J0K72qFpUMnnNndvWy8htSFfcEZpVNqkjnaenJ7SqCVlvZFeuBNTxNv++KlsSGmfJO9Fq4LUGz9VnsKDrEEWP9EQUMB8fH5Oy9KvCd+/eNSovXbp0npOnQ0JCKFGiRK5j42/evElSUpLZvIJ0kZGRJkNd8uLevXu4u7vj7Oxs8lzFihW5cuUKkZGRRkFDuXKmSYI3b95EURTDkC9z0pO7Q0JCAKhatWq2y6Y7efIkCxcu5MKFCyQlGc/BHROTcTWte/fuHDhwgMmTJzNz5kzq1q1L8+bNad++/VMdevTdd9+xfft2s89lfb06derE+PHj81WPra0tycnmkwqTkpKMesOedyMbqjgVCmsvgwJoVPBhQxhYp+DHuE57zYrYZIUtl/W42MAXflpeldmZiizHkra89m09Dk29RPTdBDzruNJmrOmJZmZOZRxo/WNjjn3zF/GhiTh42dFgVPbDP59UlW8bkHgjisjdIei1KsqMqkWpN/N4N2MLOTT1wGvay9z/5AhKUipo1bj/X/1cbzZXcm47HiSnEr/jBio7LbYtSqN2zjlHxG1tNyIGbCX50G003i64/PAqWm/XbJdXOVjjuKUPcYM3ob/4MG1WJ7UK6171sZuQ/W9ZZjbzu5OUkkrqrovg7oD1xI5ofH3MLqt+swHKV2+gn7Ib4pOhSklQq+Hv+1DdE83ct83fvfpxHHRrBL+cgrBoqFUG5g3I/Y7VLg6w+VP4YGFaLkSDCrBoKOT0+79mNPSfBQf/Tgs4/tcPyj+dWcJeeJISkW8SRBSip3UyV6lSJT788MNsn3+WY/Sz20eVSsWMGTNMelXSVayY8w9bVhcuXGDYsGGUKVOGYcOG4eXlhY2NDSqVis8//9yoh8TV1ZXly5cTFBTE8ePHCQoK4scff2T+/PlMnz49x7yHJ9GnTx9ee+01o7Jp06YBaT1Mmbm7u+e7nhIlSvDwofn5ztPvGfFv8etNhQ1X0wIIAHd7GNVQk+u0lflRzE7Fxp42JOsUtGpQ55AkKoqGCq1KUqFVSXRJqXnOaShR143UpLTvi7h7Cfw2+CivLmxO6RYFfwIXffA+iXtvY6MokALRP18haUQNbMo45r5yPriPrEeJ4XVJjUtB42CVY6JzOo27PSXnvcrthj+hD40n4ddgQn77Cc9NXXDobH6WJm0lN9wP9ku7SZ1N3j6PVn7lcf17NEpiClhpQK+gssp7kK4q5YztjvfTbmZnpUaVzW+LYflybhD7z8WmSw+gojua+9+j9shmVsLrD8B3HIT/MyzMSgMz+sBLVfLWwDZ14NLMtHwH2zwkSFfwgAOT0pa3sTKZxlaIokCCiAIWHBxsUnbz5k0grechv8qVK8eBAwcIDw/PsTeibNmyRERE0Lhx42xP0POrdOnSHD16lJiYGJOhRTdu3MDBwcGQvJyTsmXLcuTIETw8PLIdu58uvSfjypUreHtnf4Vu9+7dpKamMmPGDKPjnJCQYNQLkU6j0dCoUSPDLEpXr16lV69eLF68mOnTpwPk60Q0p3UqVKhAhQrGM8OkH0dfX1+L68pOzZo12bVrF6GhoUY9TqGhoTx8+BA/P78Cq6uwTTyqN0p2Do2DuWf1TGrx9HoIrLPOKSuKPEuSoi/+fJ2kiIyePH2KwpnZl59KEBHyVRCKLmOMfUpoAqFzL+L9deMCryudSq1Cm8PMSuZEzT2DPjTTEMtUhcdfHc02iDDUZWv5KYbK9p8shnx+hFU2easzddxW44LrD1HWnYIRbcyvMOPXjAACICUVvtkKrS3sqcpLAPEkywvxDElORAHbsGEDsbEZXzSxsbFs3LgRJycnGjZsmO/tpl/BnjFjhkneQeY5rf39/QkPD2flypVmt5M+TCg/WrVqhV6vZ9myZUblhw8f5vLly/j5+eUpcElPOp49ezapqak5trFNmzZYWVmxcOFCo+OaLn3f04eFZZ3fe8mSJSbHKzIy0mQ7Pj4+2NraEh0dbShLz7GIiorKdZ8yr5N5G4UhfTrh1atXG5WnP87aG/I8CzVzI2FzZULkVfxD05whc2UFISXUNPcp2UxZYUs186FKvf+cf9BCzXxP38/huz7UzHP3IwusOUI8j6QnooC5urrSt29fQ8L0tm3bCA0N5csvv3yi4Utt27alXbt27Nixg5CQEPz8/HBycuL27dscPXqUdevWAWn3Ajh+/DjTp0/n5MmTNG7cGAcHB0JDQzl58iTW1tbMnz8/X23o3Lkz27dv56effuLevXs0aNCAkJAQNmzYQPHixY1mWspJzZo1GTRoEAsWLODtt9+mbdu2uLu78+jRIy5evMjhw4c5duwYAKVKlWLMmDFMmTKFnj174u/vj6enJ2FhYRw4cICxY8dStWpVWrVqxapVqxg5ciRdu3bFysqK48ePc+3aNZPekUmTJhEWFoavry+enp4kJSWxd+9e4uLi8Pf3NyxXu3Zt1q1bx+TJk2nRogVarZZatWrl2KNUu3ZttmzZwty5cylfvjwqlQo/Pz+TWaMsdf/+fXbs2AFguEfIwYMHefDgAYDhuEBaovvLL7/MypUriY2NpXbt2pw7d44tW7bw2muvUa9evSdqS1HyZhUV004bB45vVpaeApF/Pu29uL4lxLjs1Se7z0t2ir/pw72p57OU5X436GfN4c3KRC/6y6TseaZ6sz7KqhOZClSoupqfthaANxvDuuNZymS6VfFikyCigA0fPpwzZ86wfv16Hj9+TLly5Zg0aRIdOnR44m1//fXX1K9fny1btrBw4UI0Gg1eXl5GSblarZZp06axYcMGdu7caQgY3N3dqVmzJp06dcp3/VqtllmzZhluNhcYGIiTkxNt2rRh6NChFiVrDxo0iBo1arBmzRpWr15NQkICbm5uVKxYkY8++sho2YCAAMqUKcPy5ctZs2YNKSkpuLu707hxY8N9J+rVq8d3333HokWLmDdvHjY2NjRp0oQFCxYwcOBAo+117NiRbdu2sWPHDiIiInBwcKBChQpMmTKFNm0yurLbt2/P5cuX2bNnD/v27UOv1zNu3Lgcg4ihQ4cSFRXF+vXriYmJQVEUtm7d+sRBxN27d5k3b55RWWBgIIGBgYb9zzyTxeTJk1m8eDG7du1i586dlCxZksGDB9OvX78nakdR800LNfEpelZeVHC1gU+aqOlYQTpYRf75vFqaJp/V5vziq6TE6ajUpRwNRlZ/KnWV+7oxKbHJhC6/jN4OKo71xc3/6dyx+kk4vFaBEjPbEDH5OPrIJJzerk7xyc/3sEjN7LdJBZRfgsDDGc2E11E3ySGA69EUgh/C1N2QkAz9XoYvuzyr5gpRJKmUbO/vLiyRfsfqefPmGd2tWAghhMhOSkoKS5cuBaB///5YWcnNC4V4llTjTe8Pkx1lfMHfTf55JpfshBBCCCGEEBaRIEIIIYQQQghhEQkihBBCCCGEEBaRxOoC0rlzZ8OMTEIIIYQQ4jkgN/LLN+mJEEIIIYQQQlhEggghhBBCCCGERSSIEEIIIYQQQlhEggghhBBCCCGERSSIEEIIIYQQQlhEZmcSQgghhBAvJpmcKd+kJ0IIIYQQQghhEQkihBBCCCGEEBaRIEIIIYQQQghhEcmJEEIIIYQQLyhJisgv6YkQQgghhBBCWESCCCGEEEIIIYRFZDiTEEIIIYR4MclopnyTngghhBBCCCGERSSIEEIIIYQQQlhEggghhBBCCCGERSSIEEIIIYQQQlhEggghhBBCCCGERWR2JiGEeI4cvquw4KweBRhUR02LMnmbWkSnV1hwVuG32wpVisGHDdWUcshY91G8wrQTqfz9SKGVt5ohDdRYacxv+9erqfx0JhV7KxjaREsDL9PrUSmpCnOPJbP/eio1SqkZ1cKaEg6myyWmKCw8lMjxmzpqemkY0tIWV3vj5YLvpbDp91gu30pBq1FRp7INAW0dcHPR5Gnfs3PqQCTnTsbgUkxLy07FKV7K+om29yKL2XiFmHVXULvZUmxEfWyqFzd6PvVeDDFTj5N6IxKb9hVweK8+KvWTTYuj23sZ3bITYGuF1dCX0DQs+0TbU+48hqm7IfghdKwLA1qiUmVpY4oOpmyC5ftBrYIBbWDM66Ax8168cBtm7oTIOHjrZXijyRO1T4iiRqUoilLYjRBCCJG7wNt62q3Xk/rPt7ZaBb8GqGnrnXun8sBfU1l0LuPrvpIrnOunwVarIiVVoe6iFC4+yli+Vy01P79hep1p3XkdPdalGB7baOHoQBvqexq3odeaBFYGZSxXo6SaM6McTAKTtxdFs/NcxnJ1y2gIHOOC+p8TzLthOgZ//ZD4ROOfKs8SGhaNc8fWOn8d6r+uD2PXmoeGx47OGj6ZWgkn12d7bS0lJYWlS5cC0L9/f6ysrJ5p/QUhYlYQYcMDDY/VztZ4n+mNdXkXAPQxSTyoNZ/U29GGZRxHNMZ1evt816nbcIbE//yUUWCtwe7wCDSNyuVre0pUPNT8FO5GZBR+1BHV928ZL9jzB1h72Ljs3Taw6APjsiv3oMFHEJeYUbZgCAxsl6/2iadHNSkpz8sqX9o8xZY8f2Q4kxBCPCdm/KkYAggAvZJWlpvIRIVlF4yXuxYJ266nle2+rhgFEACrLugJizPd9rSjqUaPk3Qw54TOqOxBjJ7VZ1KMyv4O0/PrFePlgh+lGgUQAGfvpHLkRsZyO/+INwkgAO4/SuXImUST8rw6sP2x0ePY6FROHYzM9/ZeZBFT/zR6rI9OJmrxecPjhF8uGQUQALHz/0Qfb/zaWyJ52sEsBamkzD2S7+2x7rhxAAEw5zeU5Ezv2QeRsM5MHcsCISrOuGzhXuMAAmDa9vy3T4giSIIIIYR4TiToTMsSzZRllaIHnT77dRN0pifpegWSUk2KSUgxXTZrG5J0aeubLJflnDHRTL1py2WUJ5upz1BPPs9BFUUhJdn0gKQkS8d8fihm3oSZy8w9T4oeUs28KfMq65sJICH/QYnZ7SWnGrcxKQXMDd7Q6yEly4clIdlM+8yUCfEckyCiCDp16hSNGjVi27ZthdaGy5cvM2TIEFq3bk2jRo2YP39+obVFCJGmfy3TMeT9zJRl5W6vwr+C8XJutvB6pbSyjpXUlHQwXqeNj4qyzqbb7t/AeLiPSgV96xmPBy9XTM0rFY3LSjmqeK2a8brVPLQ09DYuK1NMjV/ljCE9bX3tUJv5pXK0V/FSPVvTJ/JApVLRpLWrUZmVtYoGLVzytb0XnXO/msYFWjXOvaobHtp1rYbK2XgYiF23aqid8j80RNvPNL9A269xvrdHt8bgmOX91MMXlV2mPJly7vByDdN1O9SHEs7GZX1aYfLG7dc6/+0TogiSxGphQqfT8fHHH6PT6Rg8eDBOTk5Urly5sJv1zO3fv5/Lly/z/vvv53mdVatW4eTkROfOnQu0LefPn2fXrl1cvHiRq1evkpCQwLhx43Ks58GDByxatIgjR47w+PFjnJ2dqVq1KqNGjaJChQoF2j7xbPSopiZRB3PP6lEUGFxXzdvV83YtaKW/mrGH9fx2S6Gqm4oJzdW42KQFCY7WKvb3smLsAR1/P4LW3iq+amk+aXlEUy0qYFmQDnsrFaOaaWlb0XTZDb3s+XJPoiGxemI7GxysTYOSNQOdmLQjnmM3dNQureELf3ustRnLVfWx5usP3Fi1O4bb93WoVCqqV7Cif2dnnM0kaudV1/4eODhpOXciGhc3K14NKEEJD0mszo8SE5ujdrQmZu1lNMVtcfukMbb1Shqe15R0wD2wF9ETDqG7HoFth4o4j/d7ojqth70MKhW6pcfB1grrUX5oX62W7+2pvIqh/P4ZTNwEN/9JrB7/pumCmz+BIQtg15+gIi1ZetZA0+WaVIZtn8H3W/5JrG4BH72R7/YJURRJYnURpNfrSUlJQavVojE348NTduvWLbp168aoUaPo1avXM6+/qBg/fjzbt2/n1KlTeV6nc+fOeHp6smDBggJty/z581m8eDE+Pj44Ojry119/5RhEXLp0iQ8++AB7e3s6deqEh4cH0dHR/P333wQEBNCwYcMCbZ8QIn/+DYnVQjzPJLE6/6QnogiJi4vDwcEBtVqNjU3hvVHDw8MBcHEp2K59RVFISEjA3t6+QLf7PBs0aBBArkFHQEAAffr0wc7Ojt9++42//vor22WTkpL47LPPKFWqFAsWLMDR0bFA2ywKV2yywolQhUquKsqZGW5kTkyywsk8rHP0Tip/PYAmXhCVrMLLUUWV4sbLh0Tp+Ss0bZx4jZJqyhcz3xvwOF4h6F4qNUup8XDKucfgXmQqVx/oqVdOg4ud+WVDQnU8jk7FyUFNdKyeGhWssbZ6silCAUJuJKBLUfCubGeYEUpYLjEoDCVRh62vZ7ZTt6bejSblUjjWjTxRu2Q/FE0fmYDu9D20NdxRezpnu5ySkor+aDCqEg6oa3jk2D7l73soj2JRNauIysr8xTklJgFO3oBSLhAaBdW9UHkVM10wOQUOX4L7EVCjLNQrn33FySlw9Ap4uELV0jm2UYjnjQQRBWTbtm1MmDCB2bNnc+bMGbZt20Z4eDje3t7079+f9u2Np7JLv2I9evRoZs2axblz53BxcWHr1q2cOnWKwYMHm1xpVhSFzZs3s3nzZm7cuAGAl5cXrVu3ZvDgwYblkpOTWbFiBbt37+bOnTtYW1tTv3593n//fapVy7m7d9CgQfz5Z9pMGxMmTGDChAkAbN26FS8vLxISEli8eDF79+4lLCwMZ2dnfH19GTJkCJ6enobtZN6HhIQE1q9fz507d+jXr59heNCePXtYu3YtV69eJTU1lUqVKtG7d2/atm1r0q5Tp07x888/c/78eRISEnB3d6dhw4aMGDECV1dXANavX8/+/fu5ceMGERERuLi40KRJE4YMGYKXl5fR9v744w+WL1/O9evXSUxMxNXVlRo1ajBs2DC8vb2NjkOjRo0M6+V09T99ufv37xutk37snkTx4sVzX+gfe/fuJSQkhB9//BFHR0eSk9OS+aytZajG827nDT1vbdcTnZw2vev/NVYx2S/n3sq8rPMoXqHl8hT+Djddv1ctNT+9rkGtUvHlbyl8c1BHeve1CvjAV8NMf+P31oo/kxn0SyIJKaBVw7cdbPiopfkLI9//Gs/k3Qmk6sHBGua848gb9TKWTdUrTFkayb4TCUbrFXNW8/UHblT1yd/7OjEhlYXf3Ob63/EAeJSxYfBYb1yLS0+AJfQxydzptImEg3cBsK7uRpk93bAq42S0XPRXh4iecBBSFVQOVhT76XXsu1U32V7Smr+IefcXiE9789hPaof9J6ZDn/R/h5Lw2gKU22kzKmm61MZ2XV+TAEFJSUXXcyHKL0FpBWWLod05HHUt4xN6ZXsQvD0HYjLNqKTVoIzrgurLLhllZ2/CqxMhLCqjrHUt2PY5OGQJjP68Dp2+SQs2IO1eET+PMH9PCVF4st4LROSZBBEFbObMmSQkJBAQEACkBRdffPEFycnJJiefDx48YMiQIbRt25ZXXnmF+Pj4HLc9duxYdu3aRa1atRgwYABOTk4EBwezb98+QxCh0+kYPnw4f/31Fx07dqR79+7ExsayadMm3n33XRYuXEiNGmYSw/4xYMAA6taty9KlS+natSv169cHoFixYuh0OoYNG8bZs2dp06YNvXr14vbt22zcuJHjx4+zfPlySpUqZbS91atXExUVRZcuXShevLjh+Tlz5rBkyRKaN2/O4MGDUavVBAYG8umnn/Lxxx/TvXt3wzY2btzI5MmTKVmyJN26dcPT05PQ0FAOHTrEgwcPDEHEihUrqFWrFj169MDFxYXr16+zefNmTp48yZo1awzLnT59mtGjR1OxYkX69++Po6Mjjx494sSJE4SEhODt7c2AAQNQFIWgoCAmTpxoaEudOnWyPXYTJ07kxx9/xNXVlQEDBhjKixUzcyXrKTp8OG0OcycnJwYOHMiZM2dQFIUqVaowfPhwmjVr9kzbIwqGTq8waE9aMABpsx9NOaHwnyoKDT3M/wjq9AoDzazTvapCg1IZ63x7JNVsAAGw4ryerlXVVHJV+Pqg8Sw7CjDreCoBNVJpWT7txCg2SWHo5kTDRDk6PXyyK4n/1LHCO0uvxbWwVL7ZlWCY8CYuGUatjaN9TWts/+ll+CMo0SSAAIiI1jNjdRSzP3PP7pDl6OCOx4YAAiD0ThI7V4fx9jC5WmyJiBlBhgACIPniYx59eRjPZR0MZSmXHhE99oDhsRKXQuT7O7HrVBmVjTZTeTKxg7ekBRAAOj3xn+/B5j+10FRwM6o36cPNhgACIHXzOXQ/n8JqgK/RcvqVxzMCCICQCFJHrUP924cZ9aboYOBi4wACQJcKY39B6e6Lqso/F8lGLDYOIAACz8Oc3fB/XYzLhy3KCCAAVh+CLk2g+0sI8W8gQUQBi4yMZM2aNYYhJAEBAfTs2ZOpU6fSrl07bG0zrlTcvXuXL7/8ki5duuS63b1797Jr1y5ee+01JkyYgDrTrA96fcYUdGvXruX06dPMnDnT6GQxICCAHj16MG3atByHzjRt2hStVsvSpUupU6cOHTt2NDy3adMmzp49S+/evRk5cqSh3NfXl1GjRjFr1iy++uoro+2FhoayYcMG3NwyfgAuXbrEkiVL6N+/Px98kHGDnp49ezJmzBhmz56Nv78/Dg4OPHjwgP/973/4+PiwZMkSnJwyrm4NGTLEaN/XrFmDnZ2dUf1+fn4MHTqULVu20LdvXwAOHDiAXq9n9uzZRu167733jI7D7t27CQoKMjoGOenYsSNz587Fzc0tz+s8Dbdu3QLg448/platWnzzzTdERUWxdOlSRo4cycyZM/H19c1lK8/G48ePcXBwMAzfi42NRVEUw+ucnJxMTEyMUU/M/fv3jXq9sj4ODQ2lVKlShjvN/lvq+PtOJHdjja/uApx6kBZEmKsj6EYY92JNe7FOhqYFEel1nLyXc2rcyft6IuKyf/7UPb0hiPjjYhgxScafQ70CQfdS8S6mNjpWQbd1JjNmRsQrnLn+mKbV0tp9OTj7aTuv3Ep7Lj+vx7W/o0y2d/taRrDyrF7zEiVKGB6HhYXh5eX1XL13E0+GmhzH2KN3URTFUEfE/qsmy+jDE9DdiMSqeglDHS4hSShRWU7k9Qq603cJs0sy2g/diVtkDZ1Tjt00BBHp+2F3MtikbuXULeP9uPM4bfiSOYoCp4OhiiePHz+m2MlrJvUCcPKa6bE6ec1ksdj9Z3HMFET8W7+vnkYdouiRKV4LWEBAgNEYdEdHR7p160Z0dDSnT582WtbFxSXPs/js2rULgFGjRhkFEIDR4127duHj40P16tWJjIw0/Ol0Onx9fTl79iyJifm7QVNgYCBqtZr+/fsblbdo0YIqVapw8OBBo5N6AH9/f6MT9fQ2qlQq/P39jdoYGRmJn58fcXFxnDt3DoDffvuNlJQUBg4caBRAmNv39ABCr9cTGxtLZGQkVapUwdHRkfPnM258lP76/P777+h0eZhkv4DEx8eb7K9Op0On05mU59YrlVs9AD4+Pvz444+0a9eOgIAA5s6di0qlYs6cOQW1S0/Mzc3NKP/H0dHR6HW2trY2GcqV9Ucl62MPDw/DD9m/qY4aZVwpbSa9pfE/vRDm6qhfoaTZdZr8s056HU28cu7Ob+KppnHp7H8uMj/XonpJss7cqVFDA6+0ICPzsapfTmsyksDNQUW9ihnfGdXKZz+8qKqPldF+GLaRh9ejUg3TnK9ylTOCn8J4zUuWLPncvXdtm5jmIjg2L2NUR7HWVUyWUZewR1vB1agOTZUSqLLmSqhVaBuVNtkPra+PyTatmmXkJqTvh6qJab6CqrGP8X6UcQNPV5Pl0hZWQaO0bbi5uaFqks1MhY0rmR6rJpVMFnNsXc/o8b/1++pp1PHUqCz4E0akJ6KA+fj4mJSVL5/2BXT37l2j8tKlS+d59qWQkBBKlCiR69j4mzdvkpSUZDavIF1kZCQeHjknoZlz79493N3dcXY2TXSrWLEiV65cITIy0ihoKFeunNk2KopiGPJlTnpyd0hICABVq1bNtX0nT55k4cKFXLhwgaQk49kWYmJiDP/v3r07Bw4cYPLkycycOZO6devSvHlz2rdv/1SHHn333Xds327+jqVZX69OnToxfvz4fNWT/sXt7+9v9KVerlw56tatS1BQEAkJCSa9NqJo06pVLGqvpse2jPyGT5qojIYl5XWd+lnW+ay5hl+v6zn/yHQbfWqreaOqCrVKxX9bavn6oM5wIzkVMLypBj+fjO8xRxsV87ra8d7GBBJSwEoDkzvYUM5MAnalkhq+6GjH5F0J6P7JiZjWw8EwlAmgRT1b2jW1Y+8x4yFNbs5qRryV/8kfWvq7cfmvWK5f+CcnoqwNHXuWzGUtkVWxEfWJ23uLhP13ALCuUZwSk5obLWNVtTjOX7UkesIh0OlROVpTbEFHo6FMACp7axwXdCGm/8a0IU1WGuwntUVT3vhCFIDN1C4kvDYf5dY/ORFv1kHbq5HJcup3mqDf9hfKxn/uql22GJpp3Y2WUVlpURa9C2/NgehM7zOtBia8iapypt/LGe/CqxPgQaaei1dqwwevmR6c2YOg46SMIU3v+MGbRaMXWIiCIEFEIco8tKkgVapUiQ8//DDb55/lGP3s9lGlUjFjxgyTXpV0FStWtKieCxcuMGzYMMqUKcOwYcPw8vLCxsYGlUrF559/btRD4urqyvLlywkKCuL48eMEBQXx448/Mn/+fKZPn55j3sOT6NOnD6+9ZvxDM23aNCCthykzd/f8jfMGKFWqFNevXzcbcBYvXhxFUYiNjZUg4jnUobyau4NVhpmWzN0MLj/rFLdXce59a47fTeVcGDT2UhGVBJ6OKiq7ZSw/sY0VgxppOf8gFQWo7q7Gx0xw8HZ9K16rquXM/VSql8x5dqaPXrXnHV9broalUq+sBmfbrD2tKj7tX4x3OjoREZWKs4Oa6Dg91StYY6XN/6VBGzsNwyeW587NjNmZVJJgaTG1ozXlAruTeCbT7ExmjqPzly/jMKAeKZfDsW7oiTrLzefS2XSvjdWrldAF3Udb3R21h2kPNIC6einsr32B/tgtVMUdUFcvZXY5lVaD1Yb3US7eRwmPQ9W0PCqt6cU7Vcd6KHdnpM3O5OEKoZFQ1dN0dqY6PhCyEI5cgvuRUKNMWpk59cpD8Dw4dgU8ikGVJ5tgQ4iiRoKIAhYcHGxSdvPmTSCt5yG/ypUrx4EDBwgPD8+xN6Js2bJERETQuHHjbE/Q86t06dIcPXqUmJgYk6FFN27cwMHBwZC8nJOyZcty5MgRPDw8DL002Unvybhy5Qre3t7ZLrd7925SU1OZMWOG0XFOSEgw6oVIp9FoaNSokWEWpatXr9KrVy8WL17M9OnTAfJ1QpHTOhUqVDC5yVv6cSzIHIWaNWty5MgRHjx4YPJcWFgYGo3GbG+SeD44WqtoXc6y92Ze1/EtrcE3l6+pMi4qyrjk/tNRzF5F64p5+4nxdFHj6ZLz91XZUlrKlir4n6wy5SWYLgiZby6XHY2XExov80FBZmpXO6xb535DTJVWg6ZF3m6cqarumetoFJWjLbT+Z+KR6jmc8FtpoWWtPNWLtRX41cx9OSGeQ5ITUcA2bNhAbGys4XFsbCwbN27EycnpiW7wlX4Fe8aMGSZ5B5nvF+jv7094eDgrV640u530YUL50apVK/R6PcuWLTMqP3z4MJcvX8bPzy9PgUt60vHs2bNJTU3NsY1t2rTBysqKhQsXGh3XdOn7nj4sLOu9E5csWWJyvCIjI0224+Pjg62tLdHR0Yay9Cv1UVHZJNyZYWdnZ7SNwtC+fXs0Gg1btmwxyvm4cuUK586do1GjRoV6HxLx/Ft5VkfTBYk0nJvI3BPPJq8oOk7PtJWR9B8Xxri5jwm+l33CtSh6FJ2e6IkHCa09n4ev/Ezi3huF3SQhxBOSnogC5urqSt++fQ0J09u2bSM0NJQvv/zyiYYvtW3blnbt2rFjxw5CQkLw8/PDycmJ27dvc/ToUdatWwfAW2+9xfHjx5k+fTonT56kcePGODg4EBoaysmTJ7G2tmb+/Pn5akPnzp3Zvn07P/30E/fu3aNBgwaEhISwYcMGihcvbjTTUk5q1qzJoEGDWLBgAW+//TZt27bF3d2dR48ecfHiRQ4fPsyxY8eAtKE5Y8aMYcqUKfTs2RN/f388PT0JCwvjwIEDjB07lqpVq9KqVStWrVrFyJEj6dq1K1ZWVhw/fpxr166Z9I5MmjSJsLAwfH198fT0JCkpib179xIXF4e/v79hudq1a7Nu3TomT55MixYt0Gq11KpVK8cepdq1a7Nlyxbmzp1L+fLlUalU+Pn5PfHQofv377Njxw4Awz1CDh48aOhtSD8ukBYQ9enTh6VLlzJo0CBeffVVoqOjWbt2Lba2tiZDp4SwxNZLqfTamHECP3R7ClYaeK/h0/05mTj/MUGX0+aqvR2q4/z1ZFZMKomdrVwLex5EfR5I7PdHAdABSX+EUPLUu1jXMT8MSQhR9EkQUcCGDx/OmTNnWL9+PY8fP6ZcuXJMmjSJDh065L5yLr7++mvq16/Pli1bWLhwIRqNBi8vL6OkXK1Wy7Rp09iwYQM7d+40BAzu7u7UrFmTTp065bt+rVbLrFmzDDebCwwMxMnJiTZt2jB06FCLkrUHDRpEjRo1WLNmDatXryYhIQE3NzcqVqzIRx99ZLRsQEAAZcqUYfny5axZs4aUlBTc3d1p3Lix4b4T9erV47vvvmPRokXMmzcPGxsbmjRpwoIFCxg4cKDR9jp27Mi2bdvYsWMHERERODg4UKFCBaZMmUKbNm0My7Vv357Lly+zZ88e9u3bh16vZ9y4cTkGEUOHDiUqKor169cTExODoihs3br1iYOIu3fvMm/ePKOywMBAAgMDDfufeSaLDz74AE9PT9avX8+MGTOwsbGhUaNGDB482OJ8EyEyWxpk2vOwLCj1qQYRYY9TDQFEusgYPcfPJ9GqkQxHeh7ELztrXJCiJ37leQkihHiOqZSs4z9EvqTfsXrevHlGdysWQoh/k3c2JLPqL+NhiG0rqNnb7+kNkYuITqX7xw8Ms0Klm/SBG83qPJ0JKp6VlJQUli5dCkD//v2xsvp33jH7vs9MUm8ZDw11Hu+H8zjTu1EL8Sypvk3OfaF/KJ9ZP8WWPH+kH1gIIUSeDWuiwSrT5DYqFYxs9nQ7tYs5a2jja9zjUM5TS+OaktvzvHD80HjyCJWrLfb96xZSa4QQBUGGMwkhhMizZuU0/PGuDfNP6UhJhQENNLQqn7f73TyJj/q4Us3HmjOXk/D21PJmGwe0GpmS9XnhNLIJmtJOJKy/iNrdHscRjdGWy/99PoQQhU+CCCGEEBZpUkZNkzLPtltfq1HRpbUDXVo7PNN6RcGxD6iOfUD1wm6GEFnIxYj8kiCigHTu3NkwI5MQQgghhBD/ZpITIYQQQgghhLCIBBFCCCGEEEIIi8hwJiGEEEII8WKSlIh8k54IIYQQQgghhEUkiBBCCCGEEEJYRIIIIYQQQgghhEUkiBBCCCGEEEJYRIIIIYQQQgghhEVkdiYhhBBCCPFiktmZ8k16IoQQQgghhBAWkSBCCCGEEEIIYREJIoQQQgghhBAWkSBCCCGEEEIIYREJIoQQQgghhBAWkSBCCCGEEEIIYRGZ4lUIIYQQQryYZIrXfJOeCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRFJIgQQgghhBBCWESmeBVCCCGEEC8mlczxml/SEyGEEEIIIUQ+jR8/HkdHx8JuxjMnQYQQQgghhBDCIjKcSQghhBBCvJhkNFO+SU+EEEIIIYQQT8m5c+do3749Dg4OuLi4EBAQwO3btw3Pv/vuu7z88suGx48ePUKtVtO4cWNDWWxsLFZWVqxfv/6Ztj0nEkQIIYQQQgjxFISEhODn50d4eDgrVqxg3rx5/Pnnn7Rs2ZKYmBgA/Pz8OHnyJImJiQAcPHgQGxsbgoKCDMscOXIEnU6Hn59foe1LVjKcSQhRKBRFMXw5CvGiSklJISEhAYDo6GisrKwKuUVCFD1OTk6ontNZlKZOnUpKSgp79uzBzc0NgPr161OjRg2WLVvG8OHD8fPzIykpiePHj9OyZUsOHjxI165d2bNnD4cPH6ZDhw4cPHiQKlWqUKpUqULeowwSRAghCkVMTAwuLi6F3QwhioxRo0YVdhOEKJKioqJwdnZ+KttWPnq6p8KHDh3ilVdeMQQQANWqVaNu3br88ccfDB8+nPLly1OmTBkOHjxoCCIGDx5MQkICBw4cMAQRRakXAiSIEEIUEicnJ6Kiogq7GXkSGxuLv78/O3bseCGn8bOUHC/LyPGyjByvvPu3HCsnJ6fCbkK+RUREUK9ePZPyUqVK8fjxY8Pj9OAhOjqas2fP4ufnR1xcHBs2bCApKYkTJ04wcODAZ9jy3EkQIYQoFCqV6qldWSpoarUajUaDs7Pzc/1D/KzI8bKMHC/LyPHKOzlWhc/NzY2wsDCT8gcPHlClShXDYz8/P0aPHs3+/fspUaIE1apVIy4ujk8++YTAwECSkpKMkq+LAkmsFkIIIYQQ4ilo0aIF+/btIyIiwlB2+fJl/vrrL1q0aGEoS+95+PHHHw3DlurVq4ednR2TJ0+mbNmy+Pj4POvm50h6IoQQQgghhHgCqampbNiwwaR85MiRLF26lFdffZUvvviCxMREvvzyS8qVK0e/fv0My1WrVo2SJUty4MABZsyYAYBGo+Gll15i165dvPPOO89qV/JMggghhMiFtbU1AwcOxNraurCb8lyQ42UZOV6WkeOVd3Ksnp3ExET+85//mJT//PPPHDhwgI8++oh33nkHjUZDu3bt+PHHH01yPfz8/NiwYYNRAnXLli3ZtWtXkUuqBlApiqIUdiOEEEIIIYQQzw/JiRBCCCGEEEJYRIIIIYQQQgghhEUkiBBCCCGEEEJYRBKrhRDiCVy8eJG+fftiY2PDoUOHCrs5RUpqaiorVqzgjz/+4MaNGyiKQuXKlRk8eDD169cv7OYVuuDgYL777jv++usvHBwc6NixI0OHDsXKyqqwm1bk/Pbbb+zcuZNLly4RHR1NuXLl6NGjB6+//joqlaqwm1ekxcfHExAQQFhYGMuXL6dGjRqF3STxLyFBhBBC5JOiKHz33XcUK1aM+Pj4wm5OkZOUlMSyZcvo1KkTffv2Ra1Ws2nTJgYPHsysWbNo3LhxYTex0ERHRzN48GDKlSvH999/T1hYGFOnTiUxMZFPPvmksJtX5KxcuRJPT09GjRpFsWLFOH78OF9//TUPHjxg0KBBhd28Im3RokWkpqYWdjPEv5AEEUIIkU9bt24lMjKS119/nTVr1hR2c4ocGxsbtmzZYnRncl9fX3r06MGqVate6CBi48aNxMXF8f333+Pi4gKk9dxMmTKFAQMG4O7uXsgtLFqmTp2Kq6ur4XHjxo2Jiopi5cqVvPfee6jVMjrbnODgYNavX8+oUaP49ttvC7s54l9GPnVCCJEPMTExzJo1i9GjR6PVyvUYczQajVEAkV5WuXJlHj58WEitKhqOHDlCkyZNDAEEQLt27dDr9Rw7dqwQW1Y0ZQ4g0lWtWpW4uDgSEhKefYOeE9999x3dunXD29u7sJsi/oUkiBBCiHyYM2cO1atX5+WXXy7spjxXdDod586do3z58oXdlEIVHByMj4+PUZmTkxMlSpQgODi4UNr0vDlz5gwlS5bEwcGhsJtSJP32229cv36d9957r7CbIv6l5PKZEEJY6PLly2zdupWVK1cWdlOeO8uXL+fhw4e8/fbbhd2UQhUdHW1yt1pICySio6MLoUXPlzNnzrBnzx5GjRpV2E0pkhITE5k6dSpDhw7F0dGxsJsj/qUkiBBCvPBiY2N59OhRrsuVLl0arVbLlClTCAgIMLmS/CKw5FhlnWXo2LFjzJ8/n/fee4/q1as/rSaKf7kHDx7w2Wef0ahRI3r27FnYzSmSFi9eTPHixXn99dcLuyniX0yCCCHEC++3335j0qRJuS63YcMGLl++THBwMF9//TUxMTEAJCcnA2l5EtbW1tjY2DzV9hYmS45V5iDr0qVLfPLJJ3To0IGBAwc+xRY+H5ydnYmNjTUpj4mJMckjERliYmIYMWIELi4ufPfdd5JQbcb9+/dZsWIF33//veE9lp43Eh8fT3x8PPb29oXZRPEvoVIURSnsRgghxPNi/vz5LFy4MNvn+/bty/Dhw59hi4q+kJAQ3n33XapWrcrUqVMlER0YOHAgLi4u/O9//zOUxcbG0rp1a8aOHUvnzp0LsXVFU2JiIreQhkoAABiPSURBVB988AGhoaEsXbqUkiVLFnaTiqRTp04xePDgbJ+vVasWy5Yte3YNEv9a8k0uhBAW6Ny5Mw0bNjQq2759O3v37mX69Ol4eHgUUsuKpkePHjFs2DA8PDyYMmWKBBD/aN68OUuXLiUmJsaQG/Hbb7+hVqtp2rRpIbeu6NHpdHz22WcEBwezcOFCCSByULVqVebNm2dUduXKFX788Uc+++wzatasWUgtE/828m0uhBAW8PLywsvLy6js9OnTqNVqGjVqVEitKpoSExMZMWIEkZGRjBkzhuvXrxues7Kyolq1aoXYusLVrVs31q5dy5gxYxgwYABhYWFMnz6dN998U+4RYcaUKVM4dOgQo0aNIi4ujnPnzhmeq1q1KtbW1oXYuqLFyckp2++i6tWrv9CfO1GwJIgQQgjxVDx+/JgrV64AMHr0aKPnPD092bZtW2E0q0hwdnZm7ty5fP/994wZMwYHBwe6dOnC0KFDC7tpRVL6vTOmTZtm8tzWrVtNAnshxNMnORFCCCGEEEIIi8i0BkIIIYQQQgiLSBAhhBBCCCGEsIgEEUIIIYQQQgiLSBAhhBBCCCGEsIgEEUIIIYQQQgiLSBAhhBBCCCGEsIgEEUIIIYQQQgiLSBAhhBDCrH79+qFSqQq7GQCcP38erVbL3r17DWX79+9HpVKxbNmywmuYKBKWLVuGSqVi//79+Vpf3ktp/vzzTz788EM6dOhAo0aNWLp0KWq1mgMHDjyV+ubPn0+jRo2M/rp16/ZU6hIFT4IIIcQL5caNGwwaNIhq1aphb29PsWLFqF69On379iUwMNBoWR8fH2rVqpXtttJPsh89emT2+YsXL6JSqVCpVBw6dCjb7aQvk/5na2tL5cqVGT16NI8fP87fjv7LjB49mpdeeol27doVdlOeieDgYMaPH8+ZM2cKuyniGYmMjGT8+PH5DoTyK/N7LSEhgcqVK/PJJ58AUL58ebp06cKYMWN4WvcmrlChArt37zb8LV68+KnUIwqetrAbIIQQz8qpU6do2bIlVlZW9OnTh5o1a5KQkMDVq1fZs2cPTk5OtG7dusDqW7x4MU5OTtjZ2bFkyRJefvnlbJetV68eY8aMAeDx48fs3LmTqVOnsnfvXk6fPo21tXWBtet5c/ToUfbu3cvmzZuNyv38/EhISMDKyqpwGvYUBQcHM2HCBHx8fKhXr15hN0c8A5GRkUyYMAGAVq1aPbN6M7/X+vXrx0svvWT0/KhRo2jZsiU7d+6kXbt2zJkzh19//ZWYmBgqVqzI8OHDadSoUb7r12q1lChR4kl3QxQCCSKEEC+MCRMmEB8fz5kzZ6hbt67J86GhoQVWV0pKCj///DP/+c9/cHFxYcGCBcyYMQMnJyezy5cuXZpevXoZHo8YMYLOnTuzfft2tmzZwn/+858Ca9vzZs6cOZQoUYKOHTsalavVamxtbQupVUK8GF5++WV8fHyYN28eQUFB3Lhxg2+++QZ3d3cCAwMZMWIEa9asoVy5cvna/u3bt+nQoQM2NjbUrl2bYcOG4eHhUcB7IZ4GGc4khHhhXL16leLFi5sNIIAC/eHatm0bYWFh9O3bl379+hEXF8fatWst2kb79u0BuHbtWrbLzJ07F5VKxdatW02e0+v1lClTxuhK9p49e+jRowcVKlTAzs4OV1dXXn311TyPeW7VqhU+Pj4m5cHBwahUKsaPH29UrigKc+fOpWHDhtjb2+Po6Ejr1q1Nho5lR6fTsXnzZtq2bWvS42BuHHvmsjlz5lC1alVsbW2pXbs227dvB+DcuXN06NABZ2dnihcvzogRI0hJSTG7nzdu3OCNN97AxcUFZ2dnunbtyo0bN4yW1ev1fP311/j5+eHh4YG1tTXlypVjyJAhhIeHm92vjRs30qpVK1xdXbG3t6dq1aqMGDGC5ORkli1bZugR69+/v2GYW16uTgcHB9O7d29KlSqFjY0NFStW5PPPPyc+Pt5oufHjx6NSqbh8+TKff/45ZcqUwcbGhrp167Jz585c64GMPIR9+/YxceJEvL29sbOzw9fXl2PHjgFw4MABWrRogYODA56ennz11Vdmt7V582ZeeuklHBwccHR05KWXXmLLli1ml124cCHVqlXDxsaGSpUqMW3atGyH2kRFRfHJJ59QqVIlbGxscHd356233jJ5DS2V1+OcU16RSqWiX79+QNr7tnz58kDaxY701zz9s5b587V69Wrq1KmDra0t5cqVY/z48eh0OqNt5/Vzmpf3mkqlon379uzbt4+tW7cyZcoU6tevT5kyZejduzf16tVj27ZtFh7BNLVq1WL8+PHMnDmTTz/9lHv37vHee+8RFxeXr+2JZ0t6IoQQL4yKFSty+fJlfvnlF9588808rZOampptzkNSUlK26y1evJjy5cvz8ssvo1KpqF+/PkuWLOG9997Lc3uvXr0KkGNXf8+ePfnwww9Zvnw5r7/+utFz+/bt4+7du4ZhUpB20vD48WP69OlDmTJluHv3LosWLaJNmzYEBgbmOOQqP3r37s3q1asJCAigf//+JCUlsXLlStq1a8cvv/xi0uasTp8+TWxsLE2aNLGo3tmzZxMREcF7772Hra0tM2bMoGvXrqxfv56BAwfy1ltv0aVLF/bs2cPMmTMpWbIkX375pdE24uLiaNWqFb6+vnz77bdcvXqVOXPmcOzYMYKCggxBZ3JyMt9//z3dunXjjTfewMHBgZMnT7J48WL++OMPk+FoX3zxBd988w01atTgww8/xNPTk+vXr7Nx40YmTpyIn58fn3/+Od988w2DBg0yvCalSpXKcZ9v3bpFkyZNiIqKYujQoVSuXJn9+/fz7bffcvjwYfbt24dWa/yz37dvX6ysrPjoo49ITk5m2rRpdOnShStXrpg9CTXn008/JTU1lZEjR5KcnMwPP/zAq6++yvLly3n33XcZNGgQ77zzDuvWrWPs2LGUL1/eqNdtzpw5fPDBB1SrVo2xY8cCae/TLl26MH/+fAYNGmRYdtq0aXz44YfUrVuXb775hvj4eP73v/9RsmRJk3ZFRUXRvHlzbt++zYABA6hZsyb3799nzpw5+Pr6curUKby9vfO0j096nHNTvXp1pk6dyocffkjXrl0N30+Ojo5Gy23dupUbN27wwQcf4OHhwdatW5kwYQK3bt1i6dKlFu9LTu+1zz77zLBcs2bNWL16NXq93uS7Mzk5GRcXFyAtSAkICMixzr59+zJ8+HAAo6FTlStXplatWnTq1Im9e/fSpUsXi/dHPGOKEEK8II4cOaJYWVkpgFK5cmWlf//+ypw5c5S///7b7PLe3t4KkOvfw4cPjda7e/euotFolHHjxhnKpk2bpgBm6wKUV199VXn48KHy8OFD5cqVK8qPP/6oWFlZKS4uLsqDBw9y3K+AgADFxsZGefz4sVF5r169FK1Wa7R+bGysyfqhoaFK8eLFlddee82ovG/fvkrWn4mWLVsq3t7eJtu4efOmAhjt8y+//KIAyvz5842WTUlJURo2bKj4+Pgoer0+x31bsmSJAihbtmwxeS4wMFABlKVLl5qUeXl5KZGRkYbys2fPKoCiUqmUjRs3Gm2nQYMGioeHh8l+AsrIkSONytP36f333zeU6fV6JT4+3qR9ixYtUgBl7dq1hrLjx48rgNK6dWslISHBaHm9Xm84Hub2LTdvv/22Aig7duwwKv/oo48UQFm0aJGhbNy4cQqg+Pv7G70GJ06cUADl008/zbW+pUuXKoBSv359JSkpyVC+ZcsWBVC0Wq1y8uRJQ3lSUpLi4eGhNG3a1FD2+PFjxcHBQalYsaISFRVlKI+KilIqVKigODo6KhEREYqiKEpERIRib2+vVK9eXYmLizMsGxISojg4OCiAEhgYaCgfMWKEYmtrq5w5c8ao3cHBwYqTk5PSt29fQ5klx9uS42zuM5QOMGqDuc9Q1ufUarVy+vRpQ7ler1e6dOmiAMrRo0cN5ZZ8TrPb94YNGxqO56FDh5RixYopjRo1Um7evKncvn3b6C/9OzA5OVm5efNmjn9Zv6ey6t27tzJz5swclxFFgwxnEkK8MJo1a8bp06fp27cvUVFRLF26lKFDh1KjRg38/PzMDnHw8fFh7969Zv9effVVs/UsW7YMvV5Pnz59DGXvvPMOVlZWLFmyxOw6e/bswd3dHXd3d6pUqcLo0aOpUaMGe/bsMXuVNbO+ffuSlJRkNFwqNjaWTZs20aFDB6P1HRwcjJYJDw9Ho9Hg6+vL8ePHc6zHUitWrMDJyYkuXbrw6NEjw19kZCSdO3cmODjY0NuSnYcPHwLg5uZmUd39+vUzXB0FqFOnDs7Oznh5eZlcSW3RogWhoaHExsaabOfTTz81ety1a1eqVq1qlOStUqmws7MD0nquIiMjefToEa+88gqA0XFduXIlAN9++61JPkf6UJL80Ov1bN26lfr165vkjnz22Weo1Wo2bdpkst7IkSON6mzcuDGOjo65vi6ZDRkyxKinJf1qtq+vr1HCrbW1NU2aNDHa9t69e4mLi2PEiBE4Ozsbyp2dnRkxYgSxsbH89ttvQNpnJD4+ng8++AB7e3vDsmXKlOGdd94xapOiKKxcuRI/Pz9Kly5t9P5zcHCgadOm7NmzJ8/7mC6/x7mgtGvXjgYNGhgeq1QqPv74Y4CnWm/x4sWJj49HURQiIiIoW7as0V96b6mVlRU+Pj45/hUrVizbeuLj47lz544kWj8nZDiTEOKFUrt2bcMY+lu3bnHgwAEWLVrEoUOHeOONN0yGnjg4ONC2bVuz21qxYoVJmaIoLFmyhDp16qDX643yGV566SV+/vlnvv32W5PhDr6+vkyaNAkAGxsbvL2985yomB4oLF++nMGDBwNpY+7j4uKMAhmA69ev88UXX/Drr78SGRlp9FxB3xPi4sWLxMTE5DgM58GDB1SpUiXb59PbpFg4vWSFChVMyooVK0bZsmXNlgOEh4cbDR9xdXU1mydTvXp1Nm/eTFxcnCEoW7duHT/88ANBQUEm+RURERGG/1+9ehWVSpVtXk5+PXz4kNjYWGrWrGnynJubG56enmaDZHPHqXjx4tnmcpiTdRvpxzN9jH/W5zJv++bNmwBm251elt7u9H+rVatmsmyNGjWMHj98+JDw8HBDcG6OWm35ddT8HueCUr16dZOy9H0viHrj4+MJCQkxPL579y6XL1/m4cOHJCUl4eHhwbhx4xg1ahRVq1YlIiKCkydPUrlyZVq0aGFxfdOmTePll1/G09OThw8fMn/+fNRqtSEfTBRtEkQIIV5Y3t7e9OnTh969e/Pyyy9z+PBhTpw4ka8fw3QHDhzg+vXrQNoYX3O2b99uMt63RIkS2QYrudFqtbz99ttMmzaNa9euUalSJZYvX06xYsWMcg5iY2Px8/MjLi6OUaNGUbt2bZycnFCr1Xz77bf8/vvvudaVXaCRNbET0k783d3dWbVqVbbby+k+HIDhBNDS+2VoNBqLysHyQCXdL7/8Qo8ePWjSpAnTp0+nbNmy2NrakpqaSocOHdDr9UbLP0mPQ0HL7nhYcizyc6yftvT2t23b1nDPg8JgyeelKNT7999/Gy5EAEydOhVI66ECaNmyJc7OzkybNo2wsDBcXV2pXbt2vnOpHjx4wBdffEFUVBTFihWjbt26LFu2LMfeClF0SBAhhHjhqVQqfH19OXz4MHfv3n2ibS1ZsgQbGxuWL19u9krn+++/z+LFiws8abBv375MmzaN5cuXM3DgQPbv38+gQYOwsbExLLNv3z7u3bvHkiVL6N+/v9H6WZOKs+Pm5sbp06dNys1dBa1cuTJXrlyhadOmJgmieZUeZFgyvKagREZGEhoaatIbcfHiRUqWLGnohfj555+xtbUlMDDQaJjNpUuXTLZZpUoVdu3axdmzZ3NMFrc0yHB3d8fJyYkLFy6YPBcREcH9+/eL5P0m0nsxLly4QJs2bYye+/vvv42WSf/30qVL2S6bzt3dHVdXV6Kjo/MdnJtj6XFOH4b3+PFjoyF55j4veXnNL168aFKW9Til15vXz2nmehs1asSpU6dMllm2bBnz5s2jTp06tG/fnvfffz/XtubFt99+WyDbEYVDciKEEC+MvXv3mr0Sl5CQYBgfnXVYhCWioqLYsGEDr776Kt27dycgIMDk7/XXX2fXrl3cv38/3/WYU69ePerUqcOKFSv4+eef0ev19O3b12iZ9CvDWa8y79mzJ8/5EFWqVCEmJoYTJ04YyvR6veGKZWZ9+vRBr9cbzfKS2YMHD3Ktr379+jg7OxumDH3WJk+ebPR406ZNXL582SgI1Gg0qFQqox4HRVEMw9Mye/vttwH4/PPPSU5ONnk+/bVJD7ry2gOjVqvp3LkzQUFB7N6922Qf9Ho9Xbt2zdO2nqV27drh4ODAzJkziYmJMZTHxMQwc+ZMHB0dDXcpb9euHXZ2dsyePdtoKtU7d+6Y9Hap1WreeecdTpw4wYYNG8zWHRYWZnF7LT3O6UP10vM60v3www8m287La753717+/PNPw2NFUfjuu+8AjN6TlnxO81LvsWPH0Gq1JjeiEy826YkQQrwwPvzwQ8LDw3n99depXbs29vb2hISEsGrVKq5cuUKfPn2oXbt2vre/evVqEhIS6NatW7bLdOvWjWXLlvHTTz+ZJO0+qb59+zJmzBimTJlClSpVaNq0qdHzLVq0wMPDgzFjxhAcHEyZMmU4c+YMP//8M7Vr1+bcuXO51jFo0CB++OEHunbtysiRI7G2tmbDhg1mg7P0aV1nzZrFn3/+SadOnShRogR37tzh6NGjXLt2Lddx3BqNhjfffJPNmzeTlJRk1LPytJUoUYJffvmFe/fu0apVK8MUr6VKlTK6H0ZAQAAbN27klVdeoU+fPqSkpLB582aTewYANGnShE8++YQpU6bQoEEDevTogYeHBzdv3mTDhg2cOHECV1dXatSogZOTE3PmzMHe3h5XV1dKlixpSNY255tvvjFMjTl06FAqVarEwYMHWbt2LX5+fiZBZVHg6urKd999xwcffICvr6/hvgnLli3j2rVrzJ8/35AgX6xYMb766is++ugjmjdvTp8+fYiPj2fevHlUrlyZoKAgo21//fXXHD58mO7du9O9e3eaNm2KtbU1t27dYufOnTRs2NDoHiN5Zclxfuutt/j8888ZNGgQly5dws3Njd27d5udNrp48eJUqlSJNWvWULFiRUqVKoWDgwOdO3c2LFO3bl1eeeUVPvjgAzw9PdmyZQu//fYbvXv3plmzZoblLPmc5vZeUxSF3bt306FDh3z3KIp/qUKZE0oIIQrBr7/+qgwdOlSpU6eOUrx4cUWj0Shubm5Kq1atlMWLFyupqalGy3t7eys1a9bMdnvp0zemT2/YqFEjRavV5jiFYWJiouLk5KRUqVLFUMY/U20+qdDQUEWr1SqAMmnSJLPLnD17Vmnfvr3i6uqqODo6Ki1btlQOHjxodirK7Kan3LFjh1K3bl3F2tpa8fT0VD7++GPl0qVL2U5PuXz5cqVFixaKk5OTYmNjo3h7eytdu3ZV1qxZk6f9Sp8WdcOGDUblOU3xam6qTm9vb6Vly5Ym5enTnd68edNQlj5F5vXr15XXX39dcXJyUhwdHZXXX39duXr1qsk2FixYoFSvXl2xsbFRPDw8lIEDByrh4eEm03imW7VqldK8eXPF0dFRsbe3V6pWraqMHDnSaKrUHTt2KPXr11dsbGwUwGzbs7px44bSq1cvxd3dXbGyslLKly+vfPbZZ0ZToma3z7kdp6zSp3jNPK1quuz2O7v31C+//KI0a9ZMsbe3V+zt7ZVmzZopmzZtMlvvvHnzlCpVqijW1tZKxYoVlalTpxqmAs7alri4OGXixIlKrVq1FFtbW8XR0VGpVq2a8t577ynHjh0zLGfplLp5Pc6KoijHjh1TmjdvrtjY2CjFixdXBg4cqERERJg9RsePH1eaN2+u2NvbK4BhmtbMU7OuWrVKqV27tmJtba2UKVNG+e9//6skJyeb1GvJ5zSn99r+/fsVQNm+fXuejo14cagUJZ+ZZEIIIcQz0qFDB+Li4jh06NAzqa9Vq1YEBwcTHBz8TOoTIifBwcGUL1+ecePGmdwV/mnr2rUrISEhnDx5sshMCCCKBsmJEEIIUeT98MMPHD16NF9z+wsh8icoKIgtW7bwww8/SAAhTEhOhBBCiCKvZs2aT31aTCGEsfr165tMUSxEOumJEEIIIYQQQlhEciKEEEIIIYQQFpGeCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRFJIgQQgghhBBCWESCCCGEEEIIIYRF/h9yEsf8lQ+DTQAAAABJRU5ErkJggg==",
+      "text/plain": [
+       "<Figure size 800x950 with 2 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAOsCAYAAADX7yC0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOz9e1xVZf7//z82hzwAgjKkmAoeUt+mluWhd2OkHywLok8mKvk1GzARlEknDzPvPn48je/PmFO+xUA8BCqWJzwhKIxWgGV5SlNxDDyGAkKmkOjGYcP+/eGPPW43krAxnel5v9283eJa17rWa117dbut17rWdS2D2Ww2IyIiIiIiYgeH+x2AiIiIiIj861NiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISK1WrZsGRUVFfc7DBEREXnAKbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7Gcxms/l+ByEiDy7D+6b7HYKIiIjcgXmK0/0OwUIjFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYrcHOrGYNWsWvXv3vqu6BQUF9O7dm6VLl97jqG6qS2zh4eEEBQXd44hqV9f+ycnJITIykoEDB/6i/SoiIiIi/5oenC9qyAPDZDIxbdo0TCYTERERuLm58eijj97vsH5xmZmZ5OTkMG7cuLveZ82aNbi5uTV4IpmdnU1aWhonTpzg5MmTGI1GZs6cWetxioqK+Oijj/jqq6+4fPkyzZo1o0uXLkyaNIkOHTo0aHwiIiIiD3RiMX36dP7rv/7rfofxq5Ofn09+fj6TJk1ixIgR9zuc+yYzM5PU1NQ6JRZr167F29u7wROLPXv2kJSUhK+vL48++ihHjx6ttf53333HhAkTaNq0Ka+88gqtWrXip59+4u9//ztXrlxp0NhEREREoAESi8rKSioqKmjcuHFDxGPFyckJJ6cHOvf5t/Tjjz8C4O7u3qDtms1mjEYjTZs2bdB2/5WFh4cDsGzZslrrBQcHM3r0aJo0acKnn35aa2Jx48YN/uu//ouWLVuybNkyXF1dGzRmERERkZrU6a49JSWF2bNnExsby7Fjx0hJSeHixYtMnz6doKAgzGYzmzZtYuvWrZw9exYHBwe6devG2LFjbeYjpKamsmHDBvLy8jCZTHh6etKjRw8mT55M8+bNgZvzGFJTUzl48KDVvt9++y2LFi0iJycHFxcX/P39GTp06B3jXbJkic3xw8PDKSwsJCUlxVK2d+9ekpOT+fvf/86lS5dwdnbmscceIywsjKeeeqouXXVXDh06xEcffcTx48cxmUz4+voybNgwXn31Vat62dnZbNy4kaNHj1JUVISjoyOdOnXijTfeYODAgTbt3m3/1CQ8PJxDhw4BMHv2bGbPng3Atm3baN26NUajkfj4eHbt2kVxcTHNmjWjX79+REZG4u3tbWnn4MGDREREMHPmTIxGI0lJSVy4cIHf/e53lhGAnTt3sn79ek6ePEllZaXlnAYNGmQT18GDB1m9ejXZ2dkYjUa8vLx46qmnePvtt/Hw8AAgKSmJzMxMzpw5w5UrV3B3d6dv375ERkbSunVrq/a+/PJLEhMTOX36NOXl5Xh4eNCtWzeioqLw8fGx6odbr53aXj+qrldYWGi1T3Xf2cPT0/Ou6+7atYvz58+zYMECXF1d+cc//gHAQw89ZFcMIiIiIrWp13BAdHQ0JpOJIUOG4OLigo+PDwAzZszgb3/7G/7+/gQFBVFRUUFaWhoTJkxg/vz5PPfccwBs376dWbNm0atXLyIiImjUqBFFRUXs2bOHy5cvWxKLmmRnZzN+/HiaNm3K6NGjcXNzY+fOncycObM+p2IlJSWF0tJSAgICaNmyJcXFxSQnJzN+/HiWLFlCr1697D5Gtd27dzN16lQ8PT0ZNWoUTZs2ZefOncydO5f8/HwmTJhgqZuZmcm5c+cYNGgQ3t7elJaWkpqaytSpU5k7dy4vvviipa69/RMWFsbjjz/OihUrGDJkiOWcmzdvjslkIioqiiNHjuDv78+oUaPIy8tj06ZN7Nu3j8TERFq2bGnV3tq1ayktLeXVV1/F09PTsn3x4sUkJCTwzDPPEBERgYODAxkZGfzpT39i2rRpDB8+3NLGpk2bmDdvHg8//DBDhw7F29ubixcv8sUXX1BUVGRJLD7++GO6d+/OiBEjcHd35/Tp02zdupUDBw6wbt06S71vvvmGd955h44dOxIaGoqrqyuXLl1i//79nD9/Hh8fH8LCwjCbzRw+fJg5c+ZYYunZs+cd+27OnDksWLAADw8PwsLCLOW1Xc/3wp49ewBwc3Nj7NixfPvtt5jNZjp37szvf/97/vM///MXjUdERER+HeqVWJSXl7NmzRqr158yMjJIS0vj3Xff5bXXXrOUh4SEEBoaygcffICfnx8Gg4HMzExcXFyIi4uzetUpIiLiZ4+9YMECqqqqiI+PtyQ0w4YNY8yYMfU5FSvTp0+nSZMmVmVDhw5l+PDhrFixosESi8rKSubPn0+TJk1YtWoVXl5eAAwfPpxx48axatUqgoKCaNeuHQBjxowhKirKqo2QkBBGjhxJfHy8VWJhb/88/fTTODk5sWLFCnr27ElAQIBl25YtWzhy5AhvvPEGEydOtJT369ePSZMmERMTw5///Ger9i5evMjGjRtp0aKFpey7774jISGB0NBQqwQqJCSEyZMnExsbS2BgIC4uLhQVFfH+++/j6+tLQkICbm5ulvqRkZFUVVVZ/l63bp3N7+fn58f48eNJTk7mzTffBCArK4uqqipiY2Ot4nrrrbes+iE9PZ3Dhw9b9UFtAgICiIuLo0WLFne9z73w/fffAzBt2jS6d+/O//t//4/S0lJWrFjBxIkT+fDDD+nXr999i09ERET+PdVrudng4GCbORU7duzAxcWFAQMGUFJSYvlXVlbGs88+S0FBAXl5eQC4urpSXl7Ol19+idlsvuvjXr58maNHj/Lcc89ZbpoBnJ2dGTlyZH1OxcqtN6XXr1+npKQER0dHunfvzvHjx+1uv9qJEye4ePEir7zyiiWpgJvnMXr0aKqqqsjKyqoxrvLyckpKSigvL6dPnz6cPXuWsrIy4N73T0ZGBg4ODoSGhlqV9+/fn86dO7N7926rG32AwMBAq5t3gLS0NAwGA4GBgVbXSklJCX5+fly7do1jx44B8Omnn1JRUcHYsWOtkopqDg7/vISr+6mqqoqysjJKSkro3Lkzrq6uZGdnW+pVzzn4/PPPMZlMdvRI3VRfU7f+M5lMmEwmm/Lr16/bdRwAX19fFixYwPPPP09wcDBxcXEYDAYWL17cUKckIiIiYlGvEYvqJ+m3OnfuHNeuXeOFF164436XL1/Gx8eH0NBQDh06xJQpU3B3d+fJJ5/kt7/9Lc8//zwuLi533D8/Px+4ecN0u4ZYPvPChQvExsayd+9erl69arXNYDDY3X61goICoOaYO3bsCPzzXOFmv8XFxZGVlcXly5dt9ikrK8PV1fWe909BQQFeXl40a9asxrhzc3MpKSmxSiRqulbOnj2L2WwmODj4jseqnkB+/vx5ALp06fKz8R04cIDly5dz/Phxbty4YbXt1t9z+PDhZGVlMW/ePD788EMef/xxnnnmGQYPHnxPX1uaP38+qampNW67fV7Jyy+/zKxZs+p1nEaNGgE3k7pbr9t27drx+OOPc/jwYYxGo83ojoiIiIg96pVY1LQClNlspnnz5sydO/eO+1XfNLdr146kpCT279/PgQMHOHToEHPnzmXp0qUsX76cNm3a1CcsG7UlA5WVlVZ/X79+nbFjx2I0Gnn99dfp1KkTLi4uGAwGVq5cyYEDBxokproym81ERUVx9uxZQkJC6NatG66urjg4OJCSkkJ6errNKMGD5E6rhRkMBhYtWmQ14nCr6mvlbh0/fpyoqCjatGlDVFQUrVu3plGjRhgMBt59912rPvLw8CAxMZHDhw+zb98+Dh8+zIIFC1i6dCnR0dG1zqOwx+jRo3nppZesyhYuXAjApEmTrMpvHcmqq5YtW3L69OkaJ3x7enpiNpspKytTYiEiIiINqsHWcm3bti15eXn06NHjrpYTfeihh+jfvz/9+/cHbq7SM2nSJD755BP++Mc/1rhP9co6586ds9l25swZm7LqJ+s//fSTzbaCggKr+R379+/nhx9+YMaMGbzyyitWdePi4n72fOrikUceAWqOubqsus7JkyfJzc1l7NixNt9T2Lp1q9Xfde2funrkkUf4+uuvuXr1qs1rSWfOnMHFxcUyQbo2bdu25auvvqJVq1a0b9++1rrVIx65ublWr3fdLj09ncrKShYtWmTpOwCj0Wgz+gTg6OhI7969Las3nTx5klGjRhEfH090dDRQv1Gq2vbp0KGDzchRdT825JyHxx57jK+++oqioiKbbcXFxTg6OtY46iQiIiJij3rNsahJYGAgVVVVxMTE1Li9+tUWgJKSEpvtXbt2BaC0tPSOx6hekjYrK8syQRWgoqKCNWvW2NSvvindv3+/VXl6ejo//PCDVZmjoyOAzZyPvXv3Wr2f3xC6du1Kq1atSElJ4dKlS5Zyk8nE6tWrMRgMlhW0qp/o3x7XqVOnyMzMtCqra//U1YABA6iqqmLlypVW5Xv27CEnJwc/P787jkDcqnpic2xsrM3IEVhfK/7+/jg7O7N8+XLLXJJbVffLnX6/hIQEmxGdmq4/X19fGjdubJWEVj/Rr+2avF2TJk1qTGR/SYMHD8bR0ZHk5GSrOSS5ubkcO3aM3r17W16XEhEREWkoDTZiMWjQIIKCgtiwYQPfffcdzz77LB4eHhQXF3P06FEuXLhAcnIyABMmTMDNzY1evXrRsmVLrl69SkpKCgaD4WdX0/nDH/7AuHHjGDNmDMOGDbMsp1rTDaqvry99+/Zl8+bNluU2c3NzyczMpG3btlY3XU888QSenp4sXLiQwsJCHn74YXJzc9mxYwedOnXi1KlTDdVVODo6Mm3aNKZOncqbb77JkCFDaNq0Kbt27eLYsWOEhoZakqL27dvToUMHEhMTKS8vx8fHh7y8PDZv3kynTp04ceJEvfunroKCgkhNTWXVqlUUFBTw5JNPcv78eTZu3Iinp6fVCk+1eeyxxwgPD2fZsmWMHDmSQYMG4eXlxaVLlzhx4gR79uxh7969wM3XeiZPnsx7771HSEgIgYGBeHt7U1xcTFZWFjNmzKBLly4MGDCANWvWMHHiRIYMGYKzszP79u3j1KlTNqMoc+fOpbi4mH79+uHt7c2NGzfYtWsX165dIzAw0FKvR48ebNiwgXnz5tG/f3+cnJzo3r271YjI7Xr06EFycjJxcXG0b98eg8GAn5+f3a8dFRYWsn37duCfo0+7d++2jEpU9wvcvO5Hjx7NihUrCA8P54UXXuCnn35i/fr1NG7c2Oa1KxEREZGG0KCftZ45cya9e/dmy5YtrFy5koqKCjw9PenatavVTWdwcDC7du1i8+bNlJaW4u7uTpcuXZg2bZrNh+xu17NnT2JjY4mJiWHVqlW4urpaPgAXEhJiU3/OnDn89a9/JT09nR07dtCrVy+WLFnCX/7yFwoLCy313NzciImJYdGiRaxfv57Kykq6du1KdHQ0ycnJDZpYwM1lUBcvXkx8fDyrV6+moqICX19fpk+fbvWBPEdHR6Kjo1m4cCGpqakYjUY6duzIrFmzyM3NtUks6to/deHk5ERMTIzlA3kZGRm4ubnh7+/P+PHjadWq1V23FR4eTrdu3Vi3bh1r167FaDTSokULOnbsyJQpU6zqBgcH06ZNGxITE1m3bh0VFRV4eXnRp08fy3cxnnjiCebPn89HH33EkiVLaNSoEX379mXZsmWMHTvWqr2AgABSUlLYvn07V65cwcXFhQ4dOvDee+/h7+9vqTd48GBycnLYuXMnn332GVVVVcycObPWxGL8+PGUlpaSlJTE1atXMZvNbNu2ze7EIj8/nyVLlliVZWRkkJGRYTn/Wz9QOGHCBLy9vUlKSmLRokU0atSI3r17ExERUef5KyIiIiJ3w2Cuy3qvIvKrY3j/l1uSV0REROrGPKVBxwns0mBzLERERERE5NdLiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNjtwVmfSkQeSEubJRAaGoqzs/P9DkVEREQeYBqxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuxnMZrP5fgchIg8uw/um+x2CiIjIvwzzFKf7HcJ9oxELERERERGxmxILERERERGxmxILERERERGxmxILERERERGxmxILERERERGxmxILERERERGxmxILERERERGx2wOdWMyaNYvevXvfVd2CggJ69+7N0qVL73FUN9UltvDwcIKCgu5xRLWra//k5OQQGRnJwIEDf9F+FREREZF/Tb/eL3jIHZlMJqZNm4bJZCIiIgI3NzceffTR+x3WLy4zM5OcnBzGjRt31/usWbMGNze3Bk8ks7OzSUtL48SJE5w8eRKj0cjMmTNrPE5BQQGvvPJKje106NCBDRs2NGhsIiIiIvCAJxbTp0/nv/7rv+53GL86+fn55OfnM2nSJEaMGHG/w7lvMjMzSU1NrVNisXbtWry9vRs8sdizZw9JSUn4+vry6KOPcvTo0Z/dZ+DAgQwcONCqzM3NrUHjEhEREalmd2JRWVlJRUUFjRs3boh4rDg5OeHk9EDnPv+WfvzxRwDc3d0btF2z2YzRaKRp06YN2u6/svDwcACWLVtWa73g4GBGjx5NkyZN+PTTT+8qsejUqRMBAQENEqeIiIjIz6nTXXtKSgqzZ88mNjaWY8eOkZKSwsWLF5k+fTpBQUGYzWY2bdrE1q1bOXv2LA4ODnTr1o2xY8fazEdITU1lw4YN5OXlYTKZ8PT0pEePHkyePJnmzZsDN+cxpKamcvDgQat9v/32WxYtWkROTg4uLi74+/szdOjQO8a7ZMkSm+OHh4dTWFhISkqKpWzv3r0kJyfz97//nUuXLuHs7Mxjjz1GWFgYTz31VF266q4cOnSIjz76iOPHj2MymfD19WXYsGG8+uqrVvWys7PZuHEjR48epaioCEdHRzp16sQbb7xh80Qa7r5/ahIeHs6hQ4cAmD17NrNnzwZg27ZttG7dGqPRSHx8PLt27aK4uJhmzZrRr18/IiMj8fb2trRz8OBBIiIimDlzJkajkaSkJC5cuMDvfvc7ywjAzp07Wb9+PSdPnqSystJyToMGDbKJ6+DBg6xevZrs7GyMRiNeXl489dRTvP3223h4eACQlJREZmYmZ86c4cqVK7i7u9O3b18iIyNp3bq1VXtffvkliYmJnD59mvLycjw8POjWrRtRUVH4+PhY9cOt186dXj+6tV5hYaHVPtV9Zw9PT8967Xfjxg3MZvM9SfxFREREblWv4YDo6GhMJhNDhgzBxcUFHx8fAGbMmMHf/vY3/P39CQoKoqKigrS0NCZMmMD8+fN57rnnANi+fTuzZs2iV69eRERE0KhRI4qKitizZw+XL1+2JBY1yc7OZvz48TRt2pTRo0fj5ubGzp07mTlzZn1OxUpKSgqlpaUEBATQsmVLiouLSU5OZvz48SxZsoRevXrZfYxqu3fvZurUqXh6ejJq1CiaNm3Kzp07mTt3Lvn5+UyYMMFSNzMzk3PnzjFo0CC8vb0pLS0lNTWVqVOnMnfuXF588UVLXXv7JywsjMcff5wVK1YwZMgQyzk3b94ck8lEVFQUR44cwd/fn1GjRpGXl8emTZvYt28fiYmJtGzZ0qq9tWvXUlpayquvvoqnp6dl++LFi0lISOCZZ54hIiICBwcHMjIy+NOf/sS0adMYPny4pY1NmzYxb948Hn74YYYOHYq3tzcXL17kiy++oKioyJJYfPzxx3Tv3p0RI0bg7u7O6dOn2bp1KwcOHGDdunWWet988w3vvPMOHTt2JDQ0FFdXVy5dusT+/fs5f/48Pj4+hIWFYTabOXz4MHPmzLHE0rNnzzv23Zw5c1iwYAEeHh6EhYVZymu7nu+lTz75hI8++giz2UzLli0JCgoiLCyMhx566L7EIyIiIv/e6pVYlJeXs2bNGqunoBkZGaSlpfHuu+/y2muvWcpDQkIIDQ3lgw8+wM/PD4PBQGZmJi4uLsTFxVm96hQREfGzx16wYAFVVVXEx8dbEpphw4YxZsyY+pyKlenTp9OkSROrsqFDhzJ8+HBWrFjRYIlFZWUl8+fPp0mTJqxatQovLy8Ahg8fzrhx41i1ahVBQUG0a9cOgDFjxhAVFWXVRkhICCNHjiQ+Pt4qsbC3f55++mmcnJxYsWIFPXv2tHqVZsuWLRw5coQ33niDiRMnWsr79evHpEmTiImJ4c9//rNVexcvXmTjxo20aNHCUvbdd9+RkJBAaGioVQIVEhLC5MmTiY2NJTAwEBcXF4qKinj//ffx9fUlISHBao5AZGQkVVVVlr/XrVtn8/v5+fkxfvx4kpOTefPNNwHIysqiqqqK2NhYq7jeeustq35IT0/n8OHDd/06UUBAAHFxcbRo0eK+voLk4OBAnz59eO655/D29ubKlSt8+umnfPTRRxw9epQPP/wQR0fH+xafiIiI/Huq13KzwcHBNq9W7NixAxcXFwYMGEBJSYnlX1lZGc8++ywFBQXk5eUB4OrqSnl5OV9++SVms/muj3v58mWOHj3Kc889Z7lpBnB2dmbkyJH1ORUrt96UXr9+nZKSEhwdHenevTvHjx+3u/1qJ06c4OLFi7zyyiuWpAJunsfo0aOpqqoiKyurxrjKy8spKSmhvLycPn36cPbsWcrKyoB73z8ZGRk4ODgQGhpqVd6/f386d+7M7t27rW70AQIDA61u3gHS0tIwGAwEBgZaXSslJSX4+flx7do1jh07BsCnn35KRUUFY8eOrXHisYPDPy/h6n6qqqqirKyMkpISOnfujKurK9nZ2ZZ6rq6uAHz++eeYTCY7eqRuqq+pW/+ZTCZMJpNN+fXr1+t9nFatWhEXF0dISAjPPfccr776KjExMQwZMoT9+/ezc+fOBjwrERERkZvqNWJR/ST9VufOnePatWu88MILd9zv8uXL+Pj4EBoayqFDh5gyZQru7u48+eST/Pa3v+X555/HxcXljvvn5+cD4Ovra7OtQ4cOdT+R21y4cIHY2Fj27t3L1atXrbYZDAa7269WUFAA1Bxzx44dgX+eK9zst7i4OLKysrh8+bLNPmVlZbi6ut7z/ikoKMDLy4tmzZrVGHdubi4lJSVWiURN18rZs2cxm80EBwff8VjVE8jPnz8PQJcuXX42vgMHDrB8+XKOHz/OjRs3rLbd+nsOHz6crKws5s2bx4cffsjjjz/OM888w+DBg+/pa0vz588nNTW1xm23zyt5+eWXmTVrVoMePywsjC1btvDll1/y0ksvNWjbIiIiIvVKLGqaCGo2m2nevDlz5869437VN83t2rUjKSmJ/fv3c+DAAQ4dOsTcuXNZunQpy5cvp02bNvUJy0ZtyUBlZaXV39evX2fs2LEYjUZef/11OnXqhIuLCwaDgZUrV3LgwIEGiamuzGYzUVFRnD17lpCQELp164arqysODg6kpKSQnp5uM0rwILnTpGGDwcCiRYusRhxuVX2t3K3jx48TFRVFmzZtiIqKonXr1jRq1AiDwcC7775r1UceHh4kJiZy+PBh9u3bx+HDh1mwYAFLly4lOjq61nkU9hg9erTNDf3ChQsBmDRpklX5rSNZDaVly5Y4OjpSUlLS4G2LiIiINNharm3btiUvL48ePXrc1XKiDz30EP3796d///7AzVV6Jk2axCeffMIf//jHGvepXlnn3LlzNtvOnDljU1b9ZP2nn36y2VZQUGA1v2P//v388MMPzJgxw+bjYnFxcT97PnXxyCOPADXHXF1WXefkyZPk5uYyduxYm+8pbN261ervuvZPXT3yyCN8/fXXXL161ea1pDNnzuDi4mKZIF2btm3b8tVXX9GqVSvat29fa93qEY/c3Fyr17tul56eTmVlJYsWLbL0HYDRaLQZfQJwdHSkd+/eltWbTp48yahRo4iPjyc6Ohqo3yhVbft06NDBZuSouh/79etX52PVVX5+PpWVlTavpomIiIg0hHrNsahJYGAgVVVVxMTE1Li9+tUWoMYnpl27dgWgtLT0jseoXpI2KyuL77//3lJeUVHBmjVrbOpX35Tu37/fqjw9PZ0ffvjBqqx6Muvtcz727t1r9X5+Q+jatSutWrUiJSWFS5cuWcpNJhOrV6/GYDBYVtCqfqJ/e1ynTp0iMzPTqqyu/VNXAwYMoKqqipUrV1qV79mzh5ycHPz8/O44AnGr6onNsbGxNiNHYH2t+Pv74+zszPLlyy1zSW5V3S93+v0SEhJsRnRquv58fX1p3LixVRJaPWejtmvydk2aNKkxkf0l1XR+VVVVLF68GLg5oV1ERESkoTXYiMWgQYMICgpiw4YNfPfddzz77LN4eHhQXFzM0aNHuXDhAsnJyQBMmDABNzc3evXqRcuWLbl69SopKSkYDIafXU3nD3/4A+PGjWPMmDEMGzbMspxqTTeovr6+9O3bl82bN2M2m+ncuTO5ublkZmbStm1bq4m7TzzxBJ6enixcuJDCwkIefvhhcnNz2bFjB506deLUqVMN1VU4Ojoybdo0pk6dyptvvsmQIUNo2rQpu3bt4tixY4SGhlqSovbt29OhQwcSExMpLy/Hx8eHvLw8Nm/eTKdOnThx4kS9+6eugoKCSE1NZdWqVRQUFPDkk09y/vx5Nm7ciKenp9UKT7V57LHHCA8PZ9myZYwcOZJBgwbh5eXFpUuXOHHiBHv27GHv3r3Azdd3Jk+ezHvvvUdISAiBgYF4e3tTXFxMVlYWM2bMoEuXLgwYMIA1a9YwceJEhgwZgrOzM/v27ePUqVM2oyhz586luLiYfv364e3tzY0bN9i1axfXrl0jMDDQUq9Hjx5s2LCBefPm0b9/f5ycnOjevbvViMjtevToQXJyMnFxcbRv3x6DwYCfn5/NalV1VVhYyPbt24F/jj7t3r2boqIiAEu/APz3f/83165do2fPnrRs2ZKSkhI+//xzTpw4wXPPPYe/v79dsYiIiIjUpEE/az1z5kx69+7Nli1bWLlyJRUVFXh6etK1a1erm87g4GB27drF5s2bKS0txd3dnS5dujBt2jSbD9ndrmfPnsTGxhITE8OqVatwdXW1fAAuJCTEpv6cOXP461//Snp6Ojt27KBXr14sWbKEv/zlLxQWFlrqubm5ERMTw6JFi1i/fj2VlZV07dqV6OhokpOTGzSxgJtPjRcvXkx8fDyrV6+moqICX19fpk+fbvWBPEdHR6Kjo1m4cCGpqakYjUY6duzIrFmzyM3NtUks6to/deHk5ERMTIzlA3kZGRm4ubnh7+/P+PHjadWq1V23FR4eTrdu3Vi3bh1r167FaDTSokULOnbsyJQpU6zqBgcH06ZNGxITE1m3bh0VFRV4eXnRp08fy3cxnnjiCebPn89HH33EkiVLaNSoEX379mXZsmWMHTvWqr2AgABSUlLYvn07V65cwcXFhQ4dOvDee+9Z3XQPHjyYnJwcdu7cyWeffUZVVRUzZ86sNbEYP348paWlJCUlcfXqVcxmM9u2bbM7scjPz2fJkiVWZRkZGWRkZFjOvzqx+O1vf8uOHTvYsmULpaWlPPTQQ3To0IE//vGPDB069K5GlURERETqymCuy3qvIvKrY3j/l1uSV0RE5F+deUqDPrf/l6JHlyIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYrdf70K7InJXljZLIDQ0FGdn5/sdioiIiDzANGIhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2M5jNZvP9DkJEHlyG9033OwQREZFfnHmK0/0O4V+ORixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuD3RiMWvWLHr37n1XdQsKCujduzdLly69x1HdVJfYwsPDCQoKuscR1a6u/ZOTk0NkZCQDBw78RftVRERERP416csfYsNkMjFt2jRMJhMRERG4ubnx6KOP3u+wfnGZmZnk5OQwbty4u95nzZo1uLm5NXgimZ2dTVpaGidOnODkyZMYjUZmzpxZ43FmzZpFamrqHdtq27YtW7ZsadD4RERERB7oxGL69On813/91/0O41cnPz+f/Px8Jk2axIgRI+53OPdNZmYmqampdUos1q5di7e3d4MnFnv27CEpKQlfX18effRRjh49ese6r732Gn379rUpP3DgACkpKTz77LMNGpuIiIgINEBiUVlZSUVFBY0bN26IeKw4OTnh5PRA5z7/ln788UcA3N3dG7Rds9mM0WikadOmDdruv7Lw8HAAli1bVmu94OBgRo8eTZMmTfj0009rTSx69uxJz549bcp37NgBwP/+3//bjohFREREalanu/aUlBRmz55NbGwsx44dIyUlhYsXLzJ9+nSCgoIwm81s2rSJrVu3cvbsWRwcHOjWrRtjx461mY+QmprKhg0byMvLw2Qy4enpSY8ePZg8eTLNmzcH/vlKx8GDB632/fbbb1m0aBE5OTm4uLjg7+/P0KFD7xjvkiVLbI4fHh5OYWEhKSkplrK9e/eSnJzM3//+dy5duoSzszOPPfYYYWFhPPXUU3Xpqrty6NAhPvroI44fP47JZMLX15dhw4bx6quvWtXLzs5m48aNHD16lKKiIhwdHenUqRNvvPEGAwcOtGn3bvunJuHh4Rw6dAiA2bNnM3v2bAC2bdtG69atMRqNxMfHs2vXLoqLi2nWrBn9+vUjMjISb29vSzsHDx4kIiKCmTNnYjQaSUpK4sKFC/zud7+zjADs3LmT9evXc/LkSSorKy3nNGjQIJu4Dh48yOrVq8nOzsZoNOLl5cVTTz3F22+/jYeHBwBJSUlkZmZy5swZrly5gru7O3379iUyMpLWrVtbtffll1+SmJjI6dOnKS8vx8PDg27duhEVFYWPj49VP9x67dzp9aNb6xUWFlrtU9139vD09LRr/8LCQvbv30+PHj3o2LGjXW2JiIiI1KRewwHR0dGYTCaGDBmCi4sLPj4+AMyYMYO//e1v+Pv7ExQUREVFBWlpaUyYMIH58+fz3HPPAbB9+3ZmzZpFr169iIiIoFGjRhQVFbFnzx4uX75sSSxqkp2dzfjx42natCmjR4/Gzc2NnTt3MnPmzPqcipWUlBRKS0sJCAigZcuWFBcXk5yczPjx41myZAm9evWy+xjVdu/ezdSpU/H09GTUqFE0bdqUnTt3MnfuXPLz85kwYYKlbmZmJufOnWPQoEF4e3tTWlpKamoqU6dOZe7cubz44ouWuvb2T1hYGI8//jgrVqxgyJAhlnNu3rw5JpOJqKgojhw5gr+/P6NGjSIvL49Nmzaxb98+EhMTadmypVV7a9eupbS0lFdffRVPT0/L9sWLF5OQkMAzzzxDREQEDg4OZGRk8Kc//Ylp06YxfPhwSxubNm1i3rx5PPzwwwwdOhRvb28uXrzIF198QVFRkSWx+Pjjj+nevTsjRozA3d2d06dPs3XrVg4cOMC6dess9b755hveeecdOnbsSGhoKK6urly6dIn9+/dz/vx5fHx8CAsLw2w2c/jwYebMmWOJpaaRgGpz5sxhwYIFeHh4EBYWZimv7Xr+pWzbto2qqiqNVoiIiMg9U6/Eory8nDVr1li9/pSRkUFaWhrvvvsur732mqU8JCSE0NBQPvjgA/z8/DAYDGRmZuLi4kJcXJzVq04RERE/e+wFCxZQVVVFfHy8JaEZNmwYY8aMqc+pWJk+fTpNmjSxKhs6dCjDhw9nxYoVDZZYVFZWMn/+fJo0acKqVavw8vICYPjw4YwbN45Vq1YRFBREu3btABgzZgxRUVFWbYSEhDBy5Eji4+OtEgt7++fpp5/GycmJFStW0LNnTwICAizbtmzZwpEjR3jjjTeYOHGipbxfv35MmjSJmJgY/vznP1u1d/HiRTZu3EiLFi0sZd999x0JCQmEhoZaJVAhISFMnjyZ2NhYAgMDcXFxoaioiPfffx9fX18SEhJwc3Oz1I+MjKSqqsry97p162x+Pz8/P8aPH09ycjJvvvkmAFlZWVRVVREbG2sV11tvvWXVD+np6Rw+fNiqD2oTEBBAXFwcLVq0uOt9fglVVVWkpKTQtGlTXnjhhfsdjoiIiPybqtdys8HBwTZzKnbs2IGLiwsDBgygpKTE8q+srIxnn32WgoIC8vLyAHB1daW8vJwvv/wSs9l818e9fPkyR48e5bnnnrPcNAM4OzszcuTI+pyKlVtvSq9fv05JSQmOjo50796d48eP291+tRMnTnDx4kVeeeUVS1IBN89j9OjRVFVVkZWVVWNc5eXllJSUUF5eTp8+fTh79ixlZWXAve+fjIwMHBwcCA0NtSrv378/nTt3Zvfu3VY3+gCBgYFWN+8AaWlpGAwGAgMDra6VkpIS/Pz8uHbtGseOHQPg008/paKigrFjx1olFdUcHP55CVf3U1VVFWVlZZSUlNC5c2dcXV3Jzs621HN1dQXg888/x2Qy2dEjdVN9Td36z2QyYTKZbMqvX7/eYMfdt28fFy9e5Pnnn9f8FhEREbln6jViUf0k/Vbnzp3j2rVrtT4RvXz5Mj4+PoSGhnLo0CGmTJmCu7s7Tz75JL/97W95/vnncXFxueP++fn5APj6+tps69ChQ91P5DYXLlwgNjaWvXv3cvXqVattBoPB7varFRQUADXHXP3+e/W5ws1+i4uLIysri8uXL9vsU1ZWhqur6z3vn4KCAry8vGjWrFmNcefm5lJSUmKVSNR0rZw9exaz2UxwcPAdj1U9gfz8+fMAdOnS5WfjO3DgAMuXL+f48ePcuHHDatutv+fw4cPJyspi3rx5fPjhhzz++OM888wzDB48+J6+tjR//vw7LgN7+7ySl19+mVmzZjXIcZOTkwFs5u6IiIiINKR6JRY1rQBlNptp3rw5c+fOveN+1TfN7dq1Iykpif3793PgwAEOHTrE3LlzWbp0KcuXL6dNmzb1CctGbclAZWWl1d/Xr19n7NixGI1GXn/9dTp16oSLiwsGg4GVK1dy4MCBBomprsxmM1FRUZw9e5aQkBC6deuGq6srDg4OpKSkkJ6ebjNK8CC502phBoOBRYsWWY043KquE4yPHz9OVFQUbdq0ISoqitatW9OoUSMMBgPvvvuuVR95eHiQmJjI4cOH2bdvH4cPH2bBggUsXbqU6OjoWudR2GP06NG89NJLVmULFy4EYNKkSVblt45k2aOkpISsrCw6duxIjx49GqRNERERkZo02Fqubdu2JS8vjx49etzV6xYPPfQQ/fv3p3///sDNVXomTZrEJ598wh//+Mca96leWefcuXM2286cOWNTVv1k/aeffrLZVlBQYDW/Y//+/fzwww/MmDGDV155xapuXFzcz55PXTzyyCNAzTFXl1XXOXnyJLm5uYwdO9bmewpbt261+ruu/VNXjzzyCF9//TVXr161eS3pzJkzuLi4WCZI16Zt27Z89dVXtGrVivbt29dat3rEIzc31+r1rtulp6dTWVnJokWLLH0HYDQabUafABwdHendu7dl9aaTJ08yatQo4uPjiY6OBuo3SlXbPh06dLAZOarux379+tX5WHdj+/btVFRUaNK2iIiI3HP1mmNRk8DAQKqqqoiJialxe/WrLXDzKertunbtCkBpaekdj1G9JG1WVhbff/+9pbyiooI1a9bY1K++Kd2/f79VeXp6Oj/88INVmaOjI4DNnI+9e/davZ/fELp27UqrVq1ISUnh0qVLlnKTycTq1asxGAyWFbSqn+jfHtepU6fIzMy0Kqtr/9TVgAEDqKqqYuXKlVble/bsIScnBz8/vzuOQNyqemJzbGyszcgRWF8r/v7+ODs7s3z5cstckltV98udfr+EhASbEZ2arj9fX18aN25slYRWz9mo7Zq8XZMmTWpMZO+X5ORknJ2dH6jJ5CIiIvLvqcFGLAYNGkRQUBAbNmzgu+++49lnn8XDw4Pi4mKOHj3KhQsXLO96T5gwATc3N3r16kXLli25evUqKSkpGAyGn70B+sMf/sC4ceMYM2YMw4YNsyynWtMNqq+vL3379mXz5s2YzWY6d+5Mbm4umZmZtG3b1mri7hNPPIGnpycLFy6ksLCQhx9+mNzcXHbs2EGnTp04depUQ3UVjo6OTJs2jalTp/Lmm28yZMgQmjZtyq5duzh27BihoaGWpKh9+/Z06NCBxMREysvL8fHxIS8vj82bN9OpUydOnDhR7/6pq6CgIFJTU1m1ahUFBQU8+eSTnD9/no0bN+Lp6Wm1wlNtHnvsMcLDw1m2bBkjR45k0KBBeHl5cenSJU6cOMGePXvYu3cvAC1btmTy5Mm89957hISEEBgYiLe3N8XFxWRlZTFjxgy6dOnCgAEDWLNmDRMnTmTIkCE4Ozuzb98+Tp06ZTOKMnfuXIqLi+nXrx/e3t7cuHGDXbt2ce3aNQIDAy31evTowYYNG5g3bx79+/fHycmJ7t27W42I3K5Hjx4kJycTFxdH+/btMRgM+Pn52axWVVeFhYVs374d+Ofo0+7duykqKgKw9MutsrOzOXPmDM8///xdjSSJiIiI2KNBP2s9c+ZMevfuzZYtW1i5ciUVFRV4enrStWtXq5vO4OBgdu3axebNmyktLcXd3Z0uXbowbdo0mw/Z3a5nz57ExsYSExPDqlWrcHV1tXwALiQkxKb+nDlz+Otf/0p6ejo7duygV69eLFmyhL/85S8UFhZa6rm5uRETE8OiRYtYv349lZWVdO3alejoaJKTkxs0sYCby6AuXryY+Ph4Vq9eTUVFBb6+vkyfPt1qkq2joyPR0dEsXLiQ1NRUjEYjHTt2ZNasWeTm5tokFnXtn7pwcnIiJibG8oG8jIwM3Nzc8Pf3Z/z48bRq1equ2woPD6dbt26sW7eOtWvXYjQaadGiBR07dmTKlClWdYODg2nTpg2JiYmsW7eOiooKvLy86NOnj+W7GE888QTz58/no48+YsmSJTRq1Ii+ffuybNkyxo4da9VeQEAAKSkpbN++nStXruDi4kKHDh1477338Pf3t9QbPHgwOTk57Ny5k88++4yqqipmzpxZa2Ixfvx4SktLSUpK4urVq5jNZrZt22Z3YpGfn8+SJUusyjIyMsjIyLCc/+2JRXUir9egRERE5JdgMNdlvVcR+dUxvP/LLckrIiLyoDBPadDn778KDTbHQkREREREfr2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN20jpaI1GppswRCQ0Nxdna+36GIiIjIA0wjFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjclFiIiIiIiYjeD2Ww23+8gROTBZXjfdL9DEBERaRDmKU73O4R/axqxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuz3QicWsWbPo3bv3XdUtKCigd+/eLF269B5HdVNdYgsPDycoKOgeR1S7uvZPTk4OkZGRDBw48BftVxERERH516TFfMWGyWRi2rRpmEwmIiIicHNz49FHH73fYf3iMjMzycnJYdy4cXe9z5o1a3Bzc2vwRDI7O5u0tDROnDjByZMnMRqNzJw5866Oc+nSJYYNG8bVq1eZOHEib7zxRoPGJiIiIgIP+IjF9OnT2bNnz/0O41cnPz+f/Px8Xn/9dUaMGEFAQMCvNrFYvnx5nfZZu3YtKSkpDR7Lnj17SEpKoqysrM6/xfz586msrGzwmERERERuZXdiUVlZSXl5eUPEYsPJyYlGjRrdk7blzn788UcA3N3dG7Rds9nM9evXG7TNf3Xh4eGEh4f/bL3g4GCysrLYsGEDI0eOvOv2s7KyyMzM5K233rInTBEREZGfVadXoVJSUpg9ezaxsbEcO3aMlJQULl68yPTp0wkKCsJsNrNp0ya2bt3K2bNncXBwoFu3bowdO9ZmPkJqaiobNmwgLy8Pk8mEp6cnPXr0YPLkyTRv3hy4OY8hNTWVgwcPWu377bffsmjRInJycnBxccHf35+hQ4feMd4lS5bYHD88PJzCwkKrp8t79+4lOTmZv//971y6dAlnZ2cee+wxwsLCeOqpp+rSVXfl0KFDfPTRRxw/fhyTyYSvry/Dhg3j1VdftaqXnZ3Nxo0bOXr0KEVFRTg6OtKpUyfeeOMNBg4caNPu3fZPTcLDwzl06BAAs2fPZvbs2QBs27aN1q1bYzQaiY+PZ9euXRQXF9OsWTP69etHZGQk3t7elnYOHjxIREQEM2fOxGg0kpSUxIULF/jd735nebVo586drF+/npMnT1JZWWk5p0GDBtnEdfDgQVavXk12djZGoxEvLy+eeuop3n77bTw8PABISkoiMzOTM2fOcOXKFdzd3enbty+RkZG0bt3aqr0vv/ySxMRETp8+TXl5OR4eHnTr1o2oqCh8fHys+uHWa6e214+q6xUWFlrtU9139vD09KzzPteuXWP+/PkMHTqUbt262XV8ERERkZ9TrzkW0dHRmEwmhgwZgouLCz4+PgDMmDGDv/3tb/j7+xMUFERFRQVpaWlMmDCB+fPn89xzzwGwfft2Zs2aRa9evYiIiKBRo0YUFRWxZ88eLl++bEksapKdnc348eNp2rQpo0ePxs3NjZ07dzJz5sz6nIqVlJQUSktLCQgIoGXLlhQXF5OcnMz48eNZsmQJvXr1svsY1Xbv3s3UqVPx9PRk1KhRNG3alJ07dzJ37lzy8/OZMGGCpW5mZibnzp1j0KBBeHt7U1paSmpqKlOnTmXu3Lm8+OKLlrr29k9YWBiPP/44K1asYMiQIZZzbt68OSaTiaioKI4cOYK/vz+jRo0iLy+PTZs2sW/fPhITE2nZsqVVe2vXrqW0tJRXX30VT09Py/bFixeTkJDAM888Q0REBA4ODmRkZPCnP/2JadOmMXz4cEsbmzZtYt68eTz88MMMHToUb29vLl68yBdffEFRUZElsfj444/p3r07I0aMwN3dndOnT7N161YOHDjAunXrLPW++eYb3nnnHTp27EhoaCiurq5cunSJ/fv3c/78eXx8fAgLC8NsNnP48GHmzJljiaVnz5537Ls5c+awYMECPDw8CAsLs5TXdj3fSzExMVRWVjJhwgS+++67+xKDiIiI/HrUK7EoLy9nzZo1NG7c2FKWkZFBWloa7777Lq+99pqlPCQkhNDQUD744AP8/PwwGAxkZmbi4uJCXFwcTk7/DCEiIuJnj71gwQKqqqqIj4+3JDTDhg1jzJgx9TkVK9OnT6dJkyZWZUOHDmX48OGsWLGiwRKLyspK5s+fT5MmTVi1ahVeXl4ADB8+nHHjxrFq1SqCgoJo164dAGPGjCEqKsqqjZCQEEaOHEl8fLxVYmFv/zz99NM4OTmxYsUKevbsSUBAgGXbli1bOHLkCG+88QYTJ060lPfr149JkyYRExPDn//8Z6v2Ll68yMaNG2nRooWl7LvvviMhIYHQ0FCrBCokJITJkycTGxtLYGAgLi4uFBUV8f777+Pr60tCQgJubm6W+pGRkVRVVVn+Xrdunc3v5+fnx/jx40lOTubNN98Ebr4eVFVVRWxsrFVct74u9PTTT5Oens7hw4et+qA2AQEBxMXF0aJFi7ve5145duwYmzZtYu7cubi6ut7XWEREROTXoV5zLIKDg62SCoAdO3bg4uLCgAEDKCkpsfwrKyvj2WefpaCggLy8PABcXV0pLy/nyy+/xGw23/VxL1++zNGjR3nuuecsN80Azs7OdXrv/E5uvSm9fv06JSUlODo60r17d44fP253+9VOnDjBxYsXeeWVVyxJBdw8j9GjR1NVVUVWVlaNcZWXl1NSUkJ5eTl9+vTh7NmzlJWVAfe+fzIyMnBwcCA0NNSqvH///nTu3Jndu3db3egDBAYGWt28A6SlpWEwGAgMDLS6VkpKSvDz8+PatWscO3YMgE8//ZSKigrGjh1rlVRUc3D45yVc3U9VVVWUlZVRUlJC586dcXV1JTs721Kv+kb7888/x2Qy2dEjdVN9Td36z2QyYTKZbMrtmYtiMpmYO3cu/fr144UXXmjAMxARERG5s3qNWFQ/Sb/VuXPnuHbtWq03MpcvX8bHx4fQ0FAOHTrElClTcHd358knn+S3v/0tzz//PC4uLnfcPz8/HwBfX1+bbR06dKj7idzmwoULxMbGsnfvXq5evWq1zWAw2N1+tYKCAqDmmDt27Aj881zhZr/FxcWRlZXF5cuXbfYpKyvD1dX1nvdPQUEBXl5eNGvWrMa4c3NzKSkpsUokarpWzp49i9lsJjg4+I7Hqp5Afv78eQC6dOnys/EdOHCA5cuXc/z4cW7cuGG17dbfc/jw4WRlZTFv3jw+/PBDHn/8cZ555hkGDx58T19bmj9/PqmpqTVuu31eycsvv8ysWbPqdZyVK1dy4cIFPvjgg3rtLyIiIlIf9Uosbh+tgJsr/jRv3py5c+fecb/qm+Z27dqRlJTE/v37OXDgAIcOHWLu3LksXbqU5cuX06ZNm/qEZaO2ZOD25TevX7/O2LFjMRqNvP7663Tq1AkXFxcMBgMrV67kwIEDDRJTXZnNZqKiojh79iwhISF069YNV1dXHBwcSElJIT093WaU4EFS07UCN3+bRYsWWY043Kr6Wrlbx48fJyoqijZt2hAVFUXr1q1p1KgRBoOBd99916qPPDw8SExM5PDhw+zbt4/Dhw+zYMECli5dSnR0dK3zKOwxevRoXnrpJauyhQsXAjBp0iSr8ltHsuri0qVLrFixgsDAQMxmsyUx++GHHwAoLS3l/Pnz/OY3v7F5bUxERETEHg32gby2bduSl5dHjx49aNq06c/Wf+ihh+jfvz/9+/cHbq7SM2nSJD755BP++Mc/1rhP9co6586ds9l25swZm7LqJ+s//fSTzbaCggKr+R379+/nhx9+YMaMGbzyyitWdePi4n72fOrikUceAWqOubqsus7JkyfJzc1l7NixNh9q27p1q9Xfde2funrkkUf4+uuvuXr1qs1rSWfOnMHFxcUyQbo2bdu25auvvqJVq1a0b9++1rrVIx65ublWr3fdLj09ncrKShYtWmTpOwCj0Wgz+gTg6OhI7969Las3nTx5klGjRhEfH090dDRQv1Gq2vbp0KGDzchRdT/269evzseqyY8//siNGzfYvHkzmzdvttm+cuVKVq5cybx582pcfUtERESkvhrsA3mBgYFUVVURExNT4/bqV1sASkpKbLZ37doVuPlE9U6ql6TNysri+++/t5RXVFSwZs0am/rVN6X79++3Kk9PT7c8wa3m6OgIYDPnY+/evVbv5zeErl270qpVK1JSUrh06ZKl3GQysXr1agwGg2UFreon+rfHderUKTIzM63K6to/dTVgwACqqqpYuXKlVfmePXvIycnBz8/vjiMQt6qe2BwbG1vjh9tuvVb8/f1xdnZm+fLllrkkt6rulzv9fgkJCTYjOjVdf76+vjRu3NgqCa1+ol/bNXm7Jk2a1JjI/lIeeeQR5s2bZ/Ov+lsZgYGBzJs3756NyoiIiMivV4ONWAwaNIigoCA2bNjAd999x7PPPouHhwfFxcUcPXqUCxcukJycDMCECRNwc3OjV69etGzZkqtXr5KSkoLBYPjZ1XT+8Ic/MG7cOMaMGcOwYcMsy6nWdIPq6+tL37592bx5M2azmc6dO5Obm0tmZiZt27a1mrj7xBNP4OnpycKFCyksLOThhx8mNzeXHTt20KlTJ06dOtVQXYWjoyPTpk1j6tSpvPnmmwwZMoSmTZuya9cujh07RmhoqCUpat++PR06dCAxMZHy8nJ8fHzIy8tj8+bNdOrUiRMnTtS7f+oqKCiI1NRUVq1aRUFBAU8++STnz59n48aNeHp6Wq3wVJvHHnuM8PBwli1bxsiRIxk0aBBeXl5cunSJEydOsGfPHvbu3QtAy5YtmTx5Mu+99x4hISEEBgbi7e1NcXExWVlZzJgxgy5dujBgwADWrFnDxIkTGTJkCM7Ozuzbt49Tp07ZjKLMnTuX4uJi+vXrh7e3Nzdu3GDXrl1cu3aNwMBAS70ePXqwYcMG5s2bR//+/XFycqJ79+5WIyK369GjB8nJycTFxdG+fXsMBgN+fn52v3ZUWFjI9u3bgX+OPu3evZuioiIAS7+4urre8TsgAJ06ddJIhYiIiNwTDZZYwM2Ph/Xu3ZstW7awcuVKKioq8PT0pGvXrlY3ncHBwezatYvNmzdTWlqKu7s7Xbp0Ydq0aTYfsrtdz549iY2NJSYmhlWrVuHq6mr5AFxISIhN/Tlz5vDXv/6V9PR0duzYQa9evViyZAl/+ctfKCwstNRzc3MjJiaGRYsWsX79eiorK+natSvR0dEkJyc3aGIBN5dBXbx4MfHx8axevZqKigp8fX2ZPn261QfyHB0diY6OZuHChaSmpmI0GunYsSOzZs0iNzfXJrGoa//UhZOTEzExMZYP5GVkZODm5oa/vz/jx4+nVatWd91WeHg43bp1Y926daxduxaj0UiLFi3o2LEjU6ZMsaobHBxMmzZtSExMZN26dVRUVODl5UWfPn0s38V44oknmD9/Ph999BFLliyhUaNG9O3bl2XLljF27Fir9gICAkhJSWH79u1cuXIFFxcXOnTowHvvvYe/v7+l3uDBg8nJyWHnzp189tlnVFVVMXPmzFoTi/Hjx1NaWkpSUhJXr17FbDazbds2uxOL/Px8lixZYlWWkZFBRkaG5fxv/UChiIiIyC/NYK7Leq8i8qtjeP+XW5JXRETkXjJPadBn6nKbBptjISIiIiIiv15KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5azFdEarW0WQKhoaE4Ozvf71BERETkAaYRCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZsSCxERERERsZvBbDab73cQIvLgMrxvut8hiIiI1Mo8xel+hyBoxEJERERERBqAEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbHbA51YzJo1i969e99V3YKCAnr37s3SpUvvcVQ31SW28PBwgoKC7nFEtatr/+Tk5BAZGcnAgQN/0X4VERERkX9N+pqI2DCZTEybNg2TyURERARubm48+uij9zusX1xmZiY5OTmMGzfurvdZs2YNbm5uDZpIms1m0tLS+OKLLzhx4gQ//PADHh4edO7cmTFjxtC9e3er+t9//z1paWns3buXCxcu8I9//IM2bdrg7+/PyJEjadKkSYPFJiIiIlLtgR6xmD59Onv27LnfYfzq5Ofnk5+fz+uvv86IESMICAj41SYWy5cvr9M+a9euJSUlpUHj+Mc//sGMGTP4/vvveeGFF5g6dSpDhgwhJyeH0NBQduzYYVV/27ZtrFmzhjZt2vDWW2/x9ttv4+PjQ1xcHGFhYZSXlzdofCIiIiLQACMWlZWVVFRU0Lhx44aIx4qTkxNOThpU+aX9+OOPALi7uzdou2azGaPRSNOmTRu03X9l4eHhACxbtuyOdRwdHVm6dClPPfWUVfmQIUMYPnw4Cxcu5MUXX8TB4eZzAn9/f0JDQ3F1dbXUDQ4Opm3btiQkJJCcnMyIESPuwdmIiIjIr1md7tpTUlKYPXs2sbGxHDt2jJSUFC5evMj06dMJCgrCbDazadMmtm7dytmzZ3FwcKBbt26MHTvWZj5CamoqGzZsIC8vD5PJhKenJz169GDy5Mk0b94cuDmPITU1lYMHD1rt++2337Jo0SJycnJwcXHB39+foUOH3jHeJUuW2Bw/PDycwsJCq6fLe/fuJTk5mb///e9cunQJZ2dnHnvsMcLCwmxu6hrCoUOH+Oijjzh+/DgmkwlfX1+GDRvGq6++alUvOzubjRs3cvToUYqKinB0dKRTp0688cYbDBw40Kbdu+2fmoSHh3Po0CEAZs+ezezZs4GbT8Fbt26N0WgkPj6eXbt2UVxcTLNmzejXrx+RkZF4e3tb2jl48CARERHMnDkTo9FIUlISFy5c4He/+53l1aKdO3eyfv16Tp48SWVlpeWcBg0aZBPXwYMHWb16NdnZ2RiNRry8vHjqqad4++238fDwACApKYnMzEzOnDnDlStXcHd3p2/fvkRGRtK6dWur9r788ksSExM5ffo05eXleHh40K1bN6KiovDx8bHqh1uvnZkzZ97xNafqeoWFhVb7VPddfTk5OdV4/Xl6evLkk0+SkZHB5cuX+c1vfgNAt27damznhRdeICEhgdOnT9c7FhEREZE7qddwQHR0NCaTiSFDhuDi4oKPjw8AM2bM4G9/+xv+/v4EBQVRUVFBWloaEyZMYP78+Tz33HMAbN++nVmzZtGrVy8iIiJo1KgRRUVF7Nmzh8uXL1sSi5pkZ2czfvx4mjZtyujRo3Fzc2Pnzp3MnDmzPqdiJSUlhdLSUgICAmjZsiXFxcUkJyczfvx4lixZQq9evew+RrXdu3czdepUPD09GTVqFE2bNmXnzp3MnTuX/Px8JkyYYKmbmZnJuXPnGDRoEN7e3pSWlpKamsrUqVOZO3cuL774oqWuvf0TFhbG448/zooVKxgyZIjlnJs3b47JZCIqKoojR47g7+/PqFGjyMvLY9OmTezbt4/ExERatmxp1d7atWspLS3l1VdfxdPT07J98eLFJCQk8MwzzxAREYGDgwMZGRn86U9/Ytq0aQwfPtzSxqZNm5g3bx4PP/wwQ4cOxdvbm4sXL/LFF19QVFRkSSw+/vhjunfvzogRI3B3d+f06dNs3bqVAwcOsG7dOku9b775hnfeeYeOHTtanuxfunSJ/fv3c/78eXx8fAgLC8NsNnP48GHmzJljiaVnz5537Ls5c+awYMECPDw8CAsLs5TXdj3bq7i4GGdnZ9zc3H62blFREXAzIRERERFpaPVKLMrLy1mzZo3V608ZGRmkpaXx7rvv8tprr1nKQ0JCCA0N5YMPPsDPzw+DwUBmZiYuLi7ExcVZveoUERHxs8desGABVVVVxMfHWxKaYcOGMWbMmPqcipXp06fbTGwdOnQow4cPZ8WKFQ2WWFRWVjJ//nyaNGnCqlWr8PLyAmD48OGMGzeOVatWERQURLt27QAYM2YMUVFRVm2EhIQwcuRI4uPjrRILe/vn6aefxsnJiRUrVtCzZ08CAgIs27Zs2cKRI0d44403mDhxoqW8X79+TJo0iZiYGP785z9btXfx4kU2btxIixYtLGXfffcdCQkJhIaGWiVQISEhTJ48mdjYWAIDA3FxcaGoqIj3338fX19fEhISrG6gIyMjqaqqsvy9bt06m9/Pz8+P8ePHk5yczJtvvglAVlYWVVVVxMbGWsX11ltvWfVDeno6hw8ftuqD2gQEBBAXF0eLFi3ueh97fPnllxw/fpyAgAAaNWpUa93Kykri4+NxdHRk8ODB9zw2ERER+fWp1+Tt4OBgmzkVO3bswMXFhQEDBlBSUmL5V1ZWxrPPPktBQQF5eXkAuLq6Ul5ezpdffonZbL7r416+fJmjR4/y3HPPWW6aAZydnRk5cmR9TsXKrTel169fp6SkBEdHR7p3787x48ftbr/aiRMnuHjxIq+88oolqYCb5zF69GiqqqrIysqqMa7y8nJKSkooLy+nT58+nD17lrKyMuDe909GRgYODg6EhoZalffv35/OnTuze/duqxt9gMDAQKubd4C0tDQMBgOBgYFW10pJSQl+fn5cu3aNY8eOAfDpp59SUVHB2LFja3wqXz2vAP7ZT1VVVZSVlVFSUkLnzp1xdXUlOzvbUq967sHnn3+OyWSyo0fqpvqauvWfyWTCZDLZlF+/fr3WtvLy8pg5cyYPP/wwf/jDH3722B988AFHjx4lIiICX1/fBjojERERkX+q14hF9ZP0W507d45r167xwgsv3HG/y5cv4+PjQ2hoKIcOHWLKlCm4u7vz5JNP8tvf/pbnn38eFxeXO+6fn58PUOONUYcOHep+Ire5cOECsbGx7N27l6tXr1ptMxgMdrdfraCgAKg55o4dOwL/PFe42W9xcXFkZWVx+fJlm33KyspwdXW95/1TUFCAl5cXzZo1qzHu3NxcSkpKrBKJmq6Vs2fPYjabCQ4OvuOxqieQnz9/HoAuXbr8bHwHDhxg+fLlHD9+nBs3blhtu/X3HD58OFlZWcybN48PP/yQxx9/nGeeeYbBgwff09eW5s+fT2pqao3bbp9X8vLLLzNr1qwa6+bn5xMZGQnAokWLfjbmuLg4NmzYwJAhQ2ySQhEREZGGUq/EoqYVoMxmM82bN2fu3Ll33K/6prldu3YkJSWxf/9+Dhw4wKFDh5g7dy5Lly5l+fLltGnTpj5h2agtGaisrLT6+/r164wdOxaj0cjrr79Op06dcHFxwWAwsHLlSg4cONAgMdWV2WwmKiqKs2fPEhISQrdu3XB1dcXBwYGUlBTS09NtRgkeJHdaLcxgMLBo0SKrEYdbVV8rd+v48eNERUXRpk0boqKiaN26NY0aNcJgMPDuu+9a9ZGHhweJiYkcPnyYffv2cfjwYRYsWMDSpUuJjo6udR6FPUaPHs1LL71kVbZw4UIAJk2aZFV+60jWrQoKCoiIiMBoNLJ48WI6depU6zGXLl1KfHw8QUFBvPvuu/WOXUREROTnNNharm3btiUvL48ePXrc1XKiDz30EP3796d///7AzffFJ02axCeffMIf//jHGvepXlnn3LlzNtvOnDljU1b9ZP2nn36y2VZQUGA1v2P//v388MMPzJgxg1deecWqblxc3M+eT1088sgjQM0xV5dV1zl58iS5ubmMHTvW5kNtW7dutfq7rv1TV4888ghff/01V69etXkt6cyZM7i4uFgmSNembdu2fPXVV7Rq1Yr27dvXWrd6xCM3N9fq9a7bpaenU1lZyaJFiyx9B2A0Gm1Gn+DmEq69e/e2rN508uRJRo0aRXx8PNHR0UD9Rqlq26dDhw42I0fV/divX7+fbbugoIBx48ZRVlbG4sWL6dq1a631qxP1l19+mf/7f/9vg466iYiIiNyuwT6QFxgYSFVVFTExMTVur361BaCkpMRme/VNUmlp6R2PUb0kbVZWFt9//72lvKKigjVr1tjUr74p3b9/v1V5eno6P/zwg1WZo6MjgM2cj71791q9n98QunbtSqtWrUhJSeHSpUuWcpPJxOrVqzEYDJYVtKqf6N8e16lTp8jMzLQqq2v/1NWAAQOoqqpi5cqVVuV79uwhJycHPz+/O45A3Kp6YnNsbKzNyBFYXyv+/v44OzuzfPlyy1ySW1X3y51+v4SEBJsRnZquP19fXxo3bmyVhFbP2ajtmrxdkyZNakxk7VVYWEhERARXr14lJiaG//iP/6i1/vLly1m+fDkBAQHMmDHjrn4XEREREXs02IjFoEGDCAoKYsOGDXz33Xc8++yzeHh4UFxczNGjR7lw4QLJyckATJgwATc3N3r16kXLli25evUqKSkpGAyGn11N5w9/+APjxo1jzJgxDBs2zLKcak03qL6+vvTt25fNmzdjNpvp3Lkzubm5ZGZm0rZtW6uJu0888QSenp4sXLiQwsJCHn74YXJzc9mxYwedOnXi1KlTDdVVODo6Mm3aNKZOncqbb77JkCFDaNq0Kbt27eLYsWOEhoZakqL27dvToUMHEhMTKS8vx8fHh7y8PDZv3kynTp04ceJEvfunroKCgkhNTWXVqlUUFBTw5JNPcv78eTZu3Iinp6fVCk+1eeyxxwgPD2fZsmWMHDmSQYMG4eXlxaVLlzhx4gR79uxh7969ALRs2ZLJkyfz3nvvERISQmBgIN7e3hQXF5OVlcWMGTPo0qULAwYMYM2aNUycOJEhQ4bg7OzMvn37OHXqlM0oyty5cykuLqZfv354e3tz48YNdu3axbVr1wgMDLTU69GjBxs2bGDevHn0798fJycnunfvbjUicrsePXqQnJxMXFwc7du3x2Aw4OfnZ7NaVV1cu3aNiIgICgoKGDFiBN9//71V4gg3Rzyql5HdsGEDS5cupVWrVvTt25f09HSrui1atODpp5+udzwiIiIiNWnQz1rPnDmT3r17s2XLFlauXElFRQWenp507drV6qYzODiYXbt2sXnzZkpLS3F3d6dLly5MmzbN5kN2t+vZsyexsbHExMSwatUqXF1dLR+ACwkJsak/Z84c/vrXv5Kens6OHTvo1asXS5Ys4S9/+QuFhYWWem5ubsTExLBo0SLWr19PZWUlXbt2JTo6muTk5AZNLODmMqiLFy8mPj6e1atXU1FRga+vL9OnT7f6QJ6joyPR0dEsXLiQ1NRUjEYjHTt2ZNasWeTm5tokFnXtn7pwcnIiJibG8oG8jIwM3Nzc8Pf3Z/z48bRq1equ2woPD6dbt26sW7eOtWvXYjQaadGiBR07dmTKlClWdYODg2nTpg2JiYmsW7eOiooKvLy86NOnj+W7GE888QTz58/no48+YsmSJTRq1Ii+ffuybNkyxo4da9VeQEAAKSkpbN++nStXruDi4kKHDh1477338Pf3t9QbPHgwOTk57Ny5k88++4yqqipmzpxZa2Ixfvx4SktLSUpK4urVq5jNZrZt22ZXYlFaWmqZmL9+/foa6yxZssSSWPz9738Hbi71W9ME8CeffFKJhYiIiDQ4g7ku672KyK+O4f1fbkleERGR+jBPadBn5VJPevFaRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETsprW5RKRWS5slEBoairOz8/0ORURERB5gGrEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7Gcxms/l+ByEiDy7D+6b7HYKIiPyKmKc43e8QpJ40YiEiIiIiInZTYiEiIiIiInZTYiEiIiIiInZTYiEiIiIiInZTYiEiIiIiInZTYiEiIiIiInZ7oBOLWbNm0bt377uqW1BQQO/evVm6dOk9juqmusQWHh5OUFDQPY6odnXtn5ycHCIjIxk4cOAv2q8iIiIi8q9JCwWLDZPJxLRp0zCZTERERODm5sajjz56v8P6xWVmZpKTk8O4cePuep81a9bg5ubW4IlkdnY2aWlpnDhxgpMnT2I0Gpk5c+Ydj1NSUsKqVavYvXs3Fy9exNXVlfbt2xMSEsKAAQMaNDYREREReMBHLKZPn86ePXvudxi/Ovn5+eTn5/P6668zYsQIAgICfrWJxfLly+u0z9q1a0lJSWnwWPbs2UNSUhJlZWU/+1uUl5cTFhbGhg0bePrpp5k6dSojR47kxx9/ZMqUKWzcuLHB4xMRERGxe8SisrKSiooKGjdu3BDxWHFycsLJSYMqv7Qff/wRAHd39wZt12w2YzQaadq0aYO2+68sPDwcgGXLltVaLzg4mNGjR9OkSRM+/fRTjh49ese6mZmZ5OXlMXnyZF5//XVL+WuvvUZAQACbN28mODi4YU5ARERE5P+vTnftKSkpzJ49m9jYWI4dO0ZKSgoXL15k+vTpBAUFYTab2bRpE1u3buXs2bM4ODjQrVs3xo4dazMfITU1lQ0bNpCXl4fJZMLT05MePXowefJkmjdvDtycx5CamsrBgwet9v32229ZtGgROTk5uLi44O/vz9ChQ+8Y75IlS2yOHx4eTmFhodXT5b1795KcnMzf//53Ll26hLOzM4899hhhYWE89dRTdemqu3Lo0CE++ugjjh8/jslkwtfXl2HDhvHqq69a1cvOzmbjxo0cPXqUoqIiHB0d6dSpE2+88QYDBw60afdu+6cm4eHhHDp0CIDZs2cze/ZsALZt20br1q0xGo3Ex8eza9cuiouLadasGf369SMyMhJvb29LOwcPHiQiIoKZM2diNBpJSkriwoUL/O53v7O8WrRz507Wr1/PyZMnqaystJzToEGDbOI6ePAgq1evJjs7G6PRiJeXF0899RRvv/02Hh4eACQlJZGZmcmZM2e4cuUK7u7u9O3bl8jISFq3bm3V3pdffkliYiKnT5+mvLwcDw8PunXrRlRUFD4+Plb9cOu1U9vrR9X1CgsLrfap7jt7eHp63nXda9euAeDl5WVV7urqSpMmTe7JQwARERGReg0HREdHYzKZGDJkCC4uLvj4+AAwY8YM/va3v+Hv709QUBAVFRWkpaUxYcIE5s+fz3PPPQfA9u3bmTVrFr169SIiIoJGjRpRVFTEnj17uHz5siWxqEl2djbjx4+nadOmjB49Gjc3N3bu3MnMmTPrcypWUlJSKC0tJSAggJYtW1JcXExycjLjx49nyZIl9OrVy+5jVNu9ezdTp07F09OTUaNG0bRpU3bu3MncuXPJz89nwoQJlrqZmZmcO3eOQYMG4e3tTWlpKampqUydOpW5c+fy4osvWura2z9hYWE8/vjjrFixgiFDhljOuXnz5phMJqKiojhy5Aj+/v6MGjWKvLw8Nm3axL59+0hMTKRly5ZW7a1du5bS0lJeffVVPD09LdsXL15MQkICzzzzDBERETg4OJCRkcGf/vQnpk2bxvDhwy1tbNq0iXnz5vHwww8zdOhQvL29uXjxIl988QVFRUWWxOLjjz+me/fujBgxAnd3d06fPs3WrVs5cOAA69ats9T75ptveOedd+jYsSOhoaG4urpy6dIl9u/fz/nz5/Hx8SEsLAyz2czhw4eZM2eOJZaePXvese/mzJnDggUL8PDwICwszFJe2/V8L/Tp0wdHR0diYmJo3Lgxjz76KFevXuWTTz7h6tWrVrGJiIiINJR6JRbl5eWsWbPG6slnRkYGaWlpvPvuu7z22muW8pCQEEJDQ/nggw/w8/PDYDCQmZmJi4sLcXFxVq86RURE/OyxFyxYQFVVFfHx8ZaEZtiwYYwZM6Y+p2Jl+vTpNGnSxKps6NChDB8+nBUrVjRYYlFZWcn8+fNp0qQJq1atsjxZHj58OOPGjWPVqlUEBQXRrl07AMaMGUNUVJRVGyEhIYwcOZL4+HirxMLe/nn66adxcnJixYoV9OzZk4CAAMu2LVu2cOTIEd544w0mTpxoKe/Xrx+TJk0iJiaGP//5z1btXbx4kY0bN9KiRQtL2XfffUdCQgKhoaFWCVRISAiTJ08mNjaWwMBAXFxcKCoq4v3338fX15eEhATc3Nws9SMjI6mqqrL8vW7dOpvfz8/Pj/Hjx5OcnMybb74JQFZWFlVVVcTGxlrF9dZbb1n1Q3p6OocPH7bqg9oEBAQQFxdHixYt7nqfe6Fdu3b85S9/4YMPPmDSpEmWck9PT+Li4njiiSfuW2wiIiLy76tek7eDg4NtXqfYsWMHLi4uDBgwgJKSEsu/srIynn32WQoKCsjLywNuvpJRXl7Ol19+idlsvuvjXr58maNHj/Lcc89ZbpoBnJ2dGTlyZH1OxcqtN6XXr1+npKQER0dHunfvzvHjx+1uv9qJEye4ePEir7zyitXrKs7OzowePZqqqiqysrJqjKu8vJySkhLKy8vp06cPZ8+epaysDLj3/ZORkYGDgwOhoaFW5f3796dz587s3r3b6kYfIDAw0OrmHSAtLQ2DwUBgYKDVtVJSUoKfnx/Xrl3j2LFjAHz66adUVFQwduxYq6SimoPDPy/h6n6qqqqirKyMkpISOnfujKurK9nZ2ZZ6rq6uAHz++eeYTCY7eqRuqq+pW/+ZTCZMJpNN+fXr1+06lpubG506dSI8PJz333+fP/7xjzRu3JjJkyeTm5vbQGckIiIi8k/1GrGofpJ+q3PnznHt2jVeeOGFO+53+fJlfHx8CA0N5dChQ0yZMgV3d3eefPJJfvvb3/L888/j4uJyx/3z8/MB8PX1tdnWoUOHup/IbS5cuEBsbCx79+7l6tWrVtsMBoPd7VcrKCgAao65Y8eOwD/PFW72W1xcHFlZWVy+fNlmn7KyMlxdXe95/xQUFODl5UWzZs1qjDs3N5eSkhKrRKKma+Xs2bOYzeZaJxBXTyA/f/48AF26dPnZ+A4cOMDy5cs5fvw4N27csNp26+85fPhwsrKymDdvHh9++CGPP/44zzzzDIMHD76nry3Nnz+f1NTUGrfdPq/k5ZdfZtasWfU6ztdff83EiRNZuHAhzzzzjKV84MCBBAcH89577xEfH1+vtkVERETupF6JRU2TP81mM82bN2fu3Ll33K/6prldu3YkJSWxf/9+Dhw4wKFDh5g7dy5Lly5l+fLltGnTpj5h2agtGaisrLT6+/r164wdOxaj0cjrr79Op06dcHFxwWAwsHLlSg4cONAgMdWV2WwmKiqKs2fPEhISQrdu3XB1dcXBwYGUlBTS09NtRgkeJHeaKGwwGFi0aJHViMOtqq+Vu3X8+HGioqJo06YNUVFRtG7dmkaNGmEwGHj33Xet+sjDw4PExEQOHz7Mvn37OHz4MAsWLGDp0qVER0fXOo/CHqNHj+all16yKlu4cCGA1StLYDvxui5WrVpFkyZNrJIKgN/85jf06tWLr776ioqKCpydnet9DBEREZHbNdharm3btiUvL48ePXrc1XKiDz30EP3796d///7AzVV6Jk2axCeffMIf//jHGvepXlnn3LlzNtvOnDljU1b9ZP2nn36y2VZQUGA1v2P//v388MMPzJgxg1deecWqblxc3M+eT1088sgjQM0xV5dV1zl58iS5ubmMHTvW5kNtW7dutfq7rv1TV4888ghff/01V69etXkt6cyZM7i4uFgmSNembdu2fPXVV7Rq1Yr27dvXWrd6xCM3N9fq9a7bpaenU1lZyaJFiyx9B2A0Gm1GnwAcHR3p3bu3ZfWmkydPMmrUKOLj44mOjgbqN0pV2z4dOnSwGTmq7sd+/frV+Vh3UlxcTFVVFWaz2SaeyspKKisrH+hkVERERP41NdgH8gIDA6mqqiImJqbG7dWvtsDNrwLfrmvXrgCUlpbe8RjVS9JmZWXx/fffW8orKipYs2aNTf3qm9L9+/dblaenp/PDDz9YlTk6OgLYzPnYu3ev1fv5DaFr1660atWKlJQULl26ZCk3mUysXr0ag8FgWUGr+on+7XGdOnWKzMxMq7K69k9dDRgwgKqqKlauXGlVvmfPHnJycvDz87vjCMStqic2x8bG2owcgfW14u/vj7OzM8uXL7fMJblVdb/c6fdLSEiwuYmu6frz9fWlcePGVklo9ZyN2q7J2zVp0qTGRPaX1KFDB4xGI59++qlVeX5+PocOHaJTp040atToPkUnIiIi/64abMRi0KBBBAUFsWHDBr777jueffZZPDw8KC4u5ujRo1y4cIHk5GQAJkyYgJubG7169aJly5ZcvXqVlJQUDAbDz66m84c//IFx48YxZswYhg0bZllOtaYbVF9fX/r27cvmzZsxm8107tyZ3NxcMjMzadu2rdXE3SeeeAJPT08WLlxIYWEhDz/8MLm5uezYsYNOnTpx6tSphuoqHB0dmTZtGlOnTuXNN99kyJAhNG3alF27dnHs2DFCQ0MtSVH79u3p0KEDiYmJlJeX4+PjQ15eHps3b6ZTp06cOHGi3v1TV0FBQaSmprJq1SoKCgp48sknOX/+PBs3bsTT09NqhafaPPbYY4SHh7Ns2TJGjhzJoEGD8PLy4tKlS5w4cYI9e/awd+9eAFq2bMnkyZN57733CAkJITAwEG9vb4qLi8nKymLGjBl06dKFAQMGsGbNGiZOnMiQIUNwdnZm3759nDp1ymYUZe7cuRQXF9OvXz+8vb25ceMGu3bt4tq1awQGBlrq9ejRgw0bNjBv3jz69++Pk5MT3bt3txoRuV2PHj1ITk4mLi6O9u3bYzAY8PPzs1mtqq4KCwvZvn078M/Rp927d1NUVARg6ReA0NBQvv76a/7v//2/fPPNN3Tu3Jni4mI2btzIP/7xj7v+nURERETqokE/az1z5kx69+7Nli1bWLlyJRUVFXh6etK1a1erm5ng4GB27drF5s2bKS0txd3dnS5dujBt2jSbD9ndrmfPnsTGxhITE8OqVatwdXW1fAAuJCTEpv6cOXP461//Snp6Ojt27KBXr14sWbKEv/zlLxQWFlrqubm5ERMTw6JFi1i/fj2VlZV07dqV6OhokpOTGzSxgJvLoC5evJj4+HhWr15NRUUFvr6+TJ8+3eoDeY6OjkRHR7Nw4UJSU1MxGo107NiRWbNmkZuba5NY1LV/6sLJyYmYmBjLB/IyMjJwc3PD39+f8ePH06pVq7tuKzw8nG7durFu3TrWrl2L0WikRYsWdOzYkSlTpljVDQ4Opk2bNiQmJrJu3ToqKirw8vKiT58+lu9iPPHEE8yfP5+PPvqIJUuW0KhRI/r27cuyZcsYO3asVXsBAQGkpKSwfft2rly5gouLCx06dOC9997D39/fUm/w4MHk5OSwc+dOPvvsM6qqqpg5c2aticX48eMpLS0lKSmJq1evYjab2bZtm92JRX5+PkuWLLEqy8jIICMjw3L+1YnFY489Rnx8PAkJCXz++eds2bKFpk2b0r17d958882f/X9MREREpD4M5rqs9yoivzqG93+5JXlFRETMUxr0ubf8ghpsjoWIiIiIiPx6KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7KbEQERERERG7aaFgEanV0mYJhIaG4uzsfL9DERERkQeYRixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuBrPZbL7fQYjIg8vwvul+hyAiIv8GzFOc7ncIco9pxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxOIBdPDgQXr37k1KSsp9iyEnJ4fIyEgGDhxI7969Wbp06X2LRUREREQefPpSidgwmUxMmzYNk8lEREQEbm5uPProo/c7rF9cZmYmOTk5jBs37q73WbNmDW5ubgQFBTVoLNnZ2aSlpXHixAlOnjyJ0Whk5syZNR5n1qxZpKam3rGttm3bsmXLlgaNT0RERESJxQPoySefZM+ePTg53Z+fJz8/n/z8fCZNmsSIESPuSwwPgszMTFJTU+uUWKxduxZvb+8GTyz27NlDUlISvr6+PProoxw9evSOdV977TX69u1rU37gwAFSUlJ49tlnGzQ2EREREVBi8UC5du0aLi4uODg40KhRo/sWx48//giAu7t7g7ZrNpsxGo00bdq0Qdv9VxYeHg7AsmXLaq0XHBzM6NGjadKkCZ9++mmtiUXPnj3p2bOnTfmOHTsA+N//+3/bEbGIiIhIzZRYNJCUlBRmz55NbGws3377LSkpKfz444/4+PgQGhrK4MGDreoHBQXh7e3NO++8Q0xMDMeOHcPd3Z1t27Zx8OBBIiIibF51MZvNbN26la1bt3LmzBkAWrduzcCBA4mIiLDU+8c//sHHH39Meno6Fy5c4KGHHqJXr16MGzeOrl271noe4eHhHDp0CIDZs2cze/ZsALZt20br1q0xGo3Ex8eza9cuiouLadasGf369SMyMhJvb29LO7eeg9FoJCkpiQsXLvC73/3OMgKwc+dO1q9fz8mTJ6msrKRTp0688cYbDBo0yCaugwcPsnr1arKzszEajXh5efHUU0/x9ttv4+HhAUBSUhKZmZmcOXOGK1eu4O7uTt++fYmMjKR169ZW7X355ZckJiZy+vRpysvL8fDwoFu3bkRFReHj42PVD71797bsd6fXj26tV1hYaLVPdd/Zw9PT0679CwsL2b9/Pz169KBjx452tSUiIiJSEyUWDezDDz/EaDQSHBwM3Ew4/s//+T/84x//sLkhLSoqIjIykkGDBvG//tf/4vr167W2PWPGDNLS0ujevTthYWG4ublx7tw5PvvsM0tiYTKZ+P3vf8/Ro0cJCAhg+PDhlJWVsWXLFsaMGcPy5cvp1q3bHY8RFhbG448/zooVKxgyZAi9evUCoHnz5phMJqKiojhy5Aj+/v6MGjWKvLw8Nm3axL59+0hMTKRly5ZW7a1du5bS0lJeffVVPD09LdsXL15MQkICzzzzDBERETg4OJCRkcGf/vQnpk2bxvDhwy1tbNq0iXnz5vHwww8zdOhQvL29uXjxIl988QVFRUWWxOLjjz+me/fujBgxAnd3d06fPs3WrVs5cOAA69ats9T75ptveOedd+jYsSOhoaG4urpy6dIl9u/fz/nz5/Hx8SEsLAyz2czhw4eZM2eOJZaaRgKqzZkzhwULFuDh4UFYWJilvHnz5rX+rr+Ebdu2UVVVpdEKERERuWeUWDSwkpIS1q1bh6urK3DzFZaQkBD+53/+h+eff57GjRtb6ubn5zN9+nReffXVn213165dpKWl8dJLLzF79mwcHP65oFdVVZXlv9evX88333zDhx9+yH/+539ayoODgxkxYgQLFy6s9bWbp59+GicnJ1asWEHPnj0JCAiwbNuyZQtHjhzhjTfeYOLEiZbyfv36MWnSJGJiYvjzn/9s1d7FixfZuHEjLVq0sJR99913JCQkEBoayoQJEyzlISEhTJ48mdjYWAIDA3FxcaGoqIj3338fX19fEhIScHNzs9SPjIy0Ovd169bRpEkTq+P7+fkxfvx4kpOTefPNNwHIysqiqqqK2NhYq7jeeustq35IT0/n8OHDVn1Qm4CAAOLi4mjRosVd7/NLqKqqIiUlhaZNm/LCCy/c73BERETk35SWm21gwcHBlqQCwNXVlaFDh/LTTz/xzTffWNV1d3e/60m+aWlpAEyaNMkqqQCs/k5LS8PX15f/+I//oKSkxPLPZDLRr18/jhw5Qnl5eb3OLSMjAwcHB0JDQ63K+/fvT+fOndm9e7fVjT5AYGCg1c17dYwGg4HAwECrGEtKSvDz8+PatWscO3YMgE8//ZSKigrGjh1rlVTUdO7VSUVVVRVlZWWUlJTQuXNnXF1dyc7OttSr/n0+//xzTCZTvfqiPq5fv25zviaTCZPJZFP+c6NXdbFv3z4uXrzI888/r/ktIiIics9oxKKB+fr62pS1b98euDlCcatHHnkER0fHu2r3/Pnz/OY3v/nZd+3Pnj3LjRs3apynUK2kpIRWrVrd1XFvVVBQgJeXF82aNbPZ1rFjR3JzcykpKbFKJNq1a1djjGaz2fK6WE2qJ5CfP38egC5duvxsfAcOHGD58uUcP36cGzduWG27evWq5b+HDx9OVlYW8+bN48MPP+Txxx/nmWeeYfDgwff0taX58+ffcRnY23+vl19+mVmzZjXIcZOTkwHuamRMREREpL6UWNxHt74W1ZA6derEH/7whztu/yXf+b/TORoMBhYtWmQz+lKtrhOMjx8/TlRUFG3atCEqKorWrVvTqFEjDAYD7777rtVIioeHB4mJiRw+fJh9+/Zx+PBhFixYwNKlS4mOjq51HoU9Ro8ezUsvvWRVtnDhQuDmSNStvLy8GuSYJSUlZGVl0bFjR3r06NEgbYqIiIjURIlFAzt37pxN2dmzZ4GbIxT11a5dO7Kysvjxxx9rHbVo27YtV65coU+fPne8aa+vRx55hK+//pqrV6/avJZ05swZXFxcLBOka9O2bVu++uorWrVqZRnNuZPqEY/c3Fx8fHzuWC89PZ3KykoWLVpk1c9Go9FqtKKao6MjvXv3tqzedPLkSUaNGkV8fDzR0dHAzeSnrmrbp0OHDnTo0MGqrLof+/XrV+dj3Y3t27dTUVGhSdsiIiJyz2mORQPbuHEjZWVllr/LysrYtGkTbm5uPPXUU/Vut/pJ96JFi2zmMZjNZst/BwYG8uOPP/LJJ5/U2E71K0b1MWDAAKqqqli5cqVV+Z49e8jJycHPz++ukpnqic2xsbFUVlbWGqO/vz/Ozs4sX77cql+rVZ979Stlt/YFQEJCgk1/lZSU2LTj6+tL48aN+emnnyxl1XM2SktLf/acbt3n1jbut+TkZJydnR+oyeQiIiLy70kjFg3Mw8ODN9980zIpOyUlhYsXLzJ9+nS7Xn0aNGgQzz//PNu3b+f8+fP4+fnh5uZGXl4eX3/9NRs2bADg9ddfZ9++fURHR3PgwAH69OmDi4sLFy9e5MCBAzz00EMsXbq0XjEEBQWRmprKqlWrKCgo4Mknn+T8+fNs3LgRT09PqxWeavPYY48RHh7OsmXLGDlyJIMGDcLLy4tLly5x4sQJ9uzZw969ewFo2bIlkydP5r333iMkJITAwEC8vb0pLi4mKyuLGTNm0KVLFwYMGMCaNWuYOHEiQ4YMwdnZmX379nHq1CmbUZS5c+dSXFxMv3798Pb25saNG+zatYtr164RGBhoqdejRw82bNjAvHnz6N+/P05OTnTv3r3WkacePXqQnJxMXFwc7du3x2Aw4OfnZ7NaVV0VFhayfft2AMs3THbv3k1RURGApV9ulZ2dzZkzZ3j++efvaiRJRERExB5KLBrY73//e7799luSkpK4fPky7dq1Y+7cubz44ot2t/3f//3f9OrVi+TkZJYvX46joyOtW7e2mvjr5OTEwoUL2bhxIzt27LAkEV5eXjz22GO8/PLL9T6+k5MTMTExlg/kZWRk4Obmhr+/P+PHj6/ThPDw8HC6devGunXrWLt2LUajkRYtWtCxY0emTJliVTc4OJg2bdqQmJjIunXrqKiowMvLiz59+li+i/HEE08wf/58PvroI5YsWUKjRo3o27cvy5YtY+zYsVbtBQQEkJKSwvbt27ly5QouLi506NCB9957D39/f0u9wYMHk5OTw86dO/nss8+oqqpi5syZtSYW48ePp7S0lKSkJK5evYrZbGbbtm12Jxb5+fksWbLEqiwjI4OMjAzL+d+eWFRP2tZrUCIiIvJLMJhvf3dE6qX6y9tLliyx+uqyyL86w/u/3JK8IiLy78s8Rc+z/91pjoWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNhNcyxEpFaaYyEiIg1Bcyz+/WnEQkRERERE7KbEQkRERERE7KYxKRGp1dJmCYSGhuLs7Hy/QxEREZEHmEYsRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbkosRERERETEbgaz2Wy+30GIyIPL8L7pfocgIiIPEPMUp/sdgjygNGIhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2LxADp48CC9e/cmJSXlvsWQk5NDZGQkAwcOpHfv3ixduvS+xSIiIiIiDz4tRCw2TCYT06ZNw2QyERERgZubG48++uj9DusXl5mZSU5ODuPGjbvrfdasWYObmxtBQUENGkt2djZpaWmcOHGCkydPYjQamTlzZo3HOXbsGKtXryY3N5fLly8D0KpVKwYNGsTIkSNxdXVt0NhEREREQInFA+nJJ59kz549ODndn58nPz+f/Px8Jk2axIgRI+5LDA+CzMxMUlNT65RYrF27Fm9v7wZPLPbs2UNSUhK+vr48+uijHD169I51v//+e8rLy3nppZf4zW9+g9ls5vjx4yQkJPDZZ5+xatUqGjdu3KDxiYiIiCixeIBcu3YNFxcXHBwcaNSo0X2L48cffwTA3d29Qds1m80YjUaaNm3aoO3+KwsPDwdg2bJltdYLDg5m9OjRNGnShE8//bTWxOLll1/m5Zdfttm/ffv2LFq0iC+++ILnn3/e/uBFREREbqHEooGkpKQwe/ZsYmNj+fbbb0lJSeHHH3/Ex8eH0NBQBg8ebFU/KCgIb29v3nnnHWJiYjh27Bju7u5s27aNgwcPEhERYfOqi9lsZuvWrWzdupUzZ84A0Lp1awYOHEhERISl3j/+8Q8+/vhj0tPTuXDhAg899BC9evVi3LhxdO3atdbzCA8P59ChQwDMnj2b2bNnA7Bt2zZat26N0WgkPj6eXbt2UVxcTLNmzejXrx+RkZF4e3tb2rn1HIxGI0lJSVy4cIHf/e53lhGAnTt3sn79ek6ePEllZSWdOnXijTfeYNCgQTZxHTx4kNWrV5OdnY3RaMTLy4unnnqKt99+Gw8PDwCSkpLIzMzkzJkzXLlyBXd3d/r27UtkZCStW7e2au/LL78kMTGR06dPU15ejoeHB926dSMqKgofHx+rfujdu7dlvzu9fnRrvcLCQqt9qvvOHp6ennbtD1h+n59++snutkRERERup8SigX344YcYjUaCg4OBmwnH//k//4d//OMfNjekRUVFREZGMmjQIP7X//pfXL9+vda2Z8yYQVpaGt27dycsLAw3NzfOnTvHZ599ZkksTCYTv//97zl69CgBAQEMHz6csrIytmzZwpgxY1i+fDndunW74zHCwsJ4/PHHWbFiBUOGDKFXr14ANG/eHJPJRFRUFEeOHMHf359Ro0aRl5fHpk2b2LdvH4mJibRs2dKqvbVr11JaWsqrr76Kp6enZfvixYtJSEjgmWeeISIiAgcHBzIyMvjTn/7EtGnTGD58uKWNTZs2MW/ePB5++GGGDh2Kt7c3Fy9e5IsvvqCoqMiSWHz88cd0796dESNG4O7uzunTp9m6dSsHDhxg3bp1lnrffPMN77zzDh07diQ0NBRXV1cuXbrE/v37OX/+PD4+PoSFhWE2mzl8+DBz5syxxNKzZ8879t2cOXNYsGABHh4ehIWFWcqbN29e6+96r5SXl1v+nThxgg8//BBnZ2f69et3X+IRERGRf29KLBpYSUkJ69ats0yQDQ4OJiQkhP/5n//h+eeft3q3PT8/n+nTp/Pqq6/+bLu7du0iLS2Nl156idmzZ+Pg8M8Fvaqqqiz/vX79er755hs+/PBD/vM//9NSHhwczIgRI1i4cGGtr908/fTTODk5sWLFCnr27ElAQIBl25YtWzhy5AhvvPEGEydOtJT369ePSZMmERMTw5///Ger9i5evMjGjRtp0aKFpey7774jISGB0NBQJkyYYCkPCQlh8uTJxMbGEhgYiIuLC0VFRbz//vv4+vqSkJCAm5ubpX5kZKTVua9bt44mTZpYHd/Pz4/x48eTnJzMm2++CUBWVhZVVVXExsZaxfXWW29Z9UN6ejqHDx+26oPaBAQEEBcXR4sWLe56n3tpyZIlfPzxx5a/O3TowP/8z//Qpk2b+xiViIiI/LvScrMNLDg42GrVHVdXV4YOHcpPP/3EN998Y1XX3d39rif5pqWlATBp0iSrpAKw+jstLQ1fX1/+4z/+g5KSEss/k8lEv379OHLkCOXl5fU6t4yMDBwcHAgNDbUq79+/P507d2b37t1WN/oAgYGBVjfv1TEaDAYCAwOtYiwpKcHPz49r165x7NgxAD799FMqKioYO3asVVJR07lXJxVVVVWUlZVRUlJC586dcXV1JTs721Kv+vf5/PPPMZlM9eqL+rh+/brN+ZpMJkwmk035z41e3Y3XXnuN2NhY5s2bx//3//1/PPTQQ5SUlNh/IiIiIiI10IhFA/P19bUpa9++PXBzhOJWjzzyCI6OjnfV7vnz5/nNb37zs+/anz17lhs3btQ4T6FaSUkJrVq1uqvj3qqgoAAvLy+aNWtms61jx47k5uZSUlJilUi0a9euxhjNZrPldbGaVE8gP3/+PABdunT52fgOHDjA8uXLOX78ODdu3LDadvXqVct/Dx8+nKysLObNm8eHH37I448/zjPPPMPgwYPv6WtL8+fPJzU1tcZtt/9eL7/8MrNmzbLreO3atbP0/6BBg/j666/5/e9/D8CLL75oV9siIiIit1NicR/dqyU/O3XqxB/+8Ic7bv8l3/m/0zkaDAYWLVpkM/pSrWPHjnU6zvHjx4mKiqJNmzZERUXRunVrGjVqhMFg4N1337UaSfHw8CAxMZHDhw+zb98+Dh8+zIIFC1i6dCnR0dG1zqOwx+jRo3nppZesyhYuXAjcHIm6lZeXV4Mf/z//8z/x9PRk48aNSixERESkwSmxaGDnzp2zKTt79ixwc4Sivtq1a0dWVhY//vhjraMWbdu25cqVK/Tp0+eON+319cgjj/D1119z9epVm9eSzpw5g4uLi2WCdG3atm3LV199RatWrSyjOXdS/cQ9NzcXHx+fO9ZLT0+nsrKSRYsWWfWz0Wi0Gq2o5ujoSO/evS2rN508eZJRo0YRHx9PdHQ0cDP5qava9unQoQMdOnSwKqvux19qQvWNGze0KpSIiIjcE5pj0cA2btxIWVmZ5e+ysjI2bdqEm5sbTz31VL3brX7SvWjRIpt5DGaz2fLfgYGB/Pjjj3zyySc1tlP9ilF9DBgwgKqqKlauXGlVvmfPHnJycvDz87urZKZ6YnNsbCyVlZW1xujv74+zszPLly+36tdq1ede/UrZrX0BkJCQYNNfNc0z8PX1pXHjxlY33dVzNkpLS3/2nG7d537fuF+6dKnG8tTUVMrKyujevfsvHJGIiIj8GmjEooF5eHjw5ptvWiZlp6SkcPHiRaZPn27Xq0+DBg3i+eef//+x9+9hVVV7////XBwyBQRlo2IqeEi9PZXmoU8Z6Y1lQXRFnsiv2kYDAbnT8rD79vUSNT7XNmt7i4HgAVRsK4qaBB7SCjDdeUrLQwoeQwEhU0gU3CxYvz/8sbbLhSYu1Pbu9bguros15phjvudY84/5XmOOMdm0aRPnzp3Dx8cHFxcX8vLy+Pbbb1m7di0Ab7zxBnv27CEmJoZ9+/bRp08fnJycuHDhAvv27eORRx5h0aJF9xRDQEAAGRkZrFixgoKCAnr16sW5c+dYt24d7u7uFis83UnXrl0JDQ1l8eLFjBw5kkGDBuHh4cHFixc5duwYu3btYvfu3QA0b96cyZMn8+GHHxIUFIS/vz+enp4UFxeTnZ3NjBkz6NSpEwMGDGDVqlVMnDiRwMBAHB0d2bNnDydPnrQaRYmOjqa4uJh+/frh6enJ9evX2b59O1evXsXf399cr3v37qxdu5Y5c+bQv39/HBwc6Nat2x1Hnrp3705aWhrx8fG0bdsWg8GAj4+P1WpVdVVYWMimTZsAzO8w2bFjB0VFRQDmfgGYOHEirq6u9OjRgxYtWlBWVsb3339PdnY2zZs3N7+UT0RERKQ+KbGoZ//zP//D999/T2pqKpcuXaJNmzZER0fXyzPt//f//l969uxJWloaS5Yswd7enpYtW1pM/HVwcGD+/PmsW7eOzZs3m5MIDw8PunbtavVG5rpwcHAgNjbW/IK8zMxMXFxc8PX1JSIiok4TwkNDQ+nSpQspKSmsXr2a8vJymjZtSvv27ZkyZYpF3aFDh9KqVSuSk5NJSUmhsrISDw8P+vTpY34vxpNPPsncuXNZunQpCQkJNGjQgL59+7J48WJCQkIs2vPz8yM9PZ1NmzZx+fJlnJycaNeuHR9++CG+vr7meoMHDyYnJ4dt27bx1VdfUV1dTVRU1B0Ti4iICEpLS0lNTeXKlSuYTCY+//xzmxOL/Px8EhISLMoyMzPJzMw0n39NYhEYGMjXX3/Nxo0bKSkpwcHBgVatWvHmm28yatSou3pcTURERKSuDKZbnx2Re1Lz5u2EhASLty6L/LszfPzgluQVEZHfP9MU/S4ttdMcCxERERERsZkSCxERERERsZkSCxERERERsZnmWIjIHWmOhYiI3ExzLOR2NGIhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI200NyInJHixonERwcjKOj48MORURERH7HNGIhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2M5hMJtPDDkJEfr8MHxsfdggiIvIQmaY4POwQ5N+ERixERERERMRmSixERERERMRmSixERERERMRmSixERERERMRmSixERERERMRmSixERERERMRmSixERERERMRmv+vEYubMmfTu3fuu6hYUFNC7d28WLVp0n6O6oS6xhYaGEhAQcJ8jurO69k9OTg7h4eEMHDjwgfariIiIiPx70htPxIrRaGTatGkYjUbCwsJwcXHh8ccff9hhPXBZWVnk5OQwfvz4u95n1apVuLi41GsiaTKZ2LJlC9988w3Hjh3j559/xs3NjY4dOzJu3Di6detmtc+yZcs4fvw4x48fJz8/H09PT9LT0+stJhEREZFb/a5HLKZPn86uXbsedhh/OPn5+eTn5/PGG28wYsQI/Pz8/rCJxZIlS+q0z+rVq+v9Bv6f//wnM2bM4KeffuLFF19k6tSpBAYGkpOTQ3BwMJs3b7baJy4ujv379/PYY4/RuHHjeo1HREREpDY2j1hUVVVRWVnJo48+Wh/xWHBwcMDBQYMqD9ovv/wCgKura722azKZKC8vp1GjRvXa7r+z0NBQABYvXnzbOvb29ixatIinnnrKojwwMJDhw4czf/58XnrpJezs/vU7wcaNG2nVqhUAw4cPp7y8/D5ELyIiIvIvdbprT09PZ9asWcTFxXH48GHS09O5cOEC06dPJyAgAJPJxPr169m4cSNnzpzBzs6OLl26EBISYjUfISMjg7Vr15KXl4fRaMTd3Z3u3bszefJkmjRpAtyYx5CRkcH+/fst9v3+++9ZsGABOTk5ODk54evry5AhQ24bb0JCgtXxQ0NDKSwstPh1effu3aSlpfHjjz9y8eJFHB0d6dq1K2PHjrW6qasPBw4cYOnSpRw9ehSj0Yi3tzfDhg3jtddes6h35MgR1q1bx6FDhygqKsLe3p4OHTowevRoBg4caNXu3fZPbUJDQzlw4AAAs2bNYtasWQB8/vnntGzZkvLychITE9m+fTvFxcU0btyYfv36ER4ejqenp7md/fv3ExYWRlRUFOXl5aSmpnL+/Hn+/Oc/mx8t2rZtG2vWrOHEiRNUVVWZz2nQoEFWce3fv5+VK1dy5MgRysvL8fDw4KmnnuLtt9/Gzc0NgNTUVLKysjh9+jSXL1/G1dWVvn37Eh4eTsuWLS3a27lzJ8nJyZw6dYqKigrc3Nzo0qULkZGReHl5WfTDzddOVFTUbR9zqqlXWFhosU9N390rBweHWq8/d3d3evXqRWZmJpcuXeJPf/qTeVtNUiEiIiLyoNzTcEBMTAxGo5HAwECcnJzw8vICYMaMGXzxxRf4+voSEBBAZWUlW7ZsYcKECcydO5fnn38egE2bNjFz5kx69uxJWFgYDRo0oKioiF27dnHp0iVzYlGbI0eOEBERQaNGjRgzZgwuLi5s27aNqKioezkVC+np6ZSWluLn50fz5s0pLi4mLS2NiIgIEhIS6Nmzp83HqLFjxw6mTp2Ku7s7o0aNolGjRmzbto3o6Gjy8/OZMGGCuW5WVhZnz55l0KBBeHp6UlpaSkZGBlOnTiU6OpqXXnrJXNfW/hk7dixPPPEEy5YtIzAw0HzOTZo0wWg0EhkZyQ8//ICvry+jRo0iLy+P9evXs2fPHpKTk2nevLlFe6tXr6a0tJTXXnsNd3d38/aFCxeSlJTEM888Q1hYGHZ2dmRmZvLee+8xbdo0hg8fbm5j/fr1zJkzh2bNmjFkyBA8PT25cOEC33zzDUVFRebE4tNPP6Vbt26MGDECV1dXTp06xcaNG9m3bx8pKSnmet999x3vvvsu7du3Jzg4GGdnZy5evMjevXs5d+4cXl5ejB07FpPJxMGDB5k9e7Y5lh49ety272bPns28efNwc3Nj7Nix5vI7Xc+2Ki4uxtHRERcXl/t2DBEREZG7cU+JRUVFBatWrbJ4/CkzM5MtW7bw/vvv8/rrr5vLg4KCCA4O5m9/+xs+Pj4YDAaysrJwcnIiPj7e4lGnsLCw3zz2vHnzqK6uJjEx0ZzQDBs2jHHjxt3LqViYPn06DRs2tCgbMmQIw4cPZ9myZfWWWFRVVTF37lwaNmzIihUr8PDwAG48sjJ+/HhWrFhBQEAAbdq0AWDcuHFERkZatBEUFMTIkSNJTEy0SCxs7Z+nn34aBwcHli1bRo8ePfDz8zNv++yzz/jhhx8YPXo0EydONJf369ePSZMmERsbywcffGDR3oULF1i3bh1NmzY1lx0/fpykpCSCg4MtEqigoCAmT55MXFwc/v7+ODk5UVRUxMcff4y3tzdJSUkWN9Dh4eFUV1ebP6ekpFh9fz4+PkRERJCWlsabb74JQHZ2NtXV1cTFxVnE9dZbb1n0w9atWzl48KBFH9yJn58f8fHxNG3a9K73scXOnTs5evQofn5+NGjQ4L4fT0RERORO7mny9tChQ63mVGzevBknJycGDBhASUmJ+a+srIznnnuOgoIC8vLyAHB2dqaiooKdO3diMpnu+riXLl3i0KFDPP/88+abZgBHR0dGjhx5L6di4eab0mvXrlFSUoK9vT3dunXj6NGjNrdf49ixY1y4cIFXX33VnFTAjfMYM2YM1dXVZGdn1xpXRUUFJSUlVFRU0KdPH86cOUNZWRlw//snMzMTOzs7goODLcr79+9Px44d2bFjh8WNPoC/v7/FzTvAli1bMBgM+Pv7W1wrJSUl+Pj4cPXqVQ4fPgzAl19+SWVlJSEhIbX+Kn/zvIKafqqurqasrIySkhI6duyIs7MzR44cMddzdnYG4Ouvv8ZoNNrQI3VTc03d/Gc0GjEajVbl165du2NbeXl5REVF0axZM955550HdAYiIiIit3dPIxY1v6Tf7OzZs1y9epUXX3zxtvtdunQJLy8vgoODOXDgAFOmTMHV1ZVevXrx7LPP8sILL+Dk5HTb/fPz8wHw9va22tauXbu6n8gtzp8/T1xcHLt37+bKlSsW2wwGg83t1ygoKABqj7l9+/bAv84VbvRbfHw82dnZXLp0yWqfsrIynJ2d73v/FBQU4OHhUesqQ+3btyc3N5eSkhKLRKK2a+XMmTOYTCaGDh1622PVTCA/d+4cAJ06dfrN+Pbt28eSJUs4evQo169ft9h28/c5fPhwsrOzmTNnDp988glPPPEEzzzzDIMHD76vjy3NnTuXjIyMWrfdOq/klVdeYebMmbXWzc/PJzw8HIAFCxbc15hFRERE7tY9JRa1rQBlMplo0qQJ0dHRt92v5qa5TZs2pKamsnfvXvbt28eBAweIjo5m0aJFLFmypN4mnt4pGaiqqrL4fO3aNUJCQigvL+eNN96gQ4cOODk5YTAYWL58Ofv27auXmOrKZDIRGRnJmTNnCAoKokuXLjg7O2NnZ0d6ejpbt261GiX4PbndamEGg4EFCxZYjDjcrOZauVtHjx4lMjKSVq1aERkZScuWLWnQoAEGg4H333/foo/c3NxITk7m4MGD7Nmzh4MHDzJv3jwWLVpETEzMHedR2GLMmDG8/PLLFmXz588HYNKkSRblN49k3aygoICwsDDKy8tZuHAhHTp0uB+hioiIiNRZva3l2rp1a/Ly8ujevftdLSf6yCOP0L9/f/r37w/ceF580qRJ/P3vf+cvf/lLrfvUrKxz9uxZq22nT5+2Kqv5Zf3XX3+12lZQUGAxv2Pv3r38/PPPzJgxg1dffdWibnx8/G+eT1089thjQO0x15TV1Dlx4gS5ubmEhIRYvaht48aNFp/r2j919dhjj/Htt99y5coVq8eSTp8+jZOTk3mC9J20bt2af/zjH7Ro0YK2bdvesW7NiEdubq7F41232rp1K1VVVSxYsMDcdwDl5eVWo09wYwnX3r17m1dvOnHiBKNGjSIxMZGYmBjg3kap7rRPu3btrEaOavqxX79+v9l2QUEB48ePp6ysjIULF9K5c+c6xyciIiJyv9TbC/L8/f2prq4mNja21u01j7YAlJSUWG2vuUkqLS297TFqlqTNzs7mp59+MpdXVlayatUqq/o1N6V79+61KN+6dSs///yzRZm9vT2A1ZyP3bt3WzyfXx86d+5MixYtSE9P5+LFi+Zyo9HIypUrMRgM5hW0an7RvzWukydPkpWVZVFW1/6pqwEDBlBdXc3y5cstynft2kVOTg4+Pj63HYG4Wc3E5ri4OKuRI7C8Vnx9fXF0dGTJkiXmuSQ3q+mX231/SUlJViM6tV1/3t7ePProoxZJaM2cjTtdk7dq2LBhrYmsrQoLCwkLC+PKlSvExsbyX//1X/V+DBERERFb1NuIxaBBgwgICGDt2rUcP36c5557Djc3N4qLizl06BDnz58nLS0NgAkTJuDi4kLPnj1p3rw5V65cIT09HYPB8Jur6bzzzjuMHz+ecePGMWzYMPNyqrXdoHp7e9O3b182bNiAyWSiY8eO5ObmkpWVRevWrS0m7j755JO4u7szf/58CgsLadasGbm5uWzevJkOHTpw8uTJ+uoq7O3tmTZtGlOnTuXNN98kMDCQRo0asX37dg4fPkxwcLA5KWrbti3t2rUjOTmZiooKvLy8yMvLY8OGDXTo0IFjx47dc//UVUBAABkZGaxYsYKCggJ69erFuXPnWLduHe7u7hYrPN1J165dCQ0NZfHixYwcOZJBgwbh4eHBxYsXOXbsGLt27WL37t0ANG/enMmTJ/Phhx8SFBSEv78/np6eFBcXk52dzYwZM+jUqRMDBgxg1apVTJw4kcDAQBwdHdmzZw8nT560GkWJjo6muLiYfv364enpyfXr19m+fTtXr17F39/fXK979+6sXbuWOXPm0L9/fxwcHOjWrZvFiMitunfvTlpaGvHx8bRt2xaDwYCPj4/ValV1cfXqVcLCwigoKGDEiBH89NNPFokj3BjxcHd3N3/etGkThYWFwI1EqrKykqVLlwLg6elpcZ4iIiIi9aFeX2sdFRVF7969+eyzz1i+fDmVlZW4u7vTuXNni5vOoUOHsn37djZs2EBpaSmurq506tSJadOmWb3I7lY9evQgLi6O2NhYVqxYgbOzs/kFcEFBQVb1Z8+ezUcffcTWrVvZvHkzPXv2JCEhgb/+9a/mGy+48UhKbGwsCxYsYM2aNVRVVdG5c2diYmJIS0ur18QCbiyDunDhQhITE1m5ciWVlZV4e3szffp0ixfk2dvbExMTw/z588nIyKC8vJz27dszc+ZMcnNzrRKLuvZPXTg4OBAbG2t+QV5mZiYuLi74+voSERFBixYt7rqt0NBQunTpQkpKCqtXr6a8vJymTZvSvn17pkyZYlF36NChtGrViuTkZFJSUqisrMTDw4M+ffqY34vx5JNPMnfuXJYuXUpCQgINGjSgb9++LF68mJCQEIv2/Pz8SE9PZ9OmTVy+fBknJyfatWvHhx9+iK+vr7ne4MGDycnJYdu2bXz11VdUV1cTFRV1x8QiIiKC0tJSUlNTuXLlCiaTic8//9ymxKK0tNQ8MX/NmjW11klISLBILNLS0swv+Lu5DkCvXr2UWIiIiEi9M5jqst6riPzhGD5+cEvyiojI749pSr3+Di3/weptjoWIiIiIiPxxKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbaf0wEbmjRY2TCA4OxtHR8WGHIiIiIr9jGrEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbGUwmk+lhByEiv1+Gj40POwQREbkPTFMcHnYI8h9GIxYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRa/Q/v376d3796kp6c/tBhycnIIDw9n4MCB9O7dm0WLFj20WERERETk908LGIsVo9HItGnTMBqNhIWF4eLiwuOPP/6ww3rgsrKyyMnJYfz48Xe9z6pVq3BxcSEgIKBeYzly5Ahbtmzh2LFjnDhxgvLycqKiou7qOBcvXmTYsGFcuXKFiRMnMnr06HqNTURERAQ0YvG71KtXL3bt2oWfn99DOX5+fj75+fm88cYbjBgxAj8/vz9sYrFkyZI67bN69er7MtK0a9cuUlNTKSsrq/N3MXfuXKqqquo9JhEREZGbKbH4Hbl69SoAdnZ2NGjQAHt7+4cSxy+//AKAq6trvbZrMpm4du1avbb57y40NJTQ0NDfrDd06FCys7NZu3YtI0eOvOv2s7OzycrK4q233rIlTBEREZHfpEeh6kl6ejqzZs0iLi6O77//nvT0dH755Re8vLwIDg5m8ODBFvUDAgLw9PTk3XffJTY2lsOHD+Pq6srnn3/O/v37CQsLs3rUxWQysXHjRjZu3Mjp06cBaNmyJQMHDiQsLMxc75///CeffvopW7du5fz58zzyyCP07NmT8ePH07lz5zueR2hoKAcOHABg1qxZzJo1C4DPP/+cli1bUl5eTmJiItu3b6e4uJjGjRvTr18/wsPD8fT0NLdz8zmUl5eTmprK+fPn+fOf/2x+tGjbtm2sWbOGEydOUFVVRYcOHRg9ejSDBg2yimv//v2sXLmSI0eOUF5ejoeHB0899RRvv/02bm5uAKSmppKVlcXp06e5fPkyrq6u9O3bl/DwcFq2bGnR3s6dO0lOTubUqVNUVFTg5uZGly5diIyMxMvLy6Ifevfubd7vTo8f1dQrLCy02Kem72zh7u5e532uXr3K3LlzGTJkCF26dLHp+CIiIiK/RYlFPfvkk08oLy9n6NChwI2E4//7//4//vnPf1rdkBYVFREeHs6gQYP47//+79/8NX/GjBls2bKFbt26MXbsWFxcXDh79ixfffWVObEwGo38z//8D4cOHcLPz4/hw4dTVlbGZ599xrhx41iyZMkdbzLHjh3LE088wbJlywgMDKRnz54ANGnSBKPRSGRkJD/88AO+vr6MGjWKvLw81q9fz549e0hOTqZ58+YW7a1evZrS0lJee+013N3dzdsXLlxIUlISzzzzDGFhYdjZ2ZGZmcl7773HtGnTGD58uLmN9evXM2fOHJo1a8aQIUPw9PTkwoULfPPNNxQVFZkTi08//ZRu3boxYsQIXF1dOXXqFBs3bmTfvn2kpKSY63333Xe8++67tG/fnuDgYJydnbl48SJ79+7l3LlzeHl5MXbsWEwmEwcPHmT27NnmWHr06HHbvps9ezbz5s3Dzc2NsWPHmsubNGlyx+/1fomNjaWqqooJEyZw/PjxhxKDiIiI/HEosahnJSUlpKSk4OzsDNx4hCUoKIj//d//5YUXXuDRRx81183Pz2f69Om89tprv9nu9u3b2bJlCy+//DKzZs3Czu5fT7FVV1eb/1+zZg3fffcdn3zyCf/n//wfc/nQoUMZMWIE8+fPZ/Hixbc9ztNPP42DgwPLli2jR48eFvM8PvvsM3744QdGjx7NxIkTzeX9+vVj0qRJxMbG8sEHH1i0d+HCBdatW0fTpk3NZcePHycpKYng4GAmTJhgLg8KCmLy5MnExcXh7++Pk5MTRUVFfPzxx3h7e5OUlISLi4u5fnh4uMW5p6Sk0LBhQ4vj+/j4EBERQVpaGm+++SZw4/Gg6upq4uLiLOK6+XGhp59+mq1bt3Lw4MG7nuvi5+dHfHw8TZs2fWjzY2ocPnyY9evXEx0dbb4WRURERO4nzbGoZ0OHDrW4kXN2dmbIkCH8+uuvfPfddxZ1XV1d73r1oC1btgAwadIki6QCsPi8ZcsWvL29+a//+i9KSkrMf0ajkX79+vHDDz9QUVFxT+eWmZmJnZ0dwcHBFuX9+/enY8eO7Nixw+JGH8Df39/i5r0mRoPBgL+/v0WMJSUl+Pj4cPXqVQ4fPgzAl19+SWVlJSEhIRZJRW3nXpNUVFdXU1ZWRklJCR07dsTZ2ZkjR46Y69V8P19//TVGo/Ge+uJeXLt2zep8jUYjRqPRqtyWuShGo5Ho6Gj69evHiy++WI9nICIiInJ7GrGoZ97e3lZlbdu2BW6MUNzsscceu+sJ2ufOneNPf/rTbz5rf+bMGa5fv17rPIUaJSUltGjR4q6Oe7OCggI8PDxo3Lix1bb27duTm5tLSUmJRSLRpk2bWmM0mUzmx8VqUzOB/Ny5cwB06tTpN+Pbt28fS5Ys4ejRo1y/ft1i25UrV8z/Dx8+nOzsbObMmcMnn3zCE088wTPPPMPgwYPv62NLc+fOJSMjo9Ztt35fr7zyCjNnzryn4yxfvpzz58/zt7/97Z72FxEREbkXSiweopsfi6pPHTp04J133rnt9gf5zP/tztFgMLBgwQKr0Zca7du3r9Nxjh49SmRkJK1atSIyMpKWLVvSoEEDDAYD77//vsVIipubG8nJyRw8eJA9e/Zw8OBB5s2bx6JFi4iJibnjPApbjBkzhpdfftmibP78+cCNkaibeXh43NMxLl68yLJly/D398dkMpkTs59//hmA0tJSc5J662NjIiIiIrZQYlHPzp49a1V25swZ4MYIxb1q06YN2dnZ/PLLL3cctWjdujWXL1+mT58+t71pv1ePPfYY3377LVeuXLF6LOn06dM4OTmZJ0jfSevWrfnHP/5BixYtzKM5t1Mz4pGbm4uXl9dt623dupWqqioWLFhg0c/l5eUWoxU17O3t6d27t3n1phMnTjBq1CgSExOJiYkBbiQ/dXWnfdq1a0e7du0symr6sV+/fnU+Vm1++eUXrl+/zoYNG9iwYYPV9uXLl7N8+XLmzJlzx1EtERERkbrSHIt6tm7dOsrKysyfy8rKWL9+PS4uLjz11FP33G7NL90LFiywmsdgMpnM//v7+/PLL7/w97//vdZ2ah4xuhcDBgygurqa5cuXW5Tv2rWLnJwcfHx87iqZqZnYHBcXV+uL226O0dfXF0dHR5YsWWLRrzVqzr3mkbKb+wIgKSnJqr9KSkqs2vH29ubRRx/l119/NZfV/KJfWlr6m+d08z43t/GgPfbYY8yZM8fqr+ZdGf7+/syZM+e+jcqIiIjIH5dGLOqZm5sbb775pnlSdnp6OhcuXGD69Ok2Pfo0aNAgXnjhBTZt2sS5c+fw8fHBxcWFvLw8vv32W9auXQvAG2+8wZ49e4iJiWHfvn306dMHJycnLly4wL59+3jkkUdYtGjRPcUQEBBARkYGK1asoKCggF69enHu3DnWrVuHu7u7xQpPd9K1a1dCQ0NZvHgxI0eOZNCgQXh4eHDx4kWOHTvGrl272L17NwDNmzdn8uTJfPjhhwQFBeHv74+npyfFxcVkZ2czY8YMOnXqxIABA1i1ahUTJ04kMDAQR0dH9uzZw8mTJ61GUaKjoykuLqZfv354enpy/fp1tm/fztWrV/H39zfX6969O2vXrmXOnDn0798fBwcHunXrdseRp+7du5OWlkZ8fDxt27bFYDDg4+Nj82NHhYWFbNq0CcD8DpMdO3ZQVFQEYO4XZ2fn274HBG48JqeRChEREbkflFjUs//5n//h+++/JzU1lUuXLtGmTRuio6N56aWXbG77//7f/0vPnj1JS0tjyZIl2Nvb07JlS4sbRQcHB+bPn8+6devYvHmzOYnw8PCga9euvPLKK/d8fAcHB2JjY80vyMvMzMTFxQVfX18iIiLqNCE8NDSULl26kJKSwurVqykvL6dp06a0b9+eKVOmWNQdOnQorVq1Ijk5mZSUFCorK/Hw8KBPnz7m92I8+eSTzJ07l6VLl5KQkECDBg3o27cvixcvJiQkxKI9Pz8/0tPT2bRpE5cvX8bJyYl27drx4Ycf4uvra643ePBgcnJy2LZtG1999RXV1dVERUXdMbGIiIigtLSU1NRUrly5gslk4vPPP7c5scjPzychIcGiLDMzk8zMTPP53/yCQhEREZEHzWC69dkRuSc1b95OSEiweOuyyL87w8cPbkleERF5cExT9Puy1C/NsRAREREREZspsRAREREREZspsRAREREREZtpjoWI3JHmWIiI/GfSHAupbxqxEBERERERmymxEBERERERmymxEBERERERm+nhOhG5o0WNkwgODsbR0fFhhyIiIiK/YxqxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmxlMJpPpYQchIr9fho+NDzsEERGxkWmKw8MOQf4ANGIhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2+10nFjNnzqR37953VbegoIDevXuzaNGi+xzVDXWJLTQ0lICAgPsc0Z3VtX9ycnIIDw9n4MCBD7RfRUREROTfk96WIlaMRiPTpk3DaDQSFhaGi4sLjz/++MMO64HLysoiJyeH8ePH3/U+q1atwsXFpV4TSZPJxJYtW/jmm284duwYP//8M25ubnTs2JFx48bRrVs3i/pnz55l6dKlHD9+nJ9//hmj0UiLFi149tlnGTNmDH/605/qLTYRERGRGr/rxGL69On8v//v//uww/jDyc/PJz8/n0mTJjFixIiHHc5Dk5WVRUZGRp0Si9WrV+Pp6VmvicU///lPZsyYQceOHXnxxRdp2bIlFy9eZMOGDQQHBzNr1iz8/PzM9YuLi7l48SIDBw6kWbNm2Nvbc/LkST777DO2bdvGqlWraNq0ab3FJyIiIgL1kFhUVVVRWVnJo48+Wh/xWHBwcMDB4Xed+/xH+uWXXwBwdXWt13ZNJhPl5eU0atSoXtv9dxYaGgrA4sWLb1vH3t6eRYsW8dRTT1mUBwYGMnz4cObPn89LL72End2NJxv79u1L3759rdrp1asX7733Hunp6bz55pv1eBYiIiIidUws0tPTmTVrFnFxcRw+fJj09HQuXLjA9OnTCQgIwGQysX79ejZu3MiZM2ews7OjS5cuhISEWM1HyMjIYO3ateTl5WE0GnF3d6d79+5MnjyZJk2aADfmMWRkZLB//36Lfb///nsWLFhATk4OTk5O+Pr6MmTIkNvGm5CQYHX80NBQCgsLSU9PN5ft3r2btLQ0fvzxRy5evIijoyNdu3Zl7NixVjd19eHAgQMsXbqUo0ePYjQa8fb2ZtiwYbz22msW9Y4cOcK6des4dOgQRUVF2Nvb06FDB0aPHs3AgQOt2r3b/qlNaGgoBw4cAGDWrFnMmjULgM8//5yWLVtSXl5OYmIi27dvp7i4mMaNG9OvXz/Cw8Px9PQ0t7N//37CwsKIioqivLyc1NRUzp8/z5///GfzCMC2bdtYs2YNJ06coKqqynxOgwYNsopr//79rFy5kiNHjlBeXo6HhwdPPfUUb7/9Nm5ubgCkpqaSlZXF6dOnuXz5Mq6urvTt25fw8HBatmxp0d7OnTtJTk7m1KlTVFRU4ObmRpcuXYiMjMTLy8uiH26+dqKiom47GlFTr7Cw0GKfmr67Vw4ODrVef+7u7vTq1YvMzEwuXbr0m484tWjRAoArV67ccywiIiIit3NPwwExMTEYjUYCAwNxcnLCy8sLgBkzZvDFF1/g6+tLQEAAlZWVbNmyhQkTJjB37lyef/55ADZt2sTMmTPp2bMnYWFhNGjQgKKiInbt2sWlS5fMiUVtjhw5QkREBI0aNWLMmDG4uLiwbds2oqKi7uVULKSnp1NaWoqfnx/NmzenuLiYtLQ0IiIiSEhIoGfPnjYfo8aOHTuYOnUq7u7ujBo1ikaNGrFt2zaio6PJz89nwoQJ5rpZWVmcPXuWQYMG4enpSWlpKRkZGUydOpXo6Gheeuklc11b+2fs2LE88cQTLFu2jMDAQPM5N2nSBKPRSGRkJD/88AO+vr6MGjWKvLw81q9fz549e0hOTqZ58+YW7a1evZrS0lJee+013N3dzdsXLlxIUlISzzzzDGFhYdjZ2ZGZmcl7773HtGnTGD58uLmN9evXM2fOHJo1a8aQIUPw9PTkwoULfPPNNxQVFZkTi08//ZRu3boxYsQIXF1dOXXqFBs3bmTfvn2kpKSY63333Xe8++67tG/fnuDgYJydnbl48SJ79+7l3LlzeHl5MXbsWEwmEwcPHmT27NnmWHr06HHbvps9ezbz5s3Dzc2NsWPHmsvvdD3bqri4GEdHR1xcXKy2Xb9+nfLycq5fv86ZM2dYsGABAM8+++x9i0dERET+uO4psaioqGDVqlUWjz9lZmayZcsW3n//fV5//XVzeVBQEMHBwfztb3/Dx8cHg8FAVlYWTk5OxMfHWzzqFBYW9pvHnjdvHtXV1SQmJpoTmmHDhjFu3Lh7ORUL06dPp2HDhhZlQ4YMYfjw4SxbtqzeEouqqirmzp1Lw4YNWbFiBR4eHgAMHz6c8ePHs2LFCgICAmjTpg0A48aNIzIy0qKNoKAgRo4cSWJiokViYWv/PP300zg4OLBs2TJ69Ohh8ez+Z599xg8//MDo0aOZOHGiubxfv35MmjSJ2NhYPvjgA4v2Lly4wLp16yye6T9+/DhJSUkEBwdbJFBBQUFMnjyZuLg4/P39cXJyoqioiI8//hhvb2+SkpIsbqDDw8Oprq42f05JSbH6/nx8fIiIiCAtLc38+E92djbV1dXExcVZxPXWW29Z9MPWrVs5ePCgRR/ciZ+fH/Hx8TRt2vSu97HFzp07OXr0KH5+fjRo0MBq+8aNG/noo4/Mn1u2bMkHH3xQrwmyiIiISI17Wm526NChVnMqNm/ejJOTEwMGDKCkpMT8V1ZWxnPPPUdBQQF5eXkAODs7U1FRwc6dOzGZTHd93EuXLnHo0CGef/55800zgKOjIyNHjryXU7Fw803ptWvXKCkpwd7enm7dunH06FGb269x7NgxLly4wKuvvmpOKuDGeYwZM4bq6mqys7NrjauiooKSkhIqKiro06cPZ86coaysDLj//ZOZmYmdnR3BwcEW5f3796djx47s2LHD4kYfwN/f32qi8JYtWzAYDPj7+1tcKyUlJfj4+HD16lUOHz4MwJdffkllZSUhISG1/ipfM68A/tVP1dXVlJWVUVJSQseOHXF2dubIkSPmes7OzgB8/fXXGI1GG3qkbmquqZv/jEYjRqPRqvzatWt3bCsvL4+oqCiaNWvGO++8U2udAQMGEBcXx8cff0xISAjOzs6UlJTchzMTERERuccRi5pf0m929uxZrl69yosvvnjb/S5duoSXlxfBwcEcOHCAKVOm4OrqSq9evXj22Wd54YUXcHJyuu3++fn5AHh7e1tta9euXd1P5Bbnz58nLi6O3bt3Wz2HbjAYbG6/RkFBAVB7zO3btwf+da5wo9/i4+PJzs7m0qVLVvuUlZXh7Ox83/unoKAADw8PGjduXGvcubm5lJSUWCQStV0rZ86cwWQyMXTo0Nseq2YC+blz5wDo1KnTb8a3b98+lixZwtGjR7l+/brFtpu/z+HDh5Odnc2cOXP45JNPeOKJJ3jmmWcYPHjwfX1sae7cuWRkZNS67dZ5Ja+88gozZ86stW5+fj7h4eEALFiw4LYxN2/e3Pzo2YABA/jv//5vxowZQ0VFhVVyKCIiImKre0osalsBymQy0aRJE6Kjo2+7X81Nc5s2bUhNTWXv3r3s27ePAwcOEB0dzaJFi1iyZAmtWrW6l7Cs3CkZqKqqsvh87do1QkJCKC8v54033qBDhw44OTlhMBhYvnw5+/btq5eY6spkMhEZGcmZM2cICgqiS5cuODs7Y2dnR3p6Olu3brUaJfg9ud1qYQaDgQULFliMONys5lq5W0ePHiUyMpJWrVoRGRlJy5YtadCgAQaDgffff9+ij9zc3EhOTubgwYPs2bOHgwcPMm/ePBYtWkRMTMwd51HYYsyYMbz88ssWZfPnzwdg0qRJFuU3j2TdrKCggLCwMMrLy1m4cCEdOnS46+M//vjjdOrUiXXr1imxEBERkXpXb2u5tm7dmry8PLp3735Xy4k+8sgj9O/fn/79+wM3nhefNGkSf//73/nLX/5S6z41K+ucPXvWatvp06etymp+Wf/111+tthUUFFjM79i7dy8///wzM2bM4NVXX7WoGx8f/5vnUxePPfYYUHvMNWU1dU6cOEFubi4hISFW71PYuHGjxee69k9dPfbYY3z77bdcuXLF6rGk06dP4+TkZJ4gfSetW7fmH//4By1atKBt27Z3rFsz4pGbm2vxeNettm7dSlVVFQsWLDD3HUB5eXmtqyDZ29vTu3dv8+pNJ06cYNSoUSQmJhITEwPc2yjVnfZp166d1chRTT/269fvN9suKChg/PjxlJWVsXDhQjp37lzn+K5fv05paWmd9xMRERH5Lfc0x6I2/v7+VFdXExsbW+v2mkdbgFqf8665SbrTTU/NkrTZ2dn89NNP5vLKykpWrVplVb/mpnTv3r0W5Vu3buXnn3+2KLO3twewmvOxe/dui+fz60Pnzp1p0aIF6enpXLx40VxuNBpZuXIlBoPBvIJWzS/6t8Z18uRJsrKyLMrq2j91NWDAAKqrq1m+fLlF+a5du8jJycHHx+e2IxA3q5nYHBcXZzVyBJbXiq+vL46OjixZssQ8l+RmNf1yu+8vKSnJakSntuvP29ubRx991CIJrZmzUZcb8YYNG9aayNqqsLCQsLAwrly5QmxsLP/1X/9127o3X1M3279/P6dOnaJ79+71Hp+IiIhIvY1YDBo0iICAANauXcvx48d57rnncHNzo7i4mEOHDnH+/HnS0tIAmDBhAi4uLvTs2ZPmzZtz5coV0tPTMRgMv7mazjvvvMP48eMZN24cw4YNMy+nWtsNqre3N3379mXDhg2YTCY6duxIbm4uWVlZtG7d2mLi7pNPPom7uzvz58+nsLCQZs2akZuby+bNm+nQoQMnT56sr67C3t6eadOmMXXqVN58800CAwNp1KgR27dv5/DhwwQHB5uTorZt29KuXTuSk5OpqKjAy8uLvLw8NmzYQIcOHTh27Ng9909dBQQEkJGRwYoVKygoKKBXr16cO3eOdevW4e7ubrHC05107dqV0NBQFi9ezMiRIxk0aBAeHh5cvHiRY8eOsWvXLnbv3g3cmCcwefJkPvzwQ4KCgvD398fT05Pi4mKys7OZMWMGnTp1YsCAAaxatYqJEycSGBiIo6Mje/bs4eTJk1ajKNHR0RQXF9OvXz88PT25fv0627dv5+rVq/j7+5vrde/enbVr1zJnzhz69++Pg4MD3bp1sxgRuVX37t1JS0sjPj6etm3bYjAY8PHxsVqtqi6uXr1KWFgYBQUFjBgxgp9++skicYQbIx7u7u4AzJkzh4sXL9KnTx9atGjBP//5T44dO8a2bdto1KiR1WNXIiIiIvWhXl9rHRUVRe/evfnss89Yvnw5lZWVuLu707lzZ4ubzqFDh7J9+3Y2bNhAaWkprq6udOrUiWnTplm9yO5WPXr0IC4ujtjYWFasWIGzs7P5BXBBQUFW9WfPns1HH33E1q1b2bx5Mz179iQhIYG//vWvFBYWmuu5uLgQGxvLggULWLNmDVVVVXTu3JmYmBjS0tLqNbGAG8ugLly4kMTERFauXEllZSXe3t5Mnz7d4gV59vb2xMTEMH/+fDIyMigvL6d9+/bMnDmT3Nxcq8Sirv1TFw4ODsTGxppfkJeZmYmLiwu+vr5ERESYX8B2N0JDQ+nSpQspKSmsXr2a8vJymjZtSvv27ZkyZYpF3aFDh9KqVSuSk5NJSUmhsrISDw8P+vTpY56c/OSTTzJ37lyWLl1KQkICDRo0oG/fvixevJiQkBCL9vz8/EhPT2fTpk1cvnwZJycn2rVrx4cffoivr6+53uDBg8nJyWHbtm189dVXVFdXExUVdcfEIiIigtLSUlJTU7ly5Qomk4nPP//cpsSitLTUPDF/zZo1tdZJSEgwJxaDBw9m06ZNbN68mcuXL2MwGGjRogWvv/46Y8aMqdP3JCIiInK3DKa6rPcqIn84ho8f3JK8IiJyf5im1OtvySK1qrc5FiIiIiIi8selxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymtcdE5I4WNU4iODgYR0fHhx2KiIiI/I5pxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGxmMJlMpocdhIj8fhk+Nj7sEERE5DeYpjg87BBENGIhIiIiIiK2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2+10nFjNnzqR37953VbegoIDevXuzaNGi+xzVDXWJLTQ0lICAgPsc0Z3VtX9ycnIIDw9n4MCBD7RfRUREROTfkxY9FitGo5Fp06ZhNBoJCwvDxcWFxx9//GGH9cBlZWWRk5PD+PHj73qfVatW4eLiUu+J5JEjR9iyZQvHjh3jxIkTlJeXExUVVetxrl27xqeffsqxY8fIycmhuLiYXr16sXjx4nqNSURERORmv+sRi+nTp7Nr166HHcYfTn5+Pvn5+bzxxhuMGDECPz+/P2xisWTJkjrts3r1atLT0+s9ll27dpGamkpZWdlvfhclJSUsXryYH3/8kccffxx7e/t6j0dERETkVjaPWFRVVVFZWcmjjz5aH/FYcHBwwMFBgyoP2i+//AKAq6trvbZrMpkoLy+nUaNG9druv7PQ0FCA3xxNGDp0KGPGjKFhw4Z8+eWXHDp06LZ1//SnP7Fp0yaaN28OwHPPPVd/AYuIiIjcRp3u2tPT05k1axZxcXEcPnyY9PR0Lly4wPTp0wkICMBkMrF+/Xo2btzImTNnsLOzo0uXLoSEhFjNR8jIyGDt2rXk5eVhNBpxd3ene/fuTJ48mSZNmgA35jFkZGSwf/9+i32///57FixYQE5ODk5OTvj6+jJkyJDbxpuQkGB1/NDQUAoLCy1+Xd69ezdpaWn8+OOPXLx4EUdHR7p27crYsWN56qmn6tJVd+XAgQMsXbqUo0ePYjQa8fb2ZtiwYbz22msW9Y4cOcK6des4dOgQRUVF2Nvb06FDB0aPHs3AgQOt2r3b/qlNaGgoBw4cAGDWrFnMmjULgM8//5yWLVtSXl5OYmIi27dvp7i4mMaNG9OvXz/Cw8Px9PQ0t7N//37CwsKIioqivLyc1NRUzp8/z5///Gfzo0Xbtm1jzZo1nDhxgqqqKvM5DRo0yCqu/fv3s3LlSo4cOUJ5eTkeHh489dRTvP3227i5uQGQmppKVlYWp0+f5vLly7i6utK3b1/Cw8Np2bKlRXs7d+4kOTmZU6dOUVFRgZubG126dCEyMhIvLy+Lfrj52rnd40c31yssLLTYp6bvbOHu7n7XdR955BFzUiEiIiLyoNzTcEBMTAxGo5HAwECcnJzw8vICYMaMGXzxxRf4+voSEBBAZWUlW7ZsYcKECcydO5fnn38egE2bNjFz5kx69uxJWFgYDRo0oKioiF27dnHp0iVzYlGbI0eOEBERQaNGjRgzZgwuLi5s27aNqKioezkVC+np6ZSWluLn50fz5s0pLi4mLS2NiIgIEhIS6Nmzp83HqLFjxw6mTp2Ku7s7o0aNolGjRmzbto3o6Gjy8/OZMGGCuW5WVhZnz55l0KBBeHp6UlpaSkZGBlOnTiU6OpqXXnrJXNfW/hk7dixPPPEEy5YtIzAw0HzOTZo0wWg0EhkZyQ8//ICvry+jRo0iLy+P9evXs2fPHpKTk61uaFevXk1paSmvvfYa7u7u5u0LFy4kKSmJZ555hrCwMOzs7MjMzOS9995j2rRpDB8+3NzG+vXrmTNnDs2aNWPIkCF4enpy4cIFvvnmG4qKisyJxaeffkq3bt0YMWIErq6unDp1io0bN7Jv3z5SUlLM9b777jveffdd2rdvT3BwMM7Ozly8eJG9e/dy7tw5vLy8GDt2LCaTiYMHDzJ79mxzLD169Lht382ePZt58+bh5ubG2LFjzeV3up5FRERE/lPcU2JRUVHBqlWrLB5/yszMZMuWLbz//vu8/vrr5vKgoCCCg4P529/+ho+PDwaDgaysLJycnIiPj7d41CksLOw3jz1v3jyqq6tJTEw0JzTDhg1j3Lhx93IqFqZPn07Dhg0tyoYMGcLw4cNZtmxZvSUWVVVVzJ07l4YNG7JixQo8PDwAGD58OOPHj2fFihUEBATQpk0bAMaNG0dkZKRFG0FBQYwcOZLExESLxMLW/nn66adxcHBg2bJl9OjRAz8/P/O2zz77jB9++IHRo0czceJEc3m/fv2YNGkSsbGxfPDBBxbtXbhwgXXr1tG0aVNz2fHjx0lKSiI4ONgigQoKCmLy5MnExcXh7++Pk5MTRUVFfPzxx3h7e5OUlISLi4u5fnh4ONXV1ebPKSkpVt+fj48PERERpKWl8eabbwKQnZ1NdXU1cXFxFnG99dZbFv2wdetWDh48aNEHd+Ln50d8fDxNmza9631ERERE/lPc0+TtoUOHWs2p2Lx5M05OTgwYMICSkhLzX1lZGc899xwFBQXk5eUB4OzsTEVFBTt37sRkMt31cS9dusShQ4d4/vnnzTfNAI6OjowcOfJeTsXCzTel165do6SkBHt7e7p168bRo0dtbr/GsWPHuHDhAq+++qo5qYAb5zFmzBiqq6vJzs6uNa6KigpKSkqoqKigT58+nDlzhrKyMuD+909mZiZ2dnYEBwdblPfv35+OHTuyY8cOixt9AH9/f4ubd4AtW7ZgMBjw9/e3uFZKSkrw8fHh6tWrHD58GIAvv/ySyspKQkJCLJKKGnZ2/7qEa/qpurqasrIySkpK6NixI87Ozhw5csRcz9nZGYCvv/4ao9FoQ4/UTc01dfOf0WjEaDRalV+7du2BxSUiIiJSH+5pxKLml/SbnT17lqtXr/Liiy/edr9Lly7h5eVFcHAwBw4cYMqUKbi6utKrVy+effZZXnjhBZycnG67f35+PgDe3t5W29q1a1f3E7nF+fPniYuLY/fu3Vy5csVim8FgsLn9GgUFBUDtMbdv3x7417nCjX6Lj48nOzubS5cuWe1TVlaGs7Pzfe+fgoICPDw8aNy4ca1x5+bmUlJSYpFI1HatnDlzBpPJxNChQ297rJoJ5OfOnQOgU6dOvxnfvn37WLJkCUePHuX69esW227+PocPH052djZz5szhk08+4YknnuCZZ55h8ODB9/Wxpblz55KRkVHrtlvnlbzyyivMnDnzvsUiIiIiUt/uKbGobQUok8lEkyZNiI6Ovu1+NTfNbdq0ITU1lb1797Jv3z4OHDhAdHQ0ixYtYsmSJbRq1epewrJyp2SgqqrK4vO1a9cICQmhvLycN954gw4dOuDk5ITBYGD58uXs27evXmKqK5PJRGRkJGfOnCEoKIguXbrg7OyMnZ0d6enpbN261WqU4PfkdquFGQwGFixYYDHicLOaa+VuHT16lMjISFq1akVkZCQtW7akQYMGGAwG3n//fYs+cnNzIzk5mYMHD7Jnzx4OHjzIvHnzWLRoETExMXecR2GLMWPG8PLLL1uUzZ8/H4BJkyZZlN88kiUiIiLy76De1nJt3bo1eXl5dO/e/a6WE33kkUfo378//fv3B26s0jNp0iT+/ve/85e//KXWfWpW1jl79qzVttOnT1uV1fyy/uuvv1ptKygosJjfsXfvXn7++WdmzJjBq6++alE3Pj7+N8+nLh577DGg9phrymrqnDhxgtzcXEJCQqxe1LZx40aLz3Xtn7p67LHH+Pbbb7ly5YrVY0mnT5/GycnJPEH6Tlq3bs0//vEPWrRoQdu2be9Yt2bEIzc31+Lxrltt3bqVqqoqFixYYO47gPLycqvRJwB7e3t69+5tXr3pxIkTjBo1isTERGJiYoB7G6W60z7t2rWzGjmq6cd+/frV+VgiIiIivyf19oI8f39/qquriY2NrXV7zaMtcOMFXrfq3LkzAKWlpbc9Rs2StNnZ2fz000/m8srKSlatWmVVv+amdO/evRblW7du5eeff7Yoq3mJ2K1zPnbv3m3xfH596Ny5My1atCA9PZ2LFy+ay41GIytXrsRgMJhX0Kr5Rf/WuE6ePElWVpZFWV37p64GDBhAdXU1y5cvtyjftWsXOTk5+Pj43HYE4mY1E5vj4uKsRo7A8lrx9fXF0dGRJUuWmOeS3KymX273/SUlJVmN6NR2/Xl7e/Poo49aJKE1czbudE3eqmHDhrUmsiIiIiL/6eptxGLQoEEEBASwdu1ajh8/znPPPYebmxvFxcUcOnSI8+fPk5aWBsCECRNwcXGhZ8+eNG/enCtXrpCeno7BYPjN1XTeeecdxo8fz7hx4xg2bJh5OdXablC9vb3p27cvGzZswGQy0bFjR3Jzc8nKyqJ169YWE3effPJJ3N3dmT9/PoWFhTRr1ozc3Fw2b95Mhw4dOHnyZH11Ffb29kybNo2pU6fy5ptvEhgYSKNGjdi+fTuHDx8mODjYnBS1bduWdu3akZycTEVFBV5eXuTl5bFhwwY6dOjAsWPH7rl/6iogIICMjAxWrFhBQUEBvXr14ty5c6xbtw53d3eLFZ7upGvXroSGhrJ48WJGjhzJoEGD8PDw4OLFixw7doxdu3axe/duAJo3b87kyZP58MMPCQoKwt/fH09PT4qLi8nOzmbGjBl06tSJAQMGsGrVKiZOnEhgYCCOjo7s2bOHkydPWo2iREdHU1xcTL9+/fD09OT69ets376dq1ev4u/vb67XvXt31q5dy5w5c+jfvz8ODg5069bNYkTkVt27dyctLY34+Hjatm2LwWDAx8fHarWquiosLGTTpk3Av0afduzYQVFREYC5X2qsWbPGPFJjNBq5cOECS5cuBaBjx474+PjYFI+IiIjIrer1tdZRUVH07t2bzz77jOXLl1NZWYm7uzudO3e2uOkcOnQo27dvZ8OGDZSWluLq6kqnTp2YNm2a1YvsbtWjRw/i4uKIjY1lxYoVODs7m18AFxQUZFV/9uzZfPTRR2zdupXNmzfTs2dPEhIS+Otf/0phYaG5nouLC7GxsSxYsIA1a9ZQVVVF586diYmJIS0trV4TC7ixDOrChQtJTExk5cqVVFZW4u3tzfTp0y1ekGdvb09MTAzz588nIyOD8vJy2rdvz8yZM8nNzbVKLOraP3Xh4OBAbGys+QV5mZmZuLi44OvrS0REBC1atLjrtkJDQ+nSpQspKSmsXr2a8vJymjZtSvv27ZkyZYpF3aFDh9KqVSuSk5NJSUmhsrISDw8P+vTpY34vxpNPPsncuXNZunQpCQkJNGjQgL59+7J48WJCQkIs2vPz8yM9PZ1NmzZx+fJlnJycaNeuHR9++CG+vr7meoMHDyYnJ4dt27bx1VdfUV1dTVRU1B0Ti4iICEpLS0lNTeXKlSuYTCY+//xzmxOL/Px8EhISLMoyMzPJzMw0n//NicWnn35qcX0XFBSY93/llVeUWIiIiEi9M5jqst6riPzhGD5+cEvyiojIvTFNqdffikXuSb3NsRARERERkT8uJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzLXosIne0qHESwcHBODo6PuxQRERE5HdMIxYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzJRYiIiIiImIzg8lkMj3sIETk98vwsfFhhyAiIrcwTXF42CGIWNGIhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2Ow/KrGYOXMmvXv3vqu6BQUF9O7dm0WLFt3nqG6oS2yhoaEEBATc54jurK79k5OTQ3h4OAMHDnyg/SoiIiIivw96u4rYzGg0Mm3aNIxGI2FhYbi4uPD4448/7LAeuKysLHJychg/fvxd77Nq1SpcXFzqPZH89NNP2bFjBz/99BO//vorjRs3xtvbm6CgIAYOHFivxxIRERGB/7ARi+nTp7Nr166HHcYfTn5+Pvn5+bzxxhuMGDECPz+/P2xisWTJkjrts3r1atLT0+s9lqNHj9KyZUtGjhzJe++9x6hRo6ioqGDq1KksXbq03o8nIiIi8sBHLKqqqqisrOTRRx+t97YdHBxwcNAgzIP2yy+/AODq6lqv7ZpMJsrLy2nUqFG9tvvvLDQ0FIDFixffsd5f//pXq7I33niD0aNHk5ycTHBwMPb29vclRhEREfljuq934enp6cyaNYu4uDgOHz5Meno6Fy5cYPr06QQEBGAymVi/fj0bN27kzJkz2NnZ0aVLF0JCQqzmI2RkZLB27Vry8vIwGo24u7vTvXt3Jk+eTJMmTYAb8xgyMjLYv3+/xb7ff/89CxYsICcnBycnJ3x9fRkyZMht401ISLA6fmhoKIWFhRa/Lu/evZu0tDR+/PFHLl68iKOjI127dmXs2LE89dRT9dWNZgcOHGDp0qUcPXoUo9GIt7c3w4YN47XXXrOod+TIEdatW8ehQ4coKirC3t6eDh06MHr06Fofg7nb/qlNaGgoBw4cAGDWrFnMmjULgM8//5yWLVtSXl5OYmIi27dvp7i4mMaNG9OvXz/Cw8Px9PQ0t7N//37CwsKIioqivLyc1NRUzp8/z5///Gfzo0Xbtm1jzZo1nDhxgqqqKvM5DRo0yCqu/fv3s3LlSo4cOUJ5eTkeHh489dRTvP3227i5uQGQmppKVlYWp0+f5vLly7i6utK3b1/Cw8Np2bKlRXs7d+4kOTmZU6dOUVFRgZubG126dCEyMhIvLy+Lfrj52omKirrtY0419QoLCy32qem7+ubg4ICHhwcnT57EaDQqsRAREZF69UB+3o+JicFoNBIYGIiTkxNeXl4AzJgxgy+++AJfX18CAgKorKxky5YtTJgwgblz5/L8888DsGnTJmbOnEnPnj0JCwujQYMGFBUVsWvXLi5dumROLGpz5MgRIiIiaNSoEWPGjMHFxYVt27YRFRVl83mlp6dTWlqKn58fzZs3p7i4mLS0NCIiIkhISKBnz542H6PGjh07mDp1Ku7u7owaNYpGjRqxbds2oqOjyc/PZ8KECea6WVlZnD17lkGDBuHp6UlpaSkZGRlMnTqV6OhoXnrpJXNdW/tn7NixPPHEEyxbtozAwEDzOTdp0gSj0UhkZCQ//PADvr6+jBo1iry8PNavX8+ePXtITk6mefPmFu2tXr2a0tJSXnvtNdzd3c3bFy5cSFJSEs888wxhYWHY2dmRmZnJe++9x7Rp0xg+fLi5jfXr1zNnzhyaNWvGkCFD8PT05MKFC3zzzTcUFRWZE4tPP/2Ubt26MWLECFxdXTl16hQbN25k3759pKSkmOt99913vPvuu7Rv357g4GCcnZ25ePEie/fu5dy5c3h5eTF27FhMJhMHDx5k9uzZ5lh69Ohx276bPXs28+bNw83NjbFjx5rL73Q911VpaSnV1dWUlJTw5Zdf8u2339K7d28aNGhQb8cQERERgQeUWFRUVLBq1SqLx58yMzPZsmUL77//Pq+//rq5PCgoiODgYP72t7/h4+ODwWAgKysLJycn4uPjLR51CgsL+81jz5s3j+rqahITE80JzbBhwxg3bpzN5zV9+nQaNmxoUTZkyBCGDx/OsmXL6i2xqKqqYu7cuTRs2JAVK1bg4eEBwPDhwxk/fjwrVqwgICCANm3aADBu3DgiIyMt2ggKCmLkyJEkJiZaJBa29s/TTz+Ng4MDy5Yto0ePHvj5+Zm3ffbZZ/zwww+MHj2aiRMnmsv79evHpEmTiI2N5YMPPrBo78KFC6xbt46mTZuay44fP05SUhLBwcEWCVRQUBCTJ08mLi4Of39/nJycKCoq4uOPP8bb25ukpCRcXFzM9cPDw6murjZ/TklJsfr+fHx8iIiIIC0tjTfffBOA7OxsqquriYuLs4jrrbfesuiHrVu3cvDgQYs+uBM/Pz/i4+Np2rTpXe9TV6+//jqlpaUA2Nvb89///d+899579+VYIiIi8sf2QCZvDx061GpOxebNm3FycmLAgAGUlJSY/8rKynjuuecoKCggLy8PAGdnZyoqKti5cycmk+muj3vp0iUOHTrE888/b75pBnB0dGTkyJE2n9fNN6XXrl2jpKQEe3t7unXrxtGjR21uv8axY8e4cOECr776qjmpgBvnMWbMGKqrq8nOzq41roqKCkpKSqioqKBPnz6cOXOGsrIy4P73T2ZmJnZ2dgQHB1uU9+/fn44dO7Jjxw6LG30Af39/i5t3gC1btmAwGPD397e4VkpKSvDx8eHq1ascPnwYgC+//JLKykpCQkIskooadnb/uuRr+qm6upqysjJKSkro2LEjzs7OHDlyxFzP2dkZgK+//hqj0WhDj9RNzTV185/RaMRoNFqVX7t2rdY2PvroI2JjY5kxYwb9+vXj+vXrXL169YGdg4iIiPxxPJARi5pf0m929uxZrl69yosvvnjb/S5duoSXlxfBwcEcOHCAKVOm4OrqSq9evXj22Wd54YUXcHJyuu3++fn5AHh7e1tta9euXd1P5Bbnz58nLi6O3bt3c+XKFYttBoPB5vZrFBQUALXH3L59e+Bf5wo3+i0+Pp7s7GwuXbpktU9ZWRnOzs73vX8KCgrw8PCgcePGtcadm5tLSUmJRSJR27Vy5swZTCYTQ4cOve2xaiaQnzt3DoBOnTr9Znz79u1jyZIlHD16lOvXr1tsu/n7HD58ONnZ2cyZM4dPPvmEJ554gmeeeYbBgwfX62NLt5o7dy4ZGRm1brt1Xskrr7zCzJkzrer16tXL/P+rr77K+++/z7hx40hNTa31exERERG5Vw8ksahtBSiTyUSTJk2Ijo6+7X41N81t2rQhNTWVvXv3sm/fPg4cOEB0dDSLFi1iyZIltGrVql7ivFMyUFVVZfH52rVrhISEUF5ezhtvvEGHDh1wcnLCYDCwfPly9u3bVy8x1ZXJZCIyMpIzZ84QFBREly5dcHZ2xs7OjvT0dLZu3Wo1SvB7crvVwgwGAwsWLLAYcbhZzbVyt44ePUpkZCStWrUiMjKSli1b0qBBAwwGA++//75FH7m5uZGcnMzBgwfZs2cPBw8eZN68eSxatIiYmJg7zqOwxZgxY3j55ZctyubPnw/ApEmTLMpvHsm6k1deeYVt27bx9ddfW036FxEREbHFQ1ubtXXr1uTl5dG9e/e7Wk70kUceoX///vTv3x+4sUrPpEmT+Pvf/85f/vKXWvepWVnn7NmzVttOnz5tVVbzC+6vv/5qta2goMBifsfevXv5+eefmTFjBq+++qpF3fj4+N88n7p47LHHgNpjrimrqXPixAlyc3MJCQmxelHbxo0bLT7XtX/q6rHHHuPbb7/lypUrVo8lnT59GicnJ/ME6Ttp3bo1//jHP2jRogVt27a9Y92aEY/c3FyLx7tutXXrVqqqqliwYIG57wDKy8utRp/gxvyE3r17m1dvOnHiBKNGjSIxMZGYmBjg3kap7rRPu3btrEaOavqxX79+dT4WYB6Zqe0aFxEREbHFQ3tBnr+/P9XV1cTGxta6vebRFoCSkhKr7Z07dwYwT0ytTc2StNnZ2fz000/m8srKSlatWmVVv+amdO/evRblW7du5eeff7Yoq1mq89Y5H7t377Z4Pr8+dO7cmRYtWpCens7FixfN5UajkZUrV2IwGMwraNX8on9rXCdPniQrK8uirK79U1cDBgygurqa5cuXW5Tv2rWLnJwcfHx8bjsCcbOaic1xcXFWI0dgea34+vri6OjIkiVLzHNJblbTL7f7/pKSkqxGdGq7/ry9vXn00UctbtBr5mzc6Zq8VcOGDev9Jr+8vLzWORdVVVWkpqYC0L1793o9poiIiMhDG7EYNGgQAQEBrF27luPHj/Pcc8/h5uZGcXExhw4d4vz586SlpQEwYcIEXFxc6NmzJ82bN+fKlSukp6djMBh+czWdd955h/HjxzNu3DiGDRtmXk61thtUb29v+vbty4YNGzCZTHTs2JHc3FyysrJo3bq1xcTdJ598End3d+bPn09hYSHNmjUjNzeXzZs306FDB06ePFlvfWVvb8+0adOYOnUqb775JoGBgTRq1Ijt27dz+PBhgoODzUlR27ZtadeuHcnJyVRUVODl5UVeXh4bNmygQ4cOHDt27J77p64CAgLIyMhgxYoVFBQU0KtXL86dO8e6detwd3e3WOHpTrp27UpoaCiLFy9m5MiRDBo0CA8PDy5evMixY8fYtWsXu3fvBqB58+ZMnjyZDz/8kKCgIPz9/fH09KS4uJjs7GxmzJhBp06dGDBgAKtWrWLixIkEBgbi6OjInj17OHnypNUoSnR0NMXFxfTr1w9PT0+uX7/O9u3buXr1Kv7+/uZ63bt3Z+3atcyZM4f+/fvj4OBAt27dLEZEbtW9e3fS0tKIj4+nbdu2GAwGfHx8rFarqou8vDxCQ0Px9fXFy8sLV1dXiouL+eKLL/jpp5945ZVX6nUpZBERERF4iIkF3Hh5WO/evfnss89Yvnw5lZWVuLu707lzZ4ubzqFDh7J9+3Y2bNhAaWkprq6udOrUiWnTplm9yO5WPXr0IC4ujtjYWFasWIGzs7P5BXBBQUFW9WfPns1HH33E1q1b2bx5Mz179iQhIYG//vWvFBYWmuu5uLgQGxvLggULWLNmDVVVVXTu3JmYmBjS0tLqNbGAG8ugLly4kMTERFauXEllZSXe3t5Mnz7d4ll5e3t7YmJimD9/PhkZGZSXl9O+fXtmzpxJbm6uVWJR1/6pCwcHB2JjY80vyMvMzMTFxQVfX18iIiJo0aLFXbcVGhpKly5dSElJYfXq1ZSXl9O0aVPat2/PlClTLOoOHTqUVq1akZycTEpKCpWVlXh4eNCnTx/zezGefPJJ5s6dy9KlS0lISKBBgwb07duXxYsXExISYtGen58f6enpbNq0icuXL+Pk5ES7du348MMP8fX1NdcbPHgwOTk5bNu2ja+++orq6mqioqLumFhERERQWlpKamoqV65cwWQy8fnnn9uUWDRv3hw/Pz++//57srKyuHr1Ks7OznTq1Im33nrLYrlhERERkfpiMNVl/VYR+cMxfPzgltgVEZG7Y5ryUH8bFqnVQ5tjISIiIiIi/zmUWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM20VpmI3NGixkkEBwfj6Oj4sEMRERGR3zGNWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM2UWIiIiIiIiM0MJpPJ9LCDEJHfL8PHxocdgojIfzTTFIeHHYJIvdCIhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2Ox3nVjMnDmT3r1731XdgoICevfuzaJFi+5zVDfUJbbQ0FACAgLuc0R3Vtf+ycnJITw8nIEDBz7QfhURERGRf09aOFmsGI1Gpk2bhtFoJCwsDBcXFx5//PGHHdYDl5WVRU5ODuPHj7/rfVatWoWLi0u9JpImk4ktW7bwzTffcOzYMX7++Wfc3Nzo2LEj48aNo1u3blb7VFdXs3r1ajZs2EBhYSFNmjRh0KBBhIWF0bBhw3qLTURERKTG73rEYvr06ezatethh/GHk5+fT35+Pm+88QYjRozAz8/vD5tYLFmypE77rF69mvT09HqN45///CczZszgp59+4sUXX2Tq1KkEBgaSk5NDcHAwmzdvttpn3rx5/O///i/t2rVj6tSp+Pr6kpKSwjvvvEN1dXW9xiciIiIC9TBiUVVVRWVlJY8++mh9xGPBwcEBBwcNqjxov/zyCwCurq712q7JZKK8vJxGjRrVa7v/zkJDQwFYvHjxbevY29uzaNEinnrqKYvywMBAhg8fzvz583nppZews7vxO8GpU6dYs2YNAwcO5KOPPjLXb9myJR9//DHbtm3jpZdeug9nIyIiIn9kdbprT09PZ9asWcTFxXH48GHS09O5cOEC06dPJyAgAJPJxPr169m4cSNnzpzBzs6OLl26EBISYjUfISMjg7Vr15KXl4fRaMTd3Z3u3bszefJkmjRpAtyYx5CRkcH+/fst9v3+++9ZsGABOTk5ODk54evry5AhQ24bb0JCgtXxQ0NDKSwstPh1effu3aSlpfHjjz9y8eJFHB0d6dq1K2PHjrW6qasPBw4cYOnSpRw9ehSj0Yi3tzfDhg3jtddes6h35MgR1q1bx6FDhygqKsLe3p4OHTowevRoBg4caNXu3fZPbUJDQzlw4AAAs2bNYtasWQB8/vnntGzZkvLychITE9m+fTvFxcU0btyYfv36ER4ejqenp7md/fv3ExYWRlRUFOXl5aSmpnL+/Hn+/Oc/mx8t2rZtG2vWrOHEiRNUVVWZz2nQoEFWce3fv5+VK1dy5MgRysvL8fDw4KmnnuLtt9/Gzc0NgNTUVLKysjh9+jSXL1/G1dWVvn37Eh4eTsuWLS3a27lzJ8nJyZw6dYqKigrc3Nzo0qULkZGReHl5WfTDzddOVFTUbR9zqqlXWFhosU9N390rBweHWq8/d3d3evXqRWZmJpcuXeJPf/oTAF988QUmk4mRI0da1A8MDCQ2NpbNmzcrsRAREZF6d0/DATExMRiNRgIDA3FycsLLywuAGTNm8MUXX+Dr60tAQACVlZVs2bKFCRMmMHfuXJ5//nkANm3axMyZM+nZsydhYWE0aNCAoqIidu3axaVLl8yJRW2OHDlCREQEjRo1YsyYMbi4uLBt2zaioqLu5VQspKenU1paip+fH82bN6e4uJi0tDQiIiJISEigZ8+eNh+jxo4dO5g6dSru7u6MGjWKRo0asW3bNqKjo8nPz2fChAnmullZWZw9e5ZBgwbh6elJaWkpGRkZTJ06lejoaIubRFv7Z+zYsTzxxBMsW7aMwMBA8zk3adIEo9FIZGQkP/zwA76+vowaNYq8vDzWr1/Pnj17SE5Opnnz5hbtrV69mtLSUl577TXc3d3N2xcuXEhSUhLPPPMMYWFh2NnZkZmZyXvvvce0adMYPny4uY3169czZ84cmjVrxpAhQ/D09OTChQt88803FBUVmROLTz/9lG7dujFixAhcXV05deoUGzduZN++faSkpJjrfffdd7z77ru0b9+e4OBgnJ2duXjxInv37uXcuXN4eXkxduxYTCYTBw8eZPbs2eZYevTocdu+mz17NvPmzcPNzY2xY8eay+90PduquLgYR0dHXFxczGU//vgjdnZ2dO3a1aJugwYN6NixIz/++ON9i0dERET+uO4psaioqGDVqlUWjz9lZmayZcsW3n//fV5//XVzeVBQEMHBwfztb3/Dx8cHg8FAVlYWTk5OxMfHWzzqFBYW9pvHnjdvHtXV1SQmJpoTmmHDhjFu3Lh7ORUL06dPt5rYOmTIEIYPH86yZcvqLbGoqqpi7ty5NGzYkBUrVuDh4QHA8OHDGT9+PCtWrCAgIIA2bdoAMG7cOCIjIy3aCAoKYuTIkSQmJlokFrb2z9NPP42DgwPLli2jR48e+Pn5mbd99tln/PDDD4wePZqJEyeay/v168ekSZOIjY3lgw8+sGjvwoULrFu3jqZNm5rLjh8/TlJSEsHBwRYJVFBQEJMnTyYuLg5/f3+cnJwoKiri448/xtvbm6SkJIsb6PDwcIv5AikpKVbfn4+PDxEREaSlpfHmm28CkJ2dTXV1NXFxcRZxvfXWWxb9sHXrVg4ePGjRB3fi5+dHfHw8TZs2vet9bLFz506OHj2Kn58fDRo0MJfXTO5+5JFHrPZp1qwZhw4dorKyEkdHx/seo4iIiPxx3NPk7aFDh1rNqdi8eTNOTk4MGDCAkpIS819ZWRnPPfccBQUF5OXlAeDs7ExFRQU7d+7EZDLd9XEvXbrEoUOHeP755803zQCOjo5Wj33ci5tvSq9du0ZJSQn29vZ069aNo0eP2tx+jWPHjnHhwgVeffVVc1IBN85jzJgxVFdXk52dXWtcFRUVlJSUUFFRQZ8+fThz5gxlZWXA/e+fzMxM7OzsCA4Otijv378/HTt2ZMeOHVYTg/39/S1u3gG2bNmCwWDA39/f4lopKSnBx8eHq1evcvjwYQC+/PJLKisrCQkJsUgqatTMK4B/9VN1dTVlZWWUlJTQsWNHnJ2dOXLkiLmes7MzAF9//TVGo9GGHqmbmmvq5j+j0YjRaLQqv3bt2h3bysvLIyoqimbNmvHOO+9YbKuoqLht0lCTbFRUVNTPSYmIiIj8/93TiEXNL+k3O3v2LFevXuXFF1+87X6XLl3Cy8uL4OBgDhw4wJQpU3B1daVXr148++yzvPDCCzg5Od12//z8fAC8vb2ttrVr167uJ3KL8+fPExcXx+7du7ly5YrFNoPBYHP7NQoKCoDaY27fvj3wr3OFG/0WHx9PdnY2ly5dstqnrKwMZ2fn+94/BQUFeHh40Lhx41rjzs3NpaSkxCKRqO1aOXPmDCaTiaFDh972WDUTyM+dOwdAp06dfjO+ffv2sWTJEo4ePcr169cttt38fQ4fPpzs7GzmzJnDJ598whNPPMEzzzzD4MGD7+tjS3PnziUjI6PWbbfOK3nllVeYOXNmrXXz8/MJDw8HYMGCBVYxP/roo1y+fLnWff/5z3+a64iIiIjUp3tKLGq7KTGZTDRp0oTo6Ojb7ldz09ymTRtSU1PZu3cv+/bt48CBA0RHR7No0SKWLFlCq1at7iUsK3dKBqqqqiw+X7t2jZCQEMrLy3njjTfo0KEDTk5OGAwGli9fzr59++olproymUxERkZy5swZgoKC6NKlC87OztjZ2ZGens7WrVt/18uH3u4G1mAwsGDBAosRh5vVXCt36+jRo0RGRtKqVSsiIyNp2bIlDRo0wGAw8P7771v0kZubG8nJyRw8eJA9e/Zw8OBB5s2bx6JFi4iJibnjPApbjBkzhpdfftmibP78+QBMmjTJovzmkaybFRQUEBYWRnl5OQsXLqRDhw5WdTw8PDhz5gz//Oc/rR6HKi4uxs3NTY9BiYiISL2rt7VcW7duTV5eHt27d7+r5UQfeeQR+vfvT//+/YEbz4tPmjSJv//97/zlL3+pdZ+alXXOnj1rte306dNWZTW/rP/6669W2woKCizmd+zdu5eff/6ZGTNm8Oqrr1rUjY+P/83zqYvHHnsMqD3mmrKaOidOnCA3N5eQkBCrF7Vt3LjR4nNd+6euHnvsMb799luuXLli9VjS6dOncXJyMk+QvpPWrVvzj3/8gxYtWtC2bds71q0Z8cjNzbV4vOtWW7dupaqqigULFpj7DqC8vNxq9AluLOHau3dv8+pNJ06cYNSoUSQmJhITEwPc2yjVnfZp166d1chRTT/269fvN9suKChg/PjxlJWVsXDhQjp37lxrvS5durB7926OHj1qMS/o+vXr5Obm0qtXr7s5FREREZE6qbcX5Pn7+1NdXU1sbGyt22sebQEoKSmx2l5zk1RaWnrbY9QsSZudnc1PP/1kLq+srGTVqlVW9WtuSvfu3WtRvnXrVn7++WeLMnt7ewCrOR+7d++2eD6/PnTu3JkWLVqQnp7OxYsXzeVGo5GVK1diMBjMK2jV/KJ/a1wnT54kKyvLoqyu/VNXAwYMoLq6muXLl1uU79q1i5ycHHx8fG47AnGzmonNcXFxViNHYHmt+Pr64ujoyJIlS8xzSW5W0y+3+/6SkpKsRnRqu/68vb159NFHLZLQmjkbd7omb9WwYcNaE1lbFRYWEhYWxpUrV4iNjeW//uu/blv3xRdfxGAwWH3nn332GRUVFVpqVkRERO6LehuxGDRoEAEBAaxdu5bjx4/z3HPP4ebmRnFxMYcOHeL8+fOkpaUBMGHCBFxcXOjZsyfNmzfnypUrpKenYzAYfnM1nXfeeYfx48czbtw4hg0bZl5OtbYbVG9vb/r27cuGDRswmUx07NiR3NxcsrKyaN26tcXE3SeffBJ3d3fmz59PYWEhzZo1Izc3l82bN9OhQwdOnjxZX12Fvb0906ZNY+rUqbz55psEBgbSqFEjtm/fzuHDhwkODjYnRW3btqVdu3YkJydTUVGBl5cXeXl5bNiwgQ4dOnDs2LF77p+6CggIICMjgxUrVlBQUECvXr04d+4c69atw93d3WKFpzvp2rUroaGhLF68mJEjRzJo0CA8PDy4ePEix44dY9euXezevRuA5s2bM3nyZD788EOCgoLw9/fH09OT4uJisrOzmTFjBp06dWLAgAGsWrWKiRMnEhgYiKOjI3v27OHkyZNWoyjR0dEUFxfTr18/PD09uX79Otu3b+fq1av4+/ub63Xv3p21a9cyZ84c+vfvj4ODA926dbMYEblV9+7dSUtLIz4+nrZt22IwGPDx8bFaraourl69SlhYGAUFBYwYMYKffvrJInGEGyMe7u7uAHTo0IFhw4axdu1apk6dyrPPPsuZM2dISUmhV69eSixERETkvqjX11pHRUXRu3dvPvvsM5YvX05lZSXu7u507tzZ4qZz6NChbN++nQ0bNlBaWoqrqyudOnVi2rRpVi+yu1WPHj2Ii4sjNjaWFStW4OzsbH4BXFBQkFX92bNn89FHH7F161Y2b95Mz549SUhI4K9//SuFhYXmei4uLsTGxrJgwQLWrFlDVVUVnTt3JiYmhrS0tHpNLODGMqgLFy4kMTGRlStXUllZibe3N9OnT7d4QZ69vT0xMTHMnz+fjIwMysvLad++PTNnziQ3N9cqsahr/9SFg4MDsbGx5hfkZWZm4uLigq+vLxEREbRo0eKu2woNDaVLly6kpKSwevVqysvLadq0Ke3bt2fKlCkWdYcOHUqrVq1ITk4mJSWFyspKPDw86NOnj/m9GE8++SRz585l6dKlJCQk0KBBA/r27cvixYsJCQmxaM/Pz4/09HQ2bdrE5cuXcXJyol27dnz44Yf4+vqa6w0ePJicnBy2bdvGV199RXV1NVFRUXdMLCIiIigtLSU1NZUrV65gMpn4/PPPbUosSktLzRPz16xZU2udhIQEc2IBMHnyZFq2bMmGDRvYuXMnbm5ujBgxwvzOEBEREZH6ZjDVZb1XEfnDMXz84JbkFRH5IzJNqdffeUUeGv10KSIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNtPCySJyR4saJxEcHIyjo+PDDkVERER+xzRiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNlNiISIiIiIiNjOYTCbTww5CRH6/DB8bH3YIIiL/9kxTHB52CCL3nUYsRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZr/rxGLmzJn07t37ruoWFBTQu3dvFi1adJ+juqEusYWGhhIQEHCfI7qzuvZPTk4O4eHhDBw48IH2q4iIiIj8e9LbWsSK0Whk2rRpGI1GwsLCcHFx4fHHH3/YYT1wWVlZ5OTkMH78+LveZ9WqVbi4uNR7InnkyBG2bNnCsWPHOHHiBOXl5URFRdV6nMOHD7Ny5Upyc3O5dOkSAC1atGDQoEGMHDkSZ2fneo1NREREBH7nIxbTp09n165dDzuMP5z8/Hzy8/N54403GDFiBH5+fn/YxGLJkiV12mf16tWkp6fXeyy7du0iNTWVsrKy3/wufvrpJyoqKnj55ZeZOHEib7/9Nl27diUpKYlx48ZRUVFR7/GJiIiI2DxiUVVVRWVlJY8++mh9xGPBwcEBBwcNqjxov/zyCwCurq712q7JZKK8vJxGjRrVa7v/zkJDQwFYvHjxHesNHTqUMWPG0LBhQ7788ksOHTp027qvvPIKr7zyitX+bdu2ZcGCBXzzzTe88MILtgcvIiIicpM63bWnp6cza9Ys4uLiOHz4MOnp6Vy4cIHp06cTEBCAyWRi/fr1bNy4kTNnzmBnZ0eXLl0ICQmxmo+QkZHB2rVrycvLw2g04u7uTvfu3Zk8eTJNmjQBbsxjyMjIYP/+/Rb7fv/99yxYsICcnBycnJzw9fVlyJAht403ISHB6vihoaEUFhZa/Lq8e/du0tLS+PHHH7l48SKOjo507dqVsWPH8tRTT9Wlq+7KgQMHWLp0KUePHsVoNOLt7c2wYcN47bXXLOodOXKEdevWcejQIYqKirC3t6dDhw6MHj2agQMHWrV7t/1Tm9DQUA4cOADArFmzmDVrFgCff/45LVu2pLy8nMTERLZv305xcTGNGzemX79+hIeH4+npaW5n//79hIWFERUVRXl5OampqZw/f54///nP5keLtm3bxpo1azhx4gRVVVXmcxo0aJBVXPv372flypUcOXKE8vJyPDw8eOqpp3j77bdxc3MDIDU1laysLE6fPs3ly5dxdXWlb9++hIeH07JlS4v2du7cSXJyMqdOnaKiogI3Nze6dOlCZGQkXl5eFv1w87Vzu8ePbq5XWFhosU9N39nC3d3dpv0B8/fz66+/2tyWiIiIyK3uaTggJiYGo9FIYGAgTk5OeHl5ATBjxgy++OILfH19CQgIoLKyki1btjBhwgTmzp3L888/D8CmTZuYOXMmPXv2JCwsjAYNGlBUVMSuXbu4dOmSObGozZEjR4iIiKBRo0aMGTMGFxcXtm3bRlRU1L2cioX09HRKS0vx8/OjefPmFBcXk5aWRkREBAkJCfTs2dPmY9TYsWMHU6dOxd3dnVGjRtGoUSO2bdtGdHQ0+fn5TJgwwVw3KyuLs2fPMmjQIDw9PSktLSUjI4OpU6cSHR3NSy+9ZK5ra/+MHTuWJ554gmXLlhEYGGg+5yZNmmA0GomMjOSHH37A19eXUaNGkZeXx/r169mzZw/Jyck0b97cor3Vq1dTWlrKa6+9hru7u3n7woULSUpK4plnniEsLAw7OzsyMzN57733mDZtGsOHDze3sX79eubMmUOzZs0YMmQInp6eXLhwgW+++YaioiJzYvHpp5/SrVs3RowYgaurK6dOnWLjxo3s27ePlJQUc73vvvuOd999l/bt2xMcHIyzszMXL15k7969nDt3Di8vL8aOHYvJZOLgwYPMnj3bHEuPHj1u23ezZ89m3rx5uLm5MXbsWHP5na7n+6miosL8d+zYMT755BMcHR3p16/fQ4lHRERE/rPdU2JRUVHBqlWrLB5/yszMZMuWLbz//vu8/vrr5vKgoCCCg4P529/+ho+PDwaDgaysLJycnIiPj7d41CksLOw3jz1v3jyqq6tJTEw0JzTDhg1j3Lhx93IqFqZPn07Dhg0tyoYMGcLw4cNZtmxZvSUWVVVVzJ07l4YNG7JixQo8PDwAGD58OOPHj2fFihUEBATQpk0bAMaNG0dkZKRFG0FBQYwcOZLExESLxMLW/nn66adxcHBg2bJl9OjRAz8/P/O2zz77jB9++IHRo0czceJEc3m/fv2YNGkSsbGxfPDBBxbtXbhwgXXr1tG0aVNz2fHjx0lKSiI4ONgigQoKCmLy5MnExcXh7++Pk5MTRUVFfPzxx3h7e5OUlISLi4u5fnh4ONXV1ebPKSkpVt+fj48PERERpKWl8eabbwKQnZ1NdXU1cXFxFnG99dZbFv2wdetWDh48aNEHd+Ln50d8fDxNmza9633up4SEBD799FPz53bt2vG///u/tGrV6iFGJSIiIv+p7mny9tChQ63mVGzevBknJycGDBhASUmJ+a+srIznnnuOgoIC8vLyAHB2dqaiooKdO3diMpnu+riXLl3i0KFDPP/88+abZgBHR0dGjhx5L6di4eab0mvXrlFSUoK9vT3dunXj6NGjNrdf49ixY1y4cIFXX33VnFTAjfMYM2YM1dXVZGdn1xpXRUUFJSUlVFRU0KdPH86cOUNZWRlw//snMzMTOzs7goODLcr79+9Px44d2bFjh8WNPoC/v7/FzTvAli1bMBgM+Pv7W1wrJSUl+Pj4cPXqVQ4fPgzAl19+SWVlJSEhIRZJRQ07u39dwjX9VF1dTVlZGSUlJXTs2BFnZ2eOHDlirlezKtLXX3+N0Wi0oUfqpuaauvnPaDRiNBqtyq9du2bz8V5//XXi4uKYM2cO/8//8//wyCOPUFJSYvuJiIiIiNTinkYsan5Jv9nZs2e5evUqL7744m33u3TpEl5eXgQHB3PgwAGmTJmCq6srvXr14tlnn+WFF17Aycnptvvn5+cD4O3tbbWtXbt2dT+RW5w/f564uDh2797NlStXLLYZDAab269RUFAA1B5z+/btgX+dK9zot/j4eLKzs83Lh96srKwMZ2fn+94/BQUFeHh40Lhx41rjzs3NpaSkxCKRqO1aOXPmDCaTiaFDh972WDUTyM+dOwdAp06dfjO+ffv2sWTJEo4ePcr169cttt38fQ4fPpzs7GzmzJnDJ598whNPPMEzzzzD4MGD7+tjS3PnziUjI6PWbbfOK3nllVeYOXOmTcdr06aNuf8HDRrEt99+y//8z/8AWIxyiYiIiNSHe0osalsBymQy0aRJE6Kjo2+7X81Nc5s2bUhNTWXv3r3s27ePAwcOEB0dzaJFi1iyZEm9Papxp2SgqqrK4vO1a9cICQmhvLycN954gw4dOuDk5ITBYGD58uXs27evXmKqK5PJRGRkJGfOnCEoKIguXbrg7OyMnZ0d6enpbN261WqU4PfkdquFGQwGFixYYDHicLOaa+VuHT16lMjISFq1akVkZCQtW7akQYMGGAwG3n//fYs+cnNzIzk5mYMHD7Jnzx4OHjzIvHnzWLRoETExMXecR2GLMWPG8PLLL1uUzZ8/H4BJkyZZlN88klVf/s//+T+4u7uzbt06JRYiIiJS7+ptLdfWrVuTl5dH9+7d72o50UceeYT+/fvTv39/4MYqPZMmTeLvf/87f/nLX2rdp2ZlnbNnz1ptO336tFVZzS/rta2CU1BQYDG/Y+/evfz888/MmDGDV1991aJufHz8b55PXTz22GNA7THXlNXUOXHiBLm5uYSEhFi9qG3jxo0Wn+vaP3X12GOP8e2333LlyhWrx5JOnz6Nk5OTeYL0nbRu3Zp//OMftGjRgrZt296xbs0v7rm5uRaPd91q69atVFVVsWDBAnPfAZSXl1uNPgHY29vTu3dv8+pNJ06cYNSoUSQmJhITEwPc2yjVnfZp166d1chRTT8+qAnV169f16pQIiIicl/U2wvy/P39qa6uJjY2ttbtNY+2ALU+5925c2cASktLb3uMmiVps7Oz+emnn8zllZWVrFq1yqp+zU3p3r17Lcq3bt3Kzz//bFFmb28PYDXnY/fu3RbP59eHzp0706JFC9LT07l48aK53Gg0snLlSgwGg3kFrZpf9G+N6+TJk2RlZVmU1bV/6mrAgAFUV1ezfPlyi/Jdu3aRk5ODj4/PbUcgblYzsTkuLs5q5AgsrxVfX18cHR1ZsmSJeS7JzWr65XbfX1JSktWITm3Xn7e3N48++qjFTXfNnI07XZO3atiw4UO/cb/5mrpZRkYGZWVldOvW7QFHJCIiIn8E9TZiMWjQIAICAli7di3Hjx/nueeew83NjeLiYg4dOsT58+dJS0sDYMKECbi4uNCzZ0+aN2/OlStXSE9Px2Aw/OZqOu+88w7jx49n3LhxDBs2zLycam03qN7e3vTt25cNGzZgMpno2LEjubm5ZGVl0bp1a4uJu08++STu7u7Mnz+fwsJCmjVrRm5uLps3b6ZDhw6cPHmyvroKe3t7pk2bxtSpU3nzzTcJDAykUaNGbN++ncOHDxMcHGxOitq2bUu7du1ITk6moqICLy8v8vLy2LBhAx06dODYsWP33D91FRAQQEZGBitWrKCgoIBevXpx7tw51q1bh7u7u8UKT3fStWtXQkNDWbx4MSNHjmTQoEF4eHhw8eJFjh07xq5du9i9ezcAzZs3Z/LkyXz44YcEBQXh7++Pp6cnxcXFZGdnM2PGDDp16sSAAQNYtWoVEydOJDAwEEdHR/bs2cPJkyetRlGio6MpLi6mX79+eHp6cv36dbZv387Vq1fx9/c31+vevTtr165lzpw59O/fHwcHB7p162YxInKr7t27k5aWRnx8PG3btsVgMODj42O1WlVdFRYWsmnTJuBfo087duygqKgIwNwvABMnTsTV1ZUePXrQokULysrK+P7778nOzqZ58+bml/KJiIiI1Kd6fa11VFQUvXv35rPPPmP58uVUVlbi7u5O586dLW46hw4dyvbt29mwYQOlpaW4urrSqVMnpk2bZvUiu1v16NGDuLg4YmNjWbFiBc7OzuYXwAUFBVnVnz17Nh999BFbt25l8+bN9OzZk4SEBP76179SWFhorufi4kJsbCwLFixgzZo1VFVV0blzZ2JiYkhLS6vXxAJuLIO6cOFCEhMTWblyJZWVlXh7ezN9+nSLF+TZ29sTExPD/PnzycjIoLy8nPbt2zNz5kxyc3OtEou69k9dODg4EBsba35BXmZmJi4uLvj6+hIREUGLFi3uuq3Q0FC6dOlCSkoKq1evpry8nKZNm9K+fXumTJliUXfo0KG0atWK5ORkUlJSqKysxMPDgz59+pjfi/Hkk08yd+5cli5dSkJCAg0aNKBv374sXryYkJAQi/b8/PxIT09n06ZNXL58GScnJ9q1a8eHH36Ir6+vud7gwYPJyclh27ZtfPXVV1RXVxMVFXXHxCIiIoLS0lJSU1O5cuUKJpOJzz//3ObEIj8/n4SEBIuyzMxMMjMzzedfk1gEBgby9ddfs3HjRkpKSnBwcKBVq1a8+eabjBo16q4eVxMRERGpK4OpLuu9isgfjuHjB7ckr4jIfyrTlHr9LVfkd6ne5liIiIiIiMgflxILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmdY+E5E7WtQ4ieDgYBwdHR92KCIiIvI7phELERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmcFkMpkedhAi8vtl+Nj4sEMQEfm3ZZri8LBDEHlgNGIhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI2+49KLGbOnEnv3r3vqm5BQQG9e/dm0aJF9zmqG+oSW2hoKAEBAfc5ojura//k5OQQHh7OwIEDH2i/ioiIiMjvgxZXFpsZjUamTZuG0WgkLCwMFxcXHn/88Ycd1gOXlZVFTk4O48ePv+t9Vq1ahYuLS70nkkeOHGHLli0cO3aMEydOUF5eTlRU1ENPWEVEROQ/13/UiMX06dPZtWvXww7jDyc/P5/8/HzeeOMNRowYgZ+f3x82sViyZEmd9lm9ejXp6en1HsuuXbtITU2lrKzsD/ldiIiIyIP3wEcsqqqqqKys5NFHH633th0cHHBw0CDMg/bLL78A4OrqWq/tmkwmysvLadSoUb22++8sNDQUgMWLF9+x3tChQxkzZgwNGzbkyy+/5NChQw8iPBEREfkDu6934enp6cyaNYu4uDgOHz5Meno6Fy5cYPr06QQEBGAymVi/fj0bN27kzJkz2NnZ0aVLF0JCQqzmI2RkZLB27Vry8vIwGo24u7vTvXt3Jk+eTJMmTYAb8xgyMjLYv3+/xb7ff/89CxYsICcnBycnJ3x9fRkyZMht401ISLA6fmhoKIWFhRa/Lu/evZu0tDR+/PFHLl68iKOjI127dmXs2LE89dRT9dWNZgcOHGDp0qUcPXoUo9GIt7c3w4YN47XXXrOod+TIEdatW8ehQ4coKirC3t6eDh06MHr0aAYOHGjV7t32T21CQ0M5cOAAALNmzWLWrFkAfP7557Rs2ZLy8nISExPZvn07xcXFNG7cmH79+hEeHo6np6e5nf379xMWFkZUVBTl5eWkpqZy/vx5/vznP5sfLdq2bRtr1qzhxIkTVFVVmc9p0KBBVnHt37+flStXcuTIEcrLy/Hw8OCpp57i7bffxs3NDYDU1FSysrI4ffo0ly9fxtXVlb59+xIeHk7Lli0t2tu5cyfJycmcOnWKiooK3Nzc6NKlC5GRkXh5eVn0w83Xzp0eP6qpV1hYaLFPTd/Zwt3d3ab9RUREROrqgfy8HxMTg9FoJDAwECcnJ7y8vACYMWMGX3zxBb6+vgQEBFBZWcmWLVuYMGECc+fO5fnnnwdg06ZNzJw5k549exIWFkaDBg0oKipi165dXLp0yZxY1ObIkSNERETQqFEjxowZg4uLC9u2bSMqKsrm80pPT6e0tBQ/Pz+aN29OcXExaWlpREREkJCQQM+ePW0+Ro0dO3YwdepU3N3dGTVqFI0aNWLbtm1ER0eTn5/PhAkTzHWzsrI4e/YsgwYNwtPTk9LSUjIyMpg6dSrR0dG89NJL5rq29s/YsWN54oknWLZsGYGBgeZzbtKkCUajkcjISH744Qd8fX0ZNWoUeXl5rF+/nj179pCcnEzz5s0t2lu9ejWlpaW89tpruLu7m7cvXLiQpKQknnnmGcLCwrCzsyMzM5P33nuPadOmMXz4cHMb69evZ86cOTRr1owhQ4bg6enJhQsX+OabbygqKjInFp9++indunVjxIgRuLq6curUKTZu3Mi+fftISUkx1/vuu+949913ad++PcHBwTg7O3Px4kX27t3LuXPn8PLyYuzYsZhMJg4ePMjs2bPNsfTo0eO2fTd79mzmzZuHm5sbY8eONZff6XoWERER+b16IIlFRUUFq1atsnj8KTMzky1btvD+++/z+uuvm8uDgoIIDg7mb3/7Gz4+PhgMBrKysnByciI+Pt7iUaewsLDfPPa8efOorq4mMTHRnNAMGzaMcePG2Xxe06dPp2HDhhZlQ4YMYfjw4SxbtqzeEouqqirmzp1Lw4YNWbFiBR4eHgAMHz6c8ePHs2LFCgICAmjTpg0A48aNIzIy0qKNoKAgRo4cSWJiokViYWv/PP300zg4OLBs2TJ69OiBn5+fedtnn33GDz/8wOjRo5k4caK5vF+/fkyaNInY2Fg++OADi/YuXLjAunXraNq0qbns+PHjJCUlERwcbJFABQUFMXnyZOLi4vD398fJyYmioiI+/vhjvL29SUpKwsXFxVw/PDyc6upq8+eUlBSr78/Hx4eIiAjS0tJ48803AcjOzqa6upq4uDiLuN566y2Lfti6dSsHDx606IM78fPzIz4+nqZNm971PiIiIiK/Vw9k8vbQoUOt5lRs3rwZJycnBgwYQElJifmvrKyM5557joKCAvLy8gBwdnamoqKCnTt3YjKZ7vq4ly5d4tChQzz//PPmm2YAR0dHRo4cafN53XxTeu3aNUpKSrC3t6dbt24cPXrU5vZrHDt2jAsXLvDqq6+akwq4cR5jxoyhurqa7OzsWuOqqKigpKSEiooK+vTpw5kzZygrKwPuf/9kZmZiZ2dHcHCwRXn//v3p2LEjO3bssLjRB/D397e4eQfYsmULBoMBf39/i2ulpKQEHx8frl69yuHDhwH+f+3deVxO6f8/8Nddqai7IjcKFSX7HhljGpSt8GE0trHFiBpLlvGZxcduJsYYIUsRskW2hBpbMmJM9mVsI42khWh1K3ed3x9+9/l2u+9S3ZHl9Xw8eqjrXOec6zrn3LfzPtdycPToUbx48QJjx45VCSqUdHT+75JXHqeCggJkZ2cjPT0d9vb2MDY2xrVr18R8xsbGAIDjx49DoVBocURKR3lNFf5RKBRQKBRq6c+ePXtr5SIiIiLS5K20WCifpBcWHx+PnJwcdO/evcj1njx5Amtra3h4eODChQuYPn06TE1N0aZNG3z66afo1q0bjIyMilw/MTERAGBjY6O2rH79+qWvyCsePHgAf39//Pnnn8jKylJZJpFItN6+0sOHDwFoLrOtrS2A/6sr8PK4rV69GtHR0Xjy5InaOtnZ2TA2Nn7jx+fhw4eQyWQwMTHRWO7bt28jPT1dJZDQdK3cu3cPgiDA3d29yH0pB5AnJCQAABo2bPja8sXGxiIwMBDXr19Hbm6uS4GTDgAAak9JREFUyrLC53PgwIGIjo6Gr68vVqxYgZYtW6Jjx47o0aPHG+22tHjxYhw4cEDjslfHlfTu3Rtz5sx5Y2UhIiIiep23ElhomgFKEARUrVoVCxYsKHI95U2zlZUVQkND8ddffyE2NhYXLlzAggULsHbtWgQGBqJOnTrlUs7igoH8/HyVv589e4axY8dCLpdjyJAhsLOzg5GRESQSCTZu3IjY2NhyKVNpCYKACRMm4N69exg8eDCaNGkCY2Nj6OjoIDw8HJGRkWqtBO+SomYLk0gkWL58uUqLQ2HKa6Wkrl+/jgkTJqBOnTqYMGECLC0tYWBgAIlEgh9++EHlGJmZmSE4OBgXL17E2bNncfHiRSxduhRr166Fn59fseMotDFixAj06tVLJW3ZsmUAAB8fH5X0wi1ZRERERBWhwuZmrVu3Lu7fv4/mzZuXaDpRfX19dOrUCZ06dQLwcpYeHx8fbN26Ff/97381rqOcWSc+Pl5tWVxcnFqa8sl6Zmam2rKHDx+qjO/466+/8OjRI8yaNQt9+/ZVybt69erX1qc0ateuDUBzmZVpyjx37tzB7du3MXbsWLUXte3bt0/l79Ien9KqXbs2zpw5g6ysLLVuSXFxcTAyMhIHSBenbt26OH36NGrVqoV69eoVm1fZ4nH79m2V7l2vioyMRH5+PpYvXy4eOwCQy+VqrU8AoKurCwcHB3H2pjt37mDYsGFYv349/Pz8AJStlaq4derXr6/WcqQ8jo6OjqXeFxEREdGbVGEvyHNzc0NBQQFWrlypcbmyawsApKenqy1v1KgRACAjI6PIfSinpI2Ojsa///4rpr948QLbtm1Ty6+8Kf3rr79U0iMjI/Ho0SOVNF1dXQBQG/Px559/qvTPLw+NGjVCrVq1EB4ejsePH4vpCoUCmzdvhkQiEWfQUj7Rf7Vc//zzD06cOKGSVtrjU1qdO3dGQUEBNm7cqJIeExODW7duwcnJqcgWiMKUA5v9/f3VWo4A1WvF2dkZlSpVQmBgoDiWpDDlcSnq/AUFBam16Gi6/mxsbGBoaKgShCrHbBR3Tb6qcuXKGgNZIiIiovdNhbVYuLi4oE+fPti5cydu3ryJzz77DGZmZkhNTcWVK1fw4MEDhIWFAQC++eYbSKVStG7dGjVr1kRWVhbCw8MhkUheO5vOlClTMG7cOIwZMwZffvmlOJ2qphtUGxsbtG/fHnv27IEgCLC3t8ft27dx4sQJ1K1bV2XgbqtWrWBubo5ly5YhKSkJNWrUwO3bt3Ho0CHY2dnhn3/+KbdjpaurixkzZuDbb7/FyJEj0b9/f1SpUgVHjhzB1atX4eHhIQZF9erVQ/369REcHIznz5/D2toa9+/fx549e2BnZ4cbN26U+fiUVp8+fXDgwAFs2rQJDx8+RJs2bZCQkIBdu3bB3NxcZYan4jRt2hSenp4ICAjA0KFD4eLiAplMhsePH+PGjRuIiYnBn3/+CQCoWbMmpk2bhkWLFmHw4MFwc3ODhYUFUlNTER0djVmzZqFhw4bo3Lkztm3bhsmTJ6N///6oVKkSzp49i3/++UetFWXBggVITU2Fo6MjLCwskJubiyNHjiAnJwdubm5ivubNm2Pnzp3w9fVFp06doKenh2bNmqm0iLyqefPmCAsLw+rVq1GvXj1IJBI4OTmpzVZVWklJSTh48CCA/2t9OnnyJFJSUgBAPC5ERERE5aVCX1M9e/ZsODg4YO/evdi4cSNevHgBc3NzNGrUSOWm093dHUeOHMGePXuQkZEBU1NTNGzYEDNmzFB7kd2rWrRoAX9/f6xcuRKbNm2CsbGx+AK4wYMHq+WfN28efvnlF0RGRuLQoUNo3bo11qxZg59//hlJSUliPqlUipUrV2L58uXYsWMH8vPz0ahRI/j5+SEsLKxcAwvg5TSoq1atwvr167F582a8ePECNjY2mDlzpsoL8nR1deHn54dly5bhwIEDkMvlsLW1xZw5c3D79m21wKK0x6c09PT0sHLlSvEFeVFRUZBKpXB2doa3tzdq1apV4m15enqiSZMmCAkJwfbt2yGXy1GtWjXY2tpi+vTpKnnd3d1Rp04dBAcHIyQkBC9evIBMJkO7du3E92K0atUKixcvxrp167BmzRoYGBigffv2CAgIwNixY1W25+rqivDwcBw8eBBPnz6FkZER6tevj0WLFsHZ2VnM16NHD9y6dQuHDx/GsWPHUFBQgNmzZxcbWHh7eyMjIwOhoaHIysqCIAjYv3+/1oFFYmIi1qxZo5IWFRWFqKgosf4MLIiIiKg8SYTSzN9KRB8dyZK3N8UuEdGHRpheoc9wid6qChtjQUREREREHw4GFkREREREpDUGFkREREREpDUGFkREREREpDUGFkREREREpDUGFkREREREpDUGFkREREREpDVOrkxExVprEgQPDw9UqlSpootCRERE7zC2WBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYYWBARERERkdYkgiAIFV0IInp3SZYoKroIRETvHWG6XkUXgeitY4sFERERERFpjYEFERERERFpjYEFERERERFpjYEFERERERFpjYEFERERERFpjYEFERERERFpjYEFERERERFpjYHFO+jcuXNwcHBAeHh4hZXh1q1b8PLyQpcuXeDg4IC1a9dWWFmIiIiI6N3Ht7eQGoVCgRkzZkChUGD8+PGQSqVo0KBBRRfrrTtx4gRu3bqFcePGlXidbdu2QSqVok+fPuValmvXriEiIgI3btzAnTt3IJfLMXv2bI37uXnzJiIjIxEbG4uHDx8CAOrWrYs+ffqgf//+0NPjx56IiIjKH+8w3kFt2rRBTExMhd0AJiYmIjExET4+Phg0aFCFlOFdcOLECRw4cKBUgcX27dthYWFR7oFFTEwMQkNDYWNjgwYNGuDKlStF5t20aRP++usvdO7cGf3790d+fj5OnTqFRYsWITo6GitWrIBEIinX8hERERExsHiH5OTkwMjICDo6OjAwMKiwcqSlpQEATE1Ny3W7giBALpejSpUq5brd95mnpycAICAgoNh87u7uGDFiBCpXroyjR48WG1gMGjQIc+bMUbmGBg0ahP/973+IiIjAqVOn8Nlnn5VPBYiIiIj+PwYW5SQ8PBxz586Fv78/Ll26hPDwcKSlpcHa2hoeHh7o0aOHSv4+ffrAwsICU6dOxcqVK3H16lWYmppi//79OHfuHMaPH6/W1UUQBOzbtw/79u1DXFwcAMDS0hJdunTB+PHjxXx5eXnYsmULIiMj8eDBA+jr66N169YYN24cGjVqVGw9PD09ceHCBQDA3LlzMXfuXADA/v37YWlpCblcjvXr1+PIkSNITU2FiYkJHB0d4eXlBQsLC3E7hesgl8sRGhqKBw8eYNSoUWILwOHDh7Fjxw7cuXMH+fn5sLOzw/Dhw+Hi4qJWrnPnzmHz5s24du0a5HI5ZDIZ2rZti0mTJsHMzAwAEBoaihMnTiAuLg5Pnz6Fqakp2rdvDy8vL1haWqps79SpUwgODsbdu3fx/PlzmJmZoUmTJpgwYQKsra1VjoODg4O4XlHdjwrnS0pKUllHeey0YW5uXuK8rVq10pjerVs3RERE4O7duwwsiIiIqNwxsChnK1asgFwuh7u7O4CXAcePP/6IvLw8tRvSlJQUeHl5wcXFBV27dsWzZ8+K3fasWbMQERGBZs2aYfTo0ZBKpYiPj8exY8fEwEKhUGDixIm4cuUKXF1dMXDgQGRnZ2Pv3r0YM2YMAgMD0aRJkyL3MXr0aLRs2RIbNmxA//790bp1awBA1apVoVAoMGHCBFy+fBnOzs4YNmwY7t+/j927d+Ps2bMIDg5GzZo1Vba3fft2ZGRkoF+/fjA3NxeXr1q1CkFBQejYsSPGjx8PHR0dREVF4bvvvsOMGTMwcOBAcRu7d++Gr68vatSogQEDBsDCwgLJycn4448/kJKSIgYWW7ZsQbNmzTBo0CCYmpri7t272LdvH2JjYxESEiLmO3/+PKZOnQpbW1t4eHjA2NgYjx8/xl9//YWEhARYW1tj9OjREAQBFy9exLx588SytGjRoshjN2/ePCxduhRmZmYYPXq0mF61atViz+vbkpqaCgCoVq1aBZeEiIiIPkQMLMpZeno6QkJCYGxsDOBlF5bBgwfjt99+Q7du3WBoaCjmTUxMxMyZM9GvX7/XbvfIkSOIiIhAr169MHfuXOjo/N+EXgUFBeLvO3bswPnz57FixQp88sknYrq7uzsGDRqEZcuWFdvtpkOHDtDT08OGDRvQokULuLq6isv27t2Ly5cvY/jw4Zg8ebKY7ujoCB8fH6xcuRLz589X2V5ycjJ27dqlcjN78+ZNBAUFwcPDA998842YPnjwYEybNg3+/v5wc3ODkZERUlJSsGTJEtjY2CAoKAhSqVTM7+XlpVL3kJAQVK5cWWX/Tk5O8Pb2RlhYGEaOHAkAiI6ORkFBAfz9/VXK9fXXX6sch8jISFy8eFHlGBTH1dUVq1evRrVq1Uq8ztvy7NkzbN68GcbGxvj8888rujhERET0AeJ0s+XM3d1dDCoAwNjYGAMGDEBmZibOnz+vktfU1LTEg3wjIiIAAD4+PipBBQCVvyMiImBjY4PGjRsjPT1d/FEoFHB0dMTly5fx/PnzMtUtKioKOjo68PDwUEnv1KkT7O3tcfLkSZUbfQBwc3NTe0IeEREBiUQCNzc3lTKmp6fDyckJOTk5uHr1KgDg6NGjePHiBcaOHasSVGiquzKoKCgoQHZ2NtLT02Fvbw9jY2Ncu3ZNzKc8P8ePH4dCoSjTsSiLZ8+eqdVXoVBAoVCopb+u9ao08vPz8b///Q+JiYn47rvvyn3sDBERERHAFotyZ2Njo5ZWr149AC9bKAqrXbs2dHV1S7TdhIQEVK9e/bV97e/du4fc3FyN4xSU0tPTUatWrRLtt7CHDx9CJpPBxMREbZmtrS1u376N9PR0lUDCyspKYxkFQRC7i2miHECekJAAAGjYsOFryxcbG4vAwEBcv34dubm5KsuysrLE3wcOHIjo6Gj4+vpixYoVaNmyJTp27IgePXq80W5LixcvxoEDBzQue/V89e7dG3PmzNF6nwUFBZg3bx6io6Ph7e2Nnj17ar1NIiIiIk0YWFSgwt2iypOdnR2mTJlS5PK32ee/qDpKJBIsX75crfVFydbWtlT7uX79OiZMmIA6depgwoQJsLS0hIGBASQSCX744QeVlhQzMzMEBwfj4sWLOHv2LC5evIilS5di7dq18PPzK3YchTZGjBiBXr16qaQtW7YMwMuWqMJkMpnW+ysoKMD8+fNx8OBBjB07VmXcBxEREVF5Y2BRzuLj49XS7t27B+BlC0VZWVlZITo6GmlpacW2WtStWxdPnz5Fu3btirxpL6vatWvjzJkzyMrKUuuWFBcXByMjI3GAdHHq1q2L06dPo1atWmJrTlGULR63b9+GtbV1kfkiIyORn5+P5cuXqxxnuVyu0lqhpKurCwcHB3H2pjt37mDYsGFYv349/Pz8AKBM73oobp369eujfv36KmnK4+jo6FjqfRVHGVSEh4djzJgxpXoXBxEREVFZcIxFOdu1axeys7PFv7Ozs7F7925IpVK0bdu2zNtVPulevny52jgGQRDE393c3JCWloatW7dq3I6yi1FZdO7cGQUFBdi4caNKekxMDG7dugUnJ6cSBTPKgc3+/v7Iz88vtozOzs6oVKkSAgMDVY6rkrLuyi5lhY8FAAQFBakdr/T0dLXt2NjYwNDQEJmZmWKacsxGRkbGa+tUeJ3C26gIgiBgwYIFCA8Ph4eHB7y8vCq0PERERPRxYItFOTMzM8PIkSPFQdnh4eFITk7GzJkzter65OLigm7duuHgwYNISEiAk5MTpFIp7t+/jzNnzmDnzp0AgCFDhuDs2bPw8/NDbGws2rVrByMjIyQnJyM2Nhb6+vpYu3ZtmcrQp08fHDhwAJs2bcLDhw/Rpk0bJCQkYNeuXTA3N1eZ4ak4TZs2haenJwICAjB06FC4uLhAJpPh8ePHuHHjBmJiYvDnn38CAGrWrIlp06Zh0aJFGDx4MNzc3GBhYYHU1FRER0dj1qxZaNiwITp37oxt27Zh8uTJ6N+/PypVqoSzZ8/in3/+UWtFWbBgAVJTU+Ho6AgLCwvk5ubiyJEjyMnJgZubm5ivefPm2LlzJ3x9fdGpUyfo6emhWbNmxbY8NW/eHGFhYVi9ejXq1asHiUQCJycntdmqSispKQkHDx4EAPEdJidPnkRKSgoAiMcFAPz8/LB//37Y29ujXr16OHTokMq26tSp88a6exEREdHHi4FFOZs4cSIuXbqE0NBQPHnyBFZWVliwYEG5DJpduHAhWrdujbCwMAQGBkJXVxeWlpYqA3/19PSwbNky7Nq1C4cOHRKDCJlMhqZNm6J3795l3r+enh5WrlwpviAvKioKUqkUzs7O8Pb2LtWAcE9PTzRp0gQhISHYvn075HI5qlWrBltbW0yfPl0lr7u7O+rUqYPg4GCEhITgxYsXkMlkaNeunfhejFatWmHx4sVYt24d1qxZAwMDA7Rv3x4BAQEYO3asyvZcXV0RHh6OgwcP4unTpzAyMkL9+vWxaNEiODs7i/l69OiBW7du4fDhwzh27BgKCgowe/bsYgMLb29vZGRkIDQ0FFlZWRAEAfv379c6sEhMTMSaNWtU0qKiohAVFSXWXxlY/P333wBedh+bNWuW2rZ69+7NwIKIiIjKnUR4te8IlYnyzdtr1qxReesy0ftOsuTtTclLRPShEKbz2S19fDjGgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMYxFkRULI6xICIqPY6xoI8RWyyIiIiIiEhrDCyIiIiIiEhrbKcjomKtNQmCh4cHKlWqVNFFISIioncYWyyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhrEkEQhIouBBG9uyRLFBVdBCKid5IwXa+ii0D0TmGLBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BxTvo3LlzcHBwQHh4eIWV4datW/Dy8kKXLl3g4OCAtWvXVlhZiIiIiOjdxwmYSY1CocCMGTOgUCgwfvx4SKVSNGjQoKKL9dadOHECt27dwrhx40q8zrZt2yCVStGnT59yLcu1a9cQERGBGzdu4M6dO5DL5Zg9e7bG/Tx79gxbtmzBjRs3cOvWLaSmpqJNmzYICAgo1zIRERERFcYWi3dQmzZtEBMTA1dX1wrZf2JiIhITEzFkyBAMGjQIrq6uH21gERgYWKp1tm/f/kZammJiYhAaGors7OzXnov09HQEBATg77//RoMGDaCrq1vu5SEiIiJ6FVss3iE5OTkwMjKCjo4ODAwMKqwcaWlpAABTU9Ny3a4gCJDL5ahSpUq5bvd95unpCQCvbU1wd3fHiBEjULlyZRw9ehRXrlwpMm/16tVx8OBB1KxZEwDw2WeflV+BiYiIiIrAwKKchIeHY+7cufD398elS5cQHh6OtLQ0WFtbw8PDAz169FDJ36dPH1hYWGDq1KlYuXIlrl69ClNTU+zfvx/nzp3D+PHj1bq6CIKAffv2Yd++fYiLiwMAWFpaokuXLhg/fryYLy8vD1u2bEFkZCQePHgAfX19tG7dGuPGjUOjRo2KrYenpycuXLgAAJg7dy7mzp0LANi/fz8sLS0hl8uxfv16HDlyBKmpqTAxMYGjoyO8vLxgYWEhbqdwHeRyOUJDQ/HgwQOMGjVK7Fp0+PBh7NixA3fu3EF+fj7s7OwwfPhwuLi4qJXr3Llz2Lx5M65duwa5XA6ZTIa2bdti0qRJMDMzAwCEhobixIkTiIuLw9OnT2Fqaor27dvDy8sLlpaWKts7deoUgoODcffuXTx//hxmZmZo0qQJJkyYAGtra5Xj4ODgIK5XVPejwvmSkpJU1lEeO22Ym5uXOK++vr4YVBARERG9LQwsytmKFSsgl8vh7u4O4GXA8eOPPyIvL0/thjQlJQVeXl5wcXFB165d8ezZs2K3PWvWLERERKBZs2YYPXo0pFIp4uPjcezYMTGwUCgUmDhxIq5cuQJXV1cMHDgQ2dnZ2Lt3L8aMGYPAwEA0adKkyH2MHj0aLVu2xIYNG9C/f3+0bt0aAFC1alUoFApMmDABly9fhrOzM4YNG4b79+9j9+7dOHv2LIKDg9VuaLdv346MjAz069cP5ubm4vJVq1YhKCgIHTt2xPjx46Gjo4OoqCh89913mDFjBgYOHChuY/fu3fD19UWNGjUwYMAAWFhYIDk5GX/88QdSUlLEwGLLli1o1qwZBg0aBFNTU9y9exf79u1DbGwsQkJCxHznz5/H1KlTYWtrCw8PDxgbG+Px48f466+/kJCQAGtra4wePRqCIODixYuYN2+eWJYWLVoUeezmzZuHpUuXwszMDKNHjxbTq1atWux5JSIiIvoQMLAoZ+np6QgJCYGxsTGAl11YBg8ejN9++w3dunWDoaGhmDcxMREzZ85Ev379XrvdI0eOICIiAr169cLcuXOho/N/w2MKCgrE33fs2IHz589jxYoV+OSTT8R0d3d3DBo0CMuWLSu2202HDh2gp6eHDRs2oEWLFirjPPbu3YvLly9j+PDhmDx5spju6OgIHx8frFy5EvPnz1fZXnJyMnbt2oVq1aqJaTdv3kRQUBA8PDzwzTffiOmDBw/GtGnT4O/vDzc3NxgZGSElJQVLliyBjY0NgoKCIJVKxfxeXl4qdQ8JCUHlypVV9u/k5ARvb2+EhYVh5MiRAIDo6GgUFBTA399fpVxff/21ynGIjIzExYsXSzzWxdXVFatXr0a1atUqbHwMERERUUXh4O1y5u7uLgYVAGBsbIwBAwYgMzMT58+fV8lrampa4tmDIiIiAAA+Pj4qQQUAlb8jIiJgY2ODxo0bIz09XfxRKBRwdHTE5cuX8fz58zLVLSoqCjo6OvDw8FBJ79SpE+zt7XHy5EmVG30AcHNzU7l5V5ZRIpHAzc1NpYzp6elwcnJCTk4Orl69CgA4evQoXrx4gbFjx6oEFZrqrgwqCgoKkJ2djfT0dNjb28PY2BjXrl0T8ynPz/Hjx6FQKMp0LMri2bNnavVVKBRQKBRq6a9rvSIiIiJ617DFopzZ2NiopdWrVw/AyxaKwmrXrl3iGXsSEhJQvXr11/a1v3fvHnJzczWOU1BKT09HrVq1SrTfwh4+fAiZTAYTExO1Zba2trh9+zbS09NVAgkrKyuNZRQEQewupolyAHlCQgIAoGHDhq8tX2xsLAIDA3H9+nXk5uaqLMvKyhJ/HzhwIKKjo+Hr64sVK1agZcuW6NixI3r06PFGuy0tXrwYBw4c0Ljs1fPVu3dvzJkz542VhYiIiKi8MbCoQIW7RZUnOzs7TJkypcjlb7PPf1F1lEgkWL58uVrri5KtrW2p9nP9+nVMmDABderUwYQJE2BpaQkDAwNIJBL88MMPKi0pZmZmCA4OxsWLF3H27FlcvHgRS5cuxdq1a+Hn51fsOAptjBgxAr169VJJW7ZsGYCXLVGFyWSyN1IGIiIiojeFgUU5i4+PV0u7d+8egJctFGVlZWWF6OhopKWlFdtqUbduXTx9+hTt2rUr8qa9rGrXro0zZ84gKytLrVtSXFwcjIyMxAHSxalbty5Onz6NWrVqia05RVG2eNy+fRvW1tZF5ouMjER+fj6WL1+ucpzlcrlKa4WSrq4uHBwcxNmb7ty5g2HDhmH9+vXw8/MD8DL4Ka3i1qlfvz7q16+vkqY8jo6OjqXeFxEREdG7hGMsytmuXbuQnZ0t/p2dnY3du3dDKpWibdu2Zd6u8kn38uXL1cYxCIIg/u7m5oa0tDRs3bpV43aUXYzKonPnzigoKMDGjRtV0mNiYnDr1i04OTmVKJhRDmz29/dHfn5+sWV0dnZGpUqVEBgYqHJclZR1V3YpK3wsACAoKEjteKWnp6ttx8bGBoaGhsjMzBTTlGM2MjIyXlunwusU3gYRERHRx4ItFuXMzMwMI0eOFAdlh4eHIzk5GTNnztSq65OLiwu6deuGgwcPIiEhAU5OTpBKpbh//z7OnDmDnTt3AgCGDBmCs2fPws/PD7GxsWjXrh2MjIyQnJyM2NhY6OvrY+3atWUqQ58+fXDgwAFs2rQJDx8+RJs2bZCQkIBdu3bB3NxcZYan4jRt2hSenp4ICAjA0KFD4eLiAplMhsePH+PGjRuIiYnBn3/+CQCoWbMmpk2bhkWLFmHw4MFwc3ODhYUFUlNTER0djVmzZqFhw4bo3Lkztm3bhsmTJ6N///6oVKkSzp49i3/++UetFWXBggVITU2Fo6MjLCwskJubiyNHjiAnJwdubm5ivubNm2Pnzp3w9fVFp06doKenh2bNmhXb8tS8eXOEhYVh9erVqFevHiQSCZycnNRmqyqtpKQkHDx4EADEd5icPHkSKSkpACAeF6UdO3aILTUKhQLJyclYt24dAMDe3h5OTk5alYeIiIjoVQwsytnEiRNx6dIlhIaG4smTJ7CyssKCBQvQs2dPrbe9cOFCtG7dGmFhYQgMDISuri4sLS1VBv7q6elh2bJl2LVrFw4dOiQGETKZDE2bNkXv3r3LvH89PT2sXLlSfEFeVFQUpFIpnJ2d4e3tXaoB4Z6enmjSpAlCQkKwfft2yOVyVKtWDba2tpg+fbpKXnd3d9SpUwfBwcEICQnBixcvIJPJ0K5dO/G9GK1atcLixYuxbt06rFmzBgYGBmjfvj0CAgIwduxYle25uroiPDwcBw8exNOnT2FkZIT69etj0aJFcHZ2FvP16NEDt27dwuHDh3Hs2DEUFBRg9uzZxQYW3t7eyMjIQGhoKLKysiAIAvbv3691YJGYmIg1a9aopEVFRSEqKkqsf+HAYsuWLUhKShL/fvjwobh+7969GVgQERFRuZMIr/YdoTJRvnl7zZo1Km9dJnrfSZa8vSl5iYjeJ8J0Pp8lKoxjLIiIiIiISGsMLIiIiIiISGsMLIiIiIiISGscY0FExeIYCyIizTjGgkgVWyyIiIiIiEhrDCyIiIiIiEhrDCyIiIiIiEhr7BxIRMVaaxIEDw8PVKpUqaKLQkRERO8wtlgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWGFgQEREREZHWJIIgCBVdCCJ6d0mWKCq6CEREpSZM16voIhB9dNhiQUREREREWmNgQUREREREWmNgQUREREREWmNgQUREREREWmNgQUREREREWmNgQUREREREWmNgQUREREREWmNg8Q46d+4cHBwcEB4eXmFluHXrFry8vNClSxc4ODhg7dq1FVYWIiIiInr38e0xpEahUGDGjBlQKBQYP348pFIpGjRoUNHFeutOnDiBW7duYdy4cSVeZ9u2bZBKpejTp0+5luXatWuIiIjAjRs3cOfOHcjlcsyePbvI/eTl5SEoKAiHDh3Co0ePUKNGDfTp0wejRo2Cnh4/9kRERFT+eIfxDmrTpg1iYmIq7AYwMTERiYmJ8PHxwaBBgyqkDO+CEydO4MCBA6UKLLZv3w4LC4tyDyxiYmIQGhoKGxsbNGjQAFeuXCk2//fff4/o6Gj07dsXLVq0wJUrV7BmzRo8ePAAc+bMKdeyEREREQEMLN4pOTk5MDIygo6ODgwMDCqsHGlpaQAAU1PTct2uIAiQy+WoUqVKuW73febp6QkACAgIKDafu7s7RowYgcqVK+Po0aPFBhanTp1CdHQ0vvrqK0yZMgUA0K9fP0ilUmzduhX9+/dHy5Yty68SRERERGBgUW7Cw8Mxd+5c+Pv749KlSwgPD0daWhqsra3h4eGBHj16qOTv06cPLCwsMHXqVKxcuRJXr16Fqakp9u/fj3PnzmH8+PFqXV0EQcC+ffuwb98+xMXFAQAsLS3RpUsXjB8/XsyXl5eHLVu2IDIyEg8ePIC+vj5at26NcePGoVGjRsXWw9PTExcuXAAAzJ07F3PnzgUA7N+/H5aWlpDL5Vi/fj2OHDmC1NRUmJiYwNHREV5eXrCwsBC3U7gOcrkcoaGhePDgAUaNGiW2ABw+fBg7duzAnTt3kJ+fDzs7OwwfPhwuLi5q5Tp37hw2b96Ma9euQS6XQyaToW3btpg0aRLMzMwAAKGhoThx4gTi4uLw9OlTmJqaon379vDy8oKlpaXK9k6dOoXg4GDcvXsXz58/h5mZGZo0aYIJEybA2tpa5Tg4ODiI6xXX/UiZLykpSWUd5bHThrm5eYnz/v777wCAIUOGqKQPGTIEW7duRUREBAMLIiIiKncMLMrZihUrIJfL4e7uDuBlwPHjjz8iLy9P7YY0JSUFXl5ecHFxQdeuXfHs2bNitz1r1ixERESgWbNmGD16NKRSKeLj43Hs2DExsFAoFJg4cSKuXLkCV1dXDBw4ENnZ2di7dy/GjBmDwMBANGnSpMh9jB49Gi1btsSGDRvQv39/tG7dGgBQtWpVKBQKTJgwAZcvX4azszOGDRuG+/fvY/fu3Th79iyCg4NRs2ZNle1t374dGRkZ6NevH8zNzcXlq1atQlBQEDp27Ijx48dDR0cHUVFR+O677zBjxgwMHDhQ3Mbu3bvh6+uLGjVqYMCAAbCwsEBycjL++OMPpKSkiIHFli1b0KxZMwwaNAimpqa4e/cu9u3bh9jYWISEhIj5zp8/j6lTp8LW1hYeHh4wNjbG48eP8ddffyEhIQHW1tYYPXo0BEHAxYsXMW/ePLEsLVq0KPLYzZs3D0uXLoWZmRlGjx4tpletWrXY81rerl+/jho1aqBWrVoq6bVq1YJMJsPff//9VstDREREHwcGFuUsPT0dISEhMDY2BvCyC8vgwYPx22+/oVu3bjA0NBTzJiYmYubMmejXr99rt3vkyBFERESgV69emDt3LnR0/m9Cr4KCAvH3HTt24Pz581ixYgU++eQTMd3d3R2DBg3CsmXLiu1206FDB+jp6WHDhg1o0aIFXF1dxWV79+7F5cuXMXz4cEyePFlMd3R0hI+PD1auXIn58+erbC85ORm7du1CtWrVxLSbN28iKCgIHh4e+Oabb8T0wYMHY9q0afD394ebmxuMjIyQkpKCJUuWwMbGBkFBQZBKpWJ+Ly8vlbqHhISgcuXKKvt3cnKCt7c3wsLCMHLkSABAdHQ0CgoK4O/vr1Kur7/+WuU4REZG4uLFiyrHoDiurq5YvXo1qlWrVuJ13oTHjx+jXr16GpfJZDKkpqa+5RIRERHRx4DTzZYzd3d3MagAAGNjYwwYMACZmZk4f/68Sl5TU9MSD/KNiIgAAPj4+KgEFQBU/o6IiICNjQ0aN26M9PR08UehUMDR0RGXL1/G8+fPy1S3qKgo6OjowMPDQyW9U6dOsLe3x8mTJ1Vu9AHAzc1N5eZdWUaJRAI3NzeVMqanp8PJyQk5OTm4evUqAODo0aN48eIFxo4dqxJUaKq7MqgoKChAdnY20tPTYW9vD2NjY1y7dk3Mpzw/x48fh0KhKNOxKItnz56p1VehUEChUKilv671qjjPnz+Hvr6+xmUGBgZlPv9ERERExWGLRTmzsbFRS1M+PU5MTFRJr127NnR1dUu03YSEBFSvXv21fe3v3buH3NxcjeMUlNLT09W6yZTEw4cPIZPJYGJiorbM1tYWt2/fRnp6ukogYWVlpbGMgiCI3cU0UQ4gT0hIAAA0bNjwteWLjY1FYGAgrl+/jtzcXJVlWVlZ4u8DBw5EdHQ0fH19sWLFCrRs2RIdO3ZEjx493mi3pcWLF+PAgQMal716vnr37l3m2ZsMDQ2Rl5encVlubq5KqxkRERFReWFgUYHe1A2enZ2dOBuQJm+zz39RdZRIJFi+fLla64uSra1tqfZz/fp1TJgwAXXq1MGECRNgaWkJAwMDSCQS/PDDDyotKWZmZggODsbFixdx9uxZXLx4EUuXLsXatWvh5+dX7DgKbYwYMQK9evVSSVu2bBmAly1RhclksjLvp3r16nj06JHGZcp3WhARERGVNwYW5Sw+Pl4t7d69ewBetlCUlZWVFaKjo5GWllZsq0XdunXx9OlTtGvXrsib9rKqXbs2zpw5g6ysLLVuSXFxcTAyMhIHSBenbt26OH36NGrVqlXkWAAlZYvH7du3YW1tXWS+yMhI5OfnY/ny5SrHWS6Xq7RWKOnq6sLBwUGcvenOnTsYNmwY1q9fDz8/PwAvg5/SKm6d+vXro379+ippyuPo6OhY6n0VpWnTpoiIiEBycrJKy1RycjIePXoEJyenctsXERERkRLHWJSzXbt2ITs7W/w7Ozsbu3fvhlQqRdu2bcu8XeWT7uXLl6uNYxAEQfzdzc0NaWlp2Lp1q8btKLsYlUXnzp1RUFCAjRs3qqTHxMTg1q1bcHJyKlEwoxzY7O/vj/z8/GLL6OzsjEqVKiEwMFDluCop667sUlb4WABAUFCQ2vFKT09X246NjQ0MDQ2RmZkppinHbGRkZLy2ToXXKbyNiqCc2nj79u0q6cq/X201ISIiIioPbLEoZ2ZmZhg5cqQ4KDs8PBzJycmYOXOmVl2fXFxc0K1bNxw8eBAJCQlwcnKCVCrF/fv3cebMGezcuRPAy3cVnD17Fn5+foiNjUW7du1gZGSE5ORkxMbGQl9fH2vXri1TGfr06YMDBw5g06ZNePjwIdq0aYOEhATs2rUL5ubmKjM8Fadp06bw9PREQEAAhg4dChcXF8hkMjx+/Bg3btxATEwM/vzzTwBAzZo1MW3aNCxatAiDBw+Gm5sbLCwskJqaiujoaMyaNQsNGzZE586dsW3bNkyePBn9+/dHpUqVcPbsWfzzzz9qrSgLFixAamoqHB0dYWFhgdzcXBw5cgQ5OTlwc3MT8zVv3hw7d+6Er68vOnXqBD09PTRr1qzYlqfmzZsjLCwMq1evRr169SCRSODk5KQ2W1VpJSUl4eDBgwAgvsPk5MmTSElJAQDxuAAvB9N/9tln2Lp1K7Kzs9G8eXNcvXoVYWFh6NWrF1q1aqVVWYiIiIg0YWBRziZOnIhLly4hNDQUT548gZWVFRYsWICePXtqve2FCxeidevWCAsLQ2BgIHR1dWFpaaky8FdPTw/Lli3Drl27cOjQITGIkMlkaNq0KXr37l3m/evp6WHlypXiC/KioqIglUrh7OwMb2/vUg0I9/T0RJMmTRASEoLt27dDLpejWrVqsLW1xfTp01Xyuru7o06dOggODkZISAhevHgBmUyGdu3aie/FaNWqFRYvXox169ZhzZo1MDAwQPv27REQEICxY8eqbM/V1RXh4eE4ePAgnj59CiMjI9SvXx+LFi2Cs7OzmK9Hjx64desWDh8+jGPHjqGgoACzZ88uNrDw9vZGRkYGQkNDkZWVBUEQsH//fq0Di8TERKxZs0YlLSoqClFRUWL9C7+g0NfXF+vXr0dERAQOHTqEGjVqYPz48Rg1apRW5SAiIiIqikR4te8IlYnyzdtr1qxReesy0ftOsuTtTclLRFRehOl8dkr0tnGMBRERERERaY2BBRERERERaY2BBRERERERaY1jLIioWBxjQUTvI46xIHr72GJBRERERERaY2BBRERERERaYzshERVrrUkQPDw8UKlSpYouChEREb3D2GJBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERakwiCIFR0IYjo3SVZoqjoIhARlZgwXa+ii0D00WKLBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BBRERERERaY2BxTvo3LlzcHBwQHh4eIWV4datW/Dy8kKXLl3g4OCAtWvXVlhZiIiIiOjdx8meSY1CocCMGTOgUCgwfvx4SKVSNGjQoKKL9dadOHECt27dwrhx40q8zrZt2yCVStGnT59yLcu1a9cQERGBGzdu4M6dO5DL5Zg9e3ax+0lJScG6detw+vRpPHnyBCYmJmjYsCF8fHxQv379ci0fEREREQOLd1CbNm0QExMDPb2KOT2JiYlITEyEj48PBg0aVCFleBecOHECBw4cKFVgsX37dlhYWJR7YBETE4PQ0FDY2NigQYMGuHLlSrH5b968iW+++QZVqlRB3759UatWLWRmZuLvv//G06dPy7VsRERERAADi3dKTk4OjIyMoKOjAwMDgworR1paGgDA1NS0XLcrCALkcjmqVKlSrtt9n3l6egIAAgICis3n7u6OESNGoHLlyjh69GixgUVubi6+//571KxZEwEBATA2Ni7XMhMRERFpwsCinISHh2Pu3Lnw9/fHpUuXEB4ejrS0NFhbW8PDwwM9evRQyd+nTx9YWFhg6tSpWLlyJa5evQpTU1Ps378f586dw/jx49W6ugiCgH379mHfvn2Ii4sDAFhaWqJLly4YP368mC8vLw9btmxBZGQkHjx4AH19fbRu3Rrjxo1Do0aNiq2Hp6cnLly4AACYO3cu5s6dCwDYv38/LC0tIZfLsX79ehw5cgSpqakwMTGBo6MjvLy8YGFhIW6ncB3kcjlCQ0Px4MEDjBo1SmwBOHz4MHbs2IE7d+4gPz8fdnZ2GD58OFxcXNTKde7cOWzevBnXrl2DXC6HTCZD27ZtMWnSJJiZmQEAQkNDceLECcTFxeHp06cwNTVF+/bt4eXlBUtLS5XtnTp1CsHBwbh79y6eP38OMzMzNGnSBBMmTIC1tbXKcXBwcBDXK677kTJfUlKSyjrKY6cNc3PzEuc9cuQIEhISsHTpUhgbGyMvLw8AoK+vr1UZiIiIiIrDwKKcrVixAnK5HO7u7gBeBhw//vgj8vLy1G5IU1JS4OXlBRcXF3Tt2hXPnj0rdtuzZs1CREQEmjVrhtGjR0MqlSI+Ph7Hjh0TAwuFQoGJEyfiypUrcHV1xcCBA5GdnY29e/dizJgxCAwMRJMmTYrcx+jRo9GyZUts2LAB/fv3R+vWrQEAVatWhUKhwIQJE3D58mU4Oztj2LBhuH//Pnbv3o2zZ88iODgYNWvWVNne9u3bkZGRgX79+sHc3FxcvmrVKgQFBaFjx44YP348dHR0EBUVhe+++w4zZszAwIEDxW3s3r0bvr6+qFGjBgYMGAALCwskJyfjjz/+QEpKihhYbNmyBc2aNcOgQYNgamqKu3fvYt++fYiNjUVISIiY7/z585g6dSpsbW3h4eEBY2NjPH78GH/99RcSEhJgbW2N0aNHQxAEXLx4EfPmzRPL0qJFiyKP3bx587B06VKYmZlh9OjRYnrVqlWLPa/lLSYmBgAglUoxduxYXLp0CYIgwN7eHhMnTsQnn3zyVstDREREHwcGFuUsPT0dISEhYvcTd3d3DB48GL/99hu6desGQ0NDMW9iYiJmzpyJfv36vXa7R44cQUREBHr16oW5c+dCR+f/JvQqKCgQf9+xYwfOnz+PFStWqNxAuru7Y9CgQVi2bFmx3W46dOgAPT09bNiwAS1atICrq6u4bO/evbh8+TKGDx+OyZMni+mOjo7w8fHBypUrMX/+fJXtJScnY9euXahWrZqYdvPmTQQFBcHDwwPffPONmD548GBMmzYN/v7+cHNzg5GREVJSUrBkyRLY2NggKCgIUqlUzO/l5aVS95CQEFSuXFll/05OTvD29kZYWBhGjhwJAIiOjkZBQQH8/f1VyvX111+rHIfIyEhcvHhR5RgUx9XVFatXr0a1atVKvM6b8O+//wIAZsyYgWbNmuGnn35CRkYGNmzYgMmTJ2PFihVwdHSssPIRERHRh4nTzZYzd3d3lT7txsbGGDBgADIzM3H+/HmVvKampiUe5BsREQEA8PHxUQkqAKj8HRERARsbGzRu3Bjp6enij0KhgKOjIy5fvoznz5+XqW5RUVHQ0dGBh4eHSnqnTp1gb2+PkydPqtzoA4Cbm5vKzbuyjBKJBG5ubiplTE9Ph5OTE3JycnD16lUAwNGjR/HixQuMHTtWJajQVHdlUFFQUIDs7Gykp6fD3t4exsbGuHbtmphPeX6OHz8OhUJRpmNRFs+ePVOrr0KhgEKhUEt/XevV6/YDADY2Nli6dCm6desGd3d3rF69GhKJBKtWrSqvKhERERGJ2GJRzmxsbNTS6tWrB+BlC0VhtWvXhq6ubom2m5CQgOrVq7+2r/29e/eQm5urcZyCUnp6OmrVqlWi/Rb28OFDyGQymJiYqC2ztbXF7du3kZ6erhJIWFlZaSyjIAhidzFNlAPIExISAAANGzZ8bfliY2MRGBiI69evIzc3V2VZVlaW+PvAgQMRHR0NX19frFixAi1btkTHjh3Ro0ePN9ptafHixThw4IDGZa+er969e2POnDll2o9y4L+bmxskEomYbmVlhZYtW+LixYuQy+VqrTtERERE2mBgUYEKd4sqT3Z2dpgyZUqRy99mn/+i6iiRSLB8+XK11hclW1vbUu3n+vXrmDBhAurUqYMJEybA0tISBgYGkEgk+OGHH1RaUszMzBAcHIyLFy/i7NmzuHjxIpYuXYq1a9fCz8+v2HEU2hgxYgR69eqlkrZs2TIAL1uiCpPJZGXeT82aNXH37l2NQai5uTkEQUB2djYDCyIiIipXDCzKWXx8vFravXv3ALxsoSgrKysrREdHIy0trdhWi7p16+Lp06do165dkTftZVW7dm2cOXMGWVlZat2S4uLiYGRkJA6QLk7dunVx+vRp1KpVS2zNKYqyxeP27duwtrYuMl9kZCTy8/OxfPlyleMsl8tVWiuUdHV14eDgIM7edOfOHQwbNgzr16+Hn58fAKg87S+p4tapX7++2ovplMexPMc8NG3aFKdPn0ZKSorastTUVOjq6mpsdSIiIiLSBsdYlLNdu3YhOztb/Ds7Oxu7d++GVCpF27Zty7xd5ZPu5cuXq41jEARB/N3NzQ1paWnYunWrxu0ouxiVRefOnVFQUICNGzeqpMfExODWrVtwcnIqUTCjHNjs7++P/Pz8Ysvo7OyMSpUqITAwUOW4KinrruxSVvhYAEBQUJDa8UpPT1fbjo2NDQwNDZGZmSmmKZ/oZ2RkvLZOhdcpvI2K0KNHD+jq6iIsLExlDMnt27dx9epVODg4VOh7UoiIiOjDxBaLcmZmZoaRI0eKg7LDw8ORnJyMmTNnatX1ycXFBd26dcPBgweRkJAAJycnSKVS3L9/H2fOnMHOnTsBAEOGDMHZs2fh5+eH2NhYtGvXDkZGRkhOTkZsbCz09fWxdu3aMpWhT58+OHDgADZt2oSHDx+iTZs2SEhIwK5du2Bubq4yw1NxmjZtCk9PTwQEBGDo0KFwcXGBTCbD48ePcePGDcTExODPP/8E8LJbz7Rp07Bo0SIMHjwYbm5usLCwQGpqKqKjozFr1iw0bNgQnTt3xrZt2zB58mT0798flSpVwtmzZ/HPP/+otaIsWLAAqampcHR0hIWFBXJzc3HkyBHk5OTAzc1NzNe8eXPs3LkTvr6+6NSpE/T09NCsWbNiW56aN2+OsLAwrF69GvXq1YNEIoGTk5PW3Y6SkpJw8OBBABDfYXLy5EmxVUJ5XICXQdKIESOwYcMGeHp6onv37sjMzMSOHTtgaGio1u2KiIiIqDwwsChnEydOxKVLlxAaGoonT57AysoKCxYsQM+ePbXe9sKFC9G6dWuEhYUhMDAQurq6sLS0VBn4q6enh2XLlmHXrl04dOiQGETIZDI0bdoUvXv3LvP+9fT0sHLlSvEFeVFRUZBKpXB2doa3t3epBoR7enqiSZMmCAkJwfbt2yGXy1GtWjXY2tpi+vTpKnnd3d1Rp04dBAcHIyQkBC9evIBMJkO7du3E92K0atUKixcvxrp167BmzRoYGBigffv2CAgIwNixY1W25+rqivDwcBw8eBBPnz6FkZER6tevj0WLFsHZ2VnM16NHD9y6dQuHDx/GsWPHUFBQgNmzZxcbWHh7eyMjIwOhoaHIysqCIAjYv3+/1oFFYmIi1qxZo5IWFRWFqKgosf6FX1D4zTffwMLCAqGhoVi+fDkMDAzg4OCA8ePHl3r8ChEREVFJSIRX+45QmSjfvL1mzRqVty4Tve8kS97elLxERNoSpvOZKVFF4RgLIiIiIiLSGgMLIiIiIiLSGgMLIiIiIiLSGsdYEFGxOMaCiN4nHGNBVHHYYkFERERERFpjYEFERERERFpjYEFERERERFpjR0QiKtZakyB4eHigUqVKFV0UIiIieoexxYKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLTGwIKIiIiIiLSmV9EFIKJ3lyAIkMvlyMzMRKVKlSq6OERERFRBpFIpJBJJsXkkgiAIb6k8RPSeefz4MWQyWUUXg4iIiCpYRkYGTExMis3DFgsiKpKBgQFatWqFgwcPwtjYuKKL89ZkZ2fDzc3to6s38PHWnfVmvT8GH2u9gY+37uVZb6lU+to8DCyIqEgSiQS6urowMTH5qL6IdXR0Psp6Ax9v3Vlv1vtj8LHWG/h46/62683B20REREREpDUGFkREREREpDUGFkRUJH19fYwdOxb6+voVXZS36mOtN/Dx1p31Zr0/Bh9rvYGPt+5vu96cFYqIiIiIiLTGFgsiIiIiItIaAwsiIiIiItIap5sl+kjFx8dj8eLFuHLlCoyMjODq6gpvb+/XvmFbEARs2rQJoaGhSE9Ph729PaZOnYrmzZu/pZJrp6z17tOnD5KSktTSY2JiYGBg8KaKW24SEhKwefNmXLt2DXfv3oW1tTV27tz52vXe9/Nd1nq/7+f76NGjOHToEG7evInMzExYWVlh0KBB6Nu3b7Fvzn3fz3dZ6/2+n28AOHXqFIKDgxEXF4ecnBzUqFEDn3/+OTw9PV87zei+ffsQHByM5ORkWFtbw9vbG5999tlbKrl2ylpvT09PXLhwQS19165dsLGxeYMlfjOePXsGd3d3pKamIjg4GE2aNCky75v8nDOwIPoIZWZmYvz48bCyssIvv/yC1NRU/Pbbb3j+/Dn++9//Frvupk2bsHbtWkyYMAENGjRAaGgoJkyYgK1bt6JOnTpvqQZlo029AcDZ2RnDhg1TSXtfBgLevXsXMTExaNq0KQoKClBQUFCi9d7n8w2Uvd7A+32+t27dCgsLC/j4+KBq1ao4e/YsFi5ciJSUFHh6eha53vt+vstab+D9Pt/Ay++3pk2bYtCgQTA1NcXdu3cREBCAu3fvwt/fv8j1fv/9dyxcuBCjR49Gu3btcPjwYUyfPh3r1q17LwLKstYbAFq2bAkfHx+VNAsLizdY2jdn3bp1yM/PL1HeN/o5F4jooxMUFCR06tRJSE9PF9N2794ttG/fXkhNTS1yvefPnwtOTk7CypUrxbS8vDyhd+/ews8///xGy1weylpvQRCE3r17C76+vm+6iG9Mfn6++Pvs2bOFL7/88rXrvO/nWxDKVm9BeP/P99OnT9XSFixYIDg5Oakck8I+hPNdlnoLwvt/vouyZ88eoW3btsV+v/Xv31/44YcfVNI8PDyEiRMnvunivTElqffYsWOFyZMnv71CvUH37t0TOnXqJOzatUto27atcP369SLzvunPOcdYEH2ETp8+jfbt28PU1FRM69atGwoKCvDnn38Wud6VK1eQk5MDFxcXMa1SpUro0qULYmJi3miZy0NZ6/0h0NEp/df9+36+gbLV+0NgZmamltawYUPk5ORALpdrXOdDON9lqfeHTPld9+LFC43LHzx4gPv376Nbt24q6d27d0dsbCzy8vLeeBnfhNfV+0OzePFiDBgwANbW1q/N+6Y/5x/nNy7RRy4+Pl6tD6lUKkX16tURHx9f7HoA1NatV68ekpOT8fz58/ItaDkra72VIiMj8cknn+Czzz7DpEmT8M8//7yZgr4j3vfzra0P7XxfunQJNWrUgJGRkcblH+r5fl29lT6U852fn4/c3FzcvHkT69atg5OTEywtLTXmLeqc29jY4MWLF3j48OEbLm35KU29lS5cuIBOnTqhY8eORY65eNcdPXoUd+/exddff12i/G/6c84xFkQfoczMTEilUrV0qVSKzMzMYtfT19dXG8wolUohCAKysrJgaGhY7uUtL2WtNwA4OTmhWbNmqFWrFhITExEUFIQxY8a8N33Py+J9P9/a+NDO96VLl3D48GG1/uSFfYjnuyT1Bj6s892nTx+kpqYCADp27IiFCxcWmTcrKwsA1AY5m5iYAAAyMjLeUCnLX2nqDQBt27aFm5sbrKys8OjRI2zZsgXe3t4ICAhAixYt3kaRtfb8+XP89ttv8Pb2fu0AfaU3/TlnYEFEVALffvut+Hvr1q3RoUMHDBgwAFu2bMF3331XgSWjN+FDOt8pKSn4/vvv4eDggMGDB1d0cd6a0tT7Qzrffn5+kMvliIuLw/r16zFlyhT4+/tDV1e3oov2RpW23uPGjVP5+7PPPsPAgQOxbt06LF++/G0UWWvr16+Hubk5+vbtW9FFETGwIPoImZiYIDs7Wy09KytLfFJV1Hp5eXnIzc1VedqRlZUFiUSisTXgXVLWemtSvXp1tGrVCjdu3Civ4r1z3vfzXZ7e1/OdlZWFSZMmwdTUFIsXLy52zMmHdL5LU29N3tfzDQANGjQAALRo0QJNmjTB0KFDERUVpdKnXkl5TrOzs1G9enUxXdmCW3g82ruuNPXWpHLlyujUqROOHTv2JotZbpKSkrBlyxb88ssv4v9rynFEz549w7Nnz1ClShW19d7055yBBdFHyMbGRm1MQXZ2Nh4/flzs/N3KZf/++y/s7e3F9Pj4eNSqVeud7yZR1np/rN738/2xe/78OXx8fJCdnY0NGza8tqvEh3K+S1vvD1mDBg2gp6eHBw8eaFyuPOevjj+Lj49HpUqVULt27bdQyvL3unp/CBITE/HixQuN3fzGjx+PZs2aYePGjWrL3vTnnIO3iT5CHTt2xF9//SX2rwVeDgDT0dFBhw4dilyvRYsWMDIywtGjR8U0hUKBqKgofPrpp2+0zOWhrPXW5NGjR7h06VKxLyF6373v57s8vW/nW6FQ4Pvvv0d8fDxWrFiBGjVqvHadD+F8l6Xemrxv57so165dg0KhKDJAqFOnDqysrNSe0h85cgTt2rV77YtD31Wvq7cmcrkcf/zxx3tzzhs2bIg1a9ao/EydOhUA8P333xfZhe9Nf87ZYkH0ERowYAB27NiBadOmYfTo0UhNTYWfnx+++OILyGQyMZ+XlxeSkpKwb98+AICBgQE8PDwQEBCAqlWrws7ODqGhocjIyFB7sdS7qKz1joyMxKlTp/Dpp59CJpPhwYMH2LhxI3R1dd+LegMvn+KeOnUKwMsm9JycHPE/lrZt26Jq1aof3PkGylbvD+F8L1q0CH/88Qd8fHyQk5ODq1evissaNmwIfX39D/J8l6XeH8L5Bl6OE2ncuDEaNGgAAwMD3L59G5s3b0aDBg3QuXNnAMC8efNw8OBBnD17VlzP09MT//vf/1CnTh20bdsWR44cwbVr1xAYGFhBNSmdstT74sWLCA4ORpcuXWBpaSkO3k5LS4Ovr28F1qbkpFIpHBwcNC5r3LgxGjVqBODt/z/OwILoI2RiYoLVq1fjl19+wbRp02BkZIR+/frB29tbJV9+fr7amzxHjhwJQRCwZcsWPH36FPb29lixYsV7MXNKWetdu3ZtPHr0CL/++iuysrIglUrRrl07jBs37r3pKvDkyRO1J1jKv9esWQMHB4cP7nwDZav3h3C+le9lWbZsmdqy/fv3w9LS8oM832Wp94dwvgGgadOmOHz4MDZt2oSCggJYWFigf//+GDZsmNjyUFBQoHbOe/bsiefPn2PTpk3YuHEjrK2tsWTJkvdmZqSy1Lt69epQKBTw9/dHRkYGKleujBYtWuD7779Hs2bNKqoqb8Tb/pxLBEEQtN4KERERERF91DjGgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgoiIiIiItMbAgojKVWpqKkxNTREYGKiSPmrUKNjY2FRMoT4Qc+bMgUQiQXx8/FvZ38aNG9X2J5fLYWlpiblz55Z6e0VdG1R2ynN04sSJii4KVTBtvx94Lb1bLly4gClTpqBnz55wcHB4o+clPj4elpaWcHBwUPkZMGBAqbfFwIKIytXMmTMhk8ng4eFRovzJycmYPn06mjVrBqlUChMTEzRo0ACDBw/Gnj17VPJ27twZxsbGRW5L+R/ruXPnNC5/+vQpKleuDIlEgs2bNxe5HRsbG0gkEvFHX18fNjY2+Prrr5GQkFCien2oKleujO+++w6//PILkpKSSrVuaa8N+rhdunQJc+bMeWuBNFW8+Ph4zJkzB5cuXXqr+30XrzW5XI4GDRrgv//971vbp1QqRWRkJCIjI7Fz5040bNiw1AENAwsiKjcPHjxAUFAQJk6cCD09vdfm//fff9GyZUv4+/ujQ4cO8PX1xc8//4zevXvj5s2b2LBhQ7mWb+vWrcjNzUW9evUQFBRUbN46depg8+bN2Lx5M/z8/ODo6IigoCA4Ojri8ePH5Vqu982YMWMgkUiwdOnSEq9T2muDSmb48OGQy+VwcnKq6KKUu0uXLmHu3Lnv1M0evVnx8fGYO3duhQQW79q19umnn8Lb2xtdunTRuDwvLw/Lli1Dr1690KlTJ4wcObLIh2qvY21tjR9//BG1atVC9erVUb16dejo6ODnn38udWDBb3ciKjdr166FRCLBkCFDSpR/yZIlSE1Nxb59+/Cf//xHbXlycnK5lm/9+vXo0qUL/vOf/8DHxwdxcXGoX7++xrympqYYNmyY+LeXlxdq1KiBlStXYsOGDfj222/LtWzvEyMjI3zxxRfYuHEjFixYAAMDg9euU9pro6Ll5+cjNzcXVapUqeiiFEtXVxe6uroVXQwiessWL16MuLg4/PTTT5DJZIiKisKkSZMQEhICKyurUm1LIpFAT08PCQkJ6NmzJwwMDFCvXj1UqlSp1OViiwVRBVL2aT127BjmzZsHa2trVK5cGY6Ojvjzzz8BANHR0ejUqROMjIxgYWGB+fPna9zWuXPn0L9/f1SvXh0GBgZo2LAhFi5cCIVCoZLvr7/+wqhRo2Bvb48qVapAKpXi008/xd69e9W2OWrUKEgkEmRkZIg31oaGhvj0009x9uxZtfyhoaFwcHBAjRo1SlT/O3fuAACcnZ01Lq9Vq1aJtlMSFy5cwKVLlzBy5EgMHToUenp6r221eFWPHj0AAP/880+ReSIiIiCRSLB8+XKNyz/55BPIZDK8ePECQOnOhybKc6SJRCLBqFGj1NJ37NiBTp06QSqVokqVKnB0dMSuXbtKtD+lXr164fHjx4iKiipR/qKujYKCAixcuBBOTk6oVasW9PX1YWVlBS8vL6SlpYn50tPTYWhoiC+++ELj9r///ntIJBKVJ50ZGRn473//Czs7OxgYGEAmk2HIkCGIi4tTWVf5OTx69Cjmz58PW1tbGBoaYufOnQCAw4cPY9CgQahfvz4qV64MMzMzdO/eHdHR0RrLsnv3brRs2RKGhoawsrLC3LlzcfToUUgkEmzcuFElb25uLn766Sc0bdoUhoaGMDMzQ58+fXDx4sUSHVdN/eLL63vFxsYGnTt3xoULF9C1a1cYGxujWrVqGDlyJFJTU1XyZmVlYebMmXB0dBS/g+zs7PDdd9/h2bNnatsWBAGBgYFwdHSEsbExjI2N0bx5c8yaNQvAy26Nyi5zXbp0EbslarqeX3XlyhX0798f5ubmMDQ0RJMmTbB48WLk5+er5Cvt95smyu6Xf//9N3x8fGBhYYEqVarA2dkZt27dAgDs2bMHbdq0QeXKlWFjY4OAgACN21q3bp2Yz9TUFN27d8epU6fU8hUUFODnn39GvXr1YGhoiGbNmmHr1q1FljEpKQleXl6wsrKCvr4+LC0t4enpqXYOS6ukx7lz584ax9fFx8dDIpFgzpw5AF5et8qn8x4eHuI579y5MwDgxIkT4mdoxYoVsLe3h6GhIezt7bFixQq17Suv31cV3g5Q9mtNef2kpaVh1KhRqF69OqRSKfr16yc+FAsICEDjxo1haGiIRo0aISwsTG07q1atQvfu3VG7dm3o6+vDwsICw4YN09h6kp+fj/nz56NevXrYu3cvzp07h9u3b2PdunUYMWIEGjZsiPDwcJXyleT6jo+Px4wZM9CkSROsWLECrq6uiIyMRMOGDTF//nzxmCjP46vHsDC2WBC9A7777jvk5+dj8uTJyMvLw6+//oru3bsjODgYY8aMgaenJ7766ivs3LkTs2bNQr169VSeph88eBBffPEF7OzsMG3aNFSrVg1nzpzBrFmzcOnSJYSGhop59+7di5s3b2LgwIGwtrZGWloaNm3ahC+++AJbt27F0KFD1crXo0cPyGQyzJo1C2lpaVi6dCnc3Nxw7949SKVSAEBKSgpu3bqFSZMmlbjetra2AIDAwED4+PgUeYP8qqK6Imm6gVFav349jI2NMWDAABgZGaF3797YtGkT5s2bBx2dkj1jUQZC1atXLzJP9+7dUatWLQQHB6sdizt37uDPP//EpEmTxCdBZTkf2pg5cyYWLlyInj17Yv78+dDR0cHevXvx5ZdfYuXKlfjmm29KtJ1PPvkEwMv/YHr27Fls3uKujby8PPzyyy8YMGAA/vOf/8DIyAixsbFYv349Tp06hfPnz0NfXx9mZmbo27cvwsLC8OTJE1SrVk3cRkFBAbZu3YoWLVqgVatWAF4GFR07dsT9+/cxevRoNG3aFElJSVi1ahUcHR1x7tw5WFtbq5Rl+vTpePHiBcaOHQsTExM0bNgQwMsbnidPnmDEiBGoU6cOEhMTsW7dOjg7OyMqKgqfffaZuI0dO3ZgyJAhsLW1xezZs6Gnp4dNmzaJ/9kX9uLFC/Ts2ROnT5/G8OHDMWHCBGRkZCAwMBCffvopTp48CQcHhxKdD020/V4BXnZhc3Z2xoABA+Du7o4LFy4gKCgI586dQ2xsrNiiozwmAwYMEAP36OhoLF68GBcvXsTvv/+ust3hw4dj69atcHR0xI8//ggzMzPcvHkTu3btwrx58/DFF18gKSkJAQEB+OGHH9C4cWMA//edUZRz587h888/R6VKlfDNN9+gVq1aCA8Px3//+19cvnxZ4w14Sb7fXmfkyJEwNjbGDz/8gEePHuHXX39Fjx49MH/+fMyYMQNeXl4YPXo01q9fj3HjxqFJkybo1KmTuP5///tfLF68GO3bt8dPP/2ErKwsBAQEoEuXLggLC4Orq6uYd+rUqfDz84OTkxOmTJmC1NRUfPPNNxpbX+/fv49PPvkEeXl5GDNmDGxtbfHPP/9g9erViIqKwrlz52BqalqiOmp7nF/HyckJP/zwA3766Sd4enqKn6uaNWuq5FuxYgWSk5Mxbtw4SKVSbN++HZMmTcKTJ08we/bsUu+3rNeaUs+ePVGnTh3MmzcP//zzD5YvX47+/fvjiy++QEBAAMaMGQNDQ0MsX74c7u7uuH37NurVqyeuv2TJEnTo0AGTJk1CtWrVcO3aNaxbtw7Hjx/H1atXYW5uLuadMGEC1qxZg06dOkEul6Ny5cpYtGgRdHR00KpVK/z999/iA7nc3Fy0bdtWfHCnbMXIzc0Vv+dHjhyJiRMnAgAyMzNhaWmJBg0awMTEBBkZGdi+fTucnZ0xYsQIACh2jKNIIKIKs2HDBgGA0Lp1ayE3N1dMDwsLEwAIenp6QmxsrJiem5sr1KpVS+jQoYOYJpfLhZo1awqfffaZ8OLFC5XtL126VAAgREVFiWnZ2dlq5cjJyRHs7e2Fxo0bq6SPHDlSACB4eXmppO/cuVMAIKxZs0ZMO378uABA8PPz01jXkSNHCtbW1ippd+/eFUxMTAQAQt26dYWhQ4cKv/32m3Du3DmN2/j8888FAK/9KXzMlMfIzMxMGDlypJi2b98+AYBw6NAhtf1YW1sLjRo1Eh49eiQ8evRIiIuLE4KCggRTU1NBT09PuHr1qsbyKU2fPl0AIFy/fl0lfebMmQIA4fz582Jaac7H7NmzBQDCvXv3xDTlOdIEgEqdz58/LwAQvv/+e7W8//nPfwSpVCpkZmaKacrrs/D+CtPT0xN69+6tcVlhxV0bBQUFwrNnz9TS161bJwAQduzYIaYdOHBAACD4+/ur5D169KgAQPj111/FtEmTJgmGhobCpUuXVPLGx8cLUqlU5bgo62lvby/k5OSolUXTOUpOThbMzc2FXr16iWkvXrwQLC0thRo1aghPnjwR07OysoR69eoJAIQNGzaI6crPZ2RkpMq2MzIyhLp16wqff/652n5fpSx74c94eXyvCMLLzwEA4bffflNJV5b7559/VtlGXl6eWvmU1/zZs2fFtB07dggAhGHDhgn5+fkq+Qv/ralur9OxY0dBV1dXuHz5sphWUFAgfPnllwIA4ejRo2J6ab7fiqL8TPbu3VsoKCgQ0/38/AQAglQqFe7fvy+mp6amCgYGBsLgwYPFtJs3bwoSiUT49NNPVc5XYmKiYGpqKlhbWwsKhUIlb9euXcU0QXj52ZZIJGqf1759+woymUxISEhQKXdsbKygq6srzJ49W0wrzfEuzXH+/PPP1b77BUEQ7t27JwBQKUNUVJTa5+TVZcbGxir1yc3NFdq1ayfo6emppFtbW2v8DGnaR1muNeX14+3trZI+ZcoU8f+0jIwMMf3y5csCAOG7775Tya/p+0X5nbZo0SJBEAShbdu2wqZNmwQAQo8ePYTIyEihffv2wr1794QjR44IhoaGgoGBgXD69Gnh0aNHgiAIwvDhwwUDAwNh1KhRwr1798Sf1atXCwYGBoKvr6/4PaXpXNy7d09o1KiRMHDgwBIdQyV2hSJ6B3h5eUFfX1/8W/mkxtHRUeWJpb6+Ptq3by8+OQeAI0eOICUlBR4eHkhPT8fjx4/FH+VTrsOHD4v5jYyMxN+fPXuGtLQ0PHv2DF27dsWNGzeQmZmpVr4pU6ao/N21a1cAUCnHo0ePAEDlSfLr1K9fH5cvXxafnmzbtg1TpkyBg4MDWrRogfPnz6utY2hoiCNHjmj8GT58uMb97NmzB+np6Rg5cqSY5urqCplMVmR3qJs3b0Imk0Emk6F+/foYPXo0qlevjrCwMDRr1qzYein3ExwcLKYJgoAtW7agWbNmaNOmjZhelvNRVlu3boVEIsHIkSNVrpPHjx+jb9++yMrKwpkzZ0q8vWrVqpWoO0Vx14ZEIkHlypUBvGzmV17DymuscJN9jx49ULNmTZXjCrw8znp6evjqq68AvDzWW7duhZOTE2rXrq1STyMjI3To0EHlM6Hk5eWlcUxF4XOUnZ2NtLQ06OrqwtHRUaV858+fx8OHDzFq1ChUrVpVTDc2Nsb48ePVtrtlyxY0atQIbdu2VSljXl4eunXrhlOnTkEul2s4oiWjzfeKkomJCby9vVXSvL29YWJiotJdT19fX2yFUygUePr0KR4/fgwXFxcAqudR+TR7yZIlaq2FJW091CQ1NRWnT59G37590aJFCzFdIpHgxx9/BACNXQxL8v32OpMmTVJpcVUe6759+6Ju3bpiukwmQ8OGDVW2HRYWBkEQMGPGDJXzZWlpCQ8PD/z7779i1zhl3qlTp6qMrWnTpg26deumUqaMjAwcOHAAffv2haGhoco1ZmNjAzs7O42fg9cp63EuL1999RXq1Kkj/q2vr48pU6ZAoVBobBl803x8fFT+Vp77ESNGwMTERExv0aIFTExM1K4r5fdLQUEBMjIy8PjxY7Rs2RKmpqYqnxvlwOzJkyejUaNGyM/Px9OnT+Hi4oIuXbogNzcXFhYWYou6jo4OcnNz8cMPP8DGxkb8+fLLL5Gbm4tHjx6pfE+9Si6Xw8DAAIaGhqU6HuwKRfQOeLUJW/lhL9xcWnhZ4b7nN27cAACMHj26yO2npKSIv6empmLmzJkICwvTeFOYnp6u8mWoqXzKptnC5VD+pyoIQpHl0MTGxgYrV67EypUrkZSUhFOnTmHz5s0IDw9H7969cf36dZUbUl1dXfFm5VWa+iMDL7tByWQy1KlTR2V8RPfu3REaGorHjx+rdW+ysbER37eg7JdsZ2dXojopg4etW7fip59+go6ODk6ePIn4+HgsXrxYJW9ZzkdZ3bhxA4IgoFGjRkXmKXytvI4gCCXqvva6a2Pnzp349ddfcfHiRXHsidLTp0/F35XBw9KlS3H79m3Y29sjJycHe/bsQffu3cUuE48ePUJaWhoOHz4MmUymcZ+abmDt7e015r179y5+/PFH/P7770hPT9dYNwC4d+8eAIhdqArTlHbjxg3I5fIiywi87PZX+Ma0NLT5Xim8jcI3uwBgYGCA+vXrq41VWbVqFdasWYPr16+joKBAZVnh83jnzh1YWFiodXHRlvL4N23aVG1Z48aNoaOjo1ZmoGTfb69T2mP977//lqjcyrS4uDg4ODiI5df0GW7SpIlKoHDr1i0UFBRg/fr1WL9+fYnKXRJlPc7lRdlVqbAmTZoAwBvdb1G0/ZwdP34c8+bNw9mzZ/H8+XMxXUdHB48fPxbH6ty/fx+VK1eGubk5rK2t0atXL8yePRs+Pj6wtrZGlSpVsGfPHrRv316lm11Jr+/atWsjLS0NDx8+xKNHj+Dn5wdBEGBpaVmq48HAgugdUNSsLiWZ7UV5s/bLL7+I/ctfpfxiEAQB3bt3x40bNzB58mQ4ODjA1NQUurq62LBhA7Zt26Z2Q1BcOQrfKCpvjp48efLaMhfFwsICX375Jb788kt89dVX2LZtGw4dOqTW77s07t27h6ioKAiCUOSN45YtW9SeOhkZGRUZwJTEiBEj4OPjg+PHj8PFxQXBwcHQ1dVVqUtZz0dhRd3YvzpoX7k/iUSCiIiIIs+pppuFojx9+rTYm2Kl4q6NPXv2YNCgQWjfvj38/PxQt25dGBoaIj8/Hz179lSr/4gRI7B06VIEBwdjwYIF2LNnD7Kzs1Vao5TXpYuLS6nmgNfUWpGdnQ0nJyfk5OTAx8cHzZs3h1QqFadiPH78eIm3/ypBENC8efNip+0tyfEtijbfK6W1dOlSTJs2Dd27d8ekSZNgaWkJfX19JCYmYtSoUa+9jitSSb7fyrqN8th2WSn3MWzYMJXPR2HK1sI3qTTfUe/jfrU597GxsejevTvs7Ozg6+uLevXqie9aGjVqFHJycsSW2AcPHqBJkybYsWMH2rdvj9mzZ2P9+vVYtmwZkpKSxPEzffv2LXU5gJcP0C5cuIABAwagatWqsLOzw82bN9G/f3+1dYt7oMTAgug916BBAwAluxG+cuUKLl++jFmzZqm9OXndunValUN5Q1qa7gPF6dChA7Zt24bExESttrNhwwZxBhozMzO15TNnzkRQUJBaYKGtoUOH4ttvv0VwcDA+/fRT7Nq1C926dYOFhYWYpzzOh7I159UBzZqe3DVo0ACRkZGwsrLS+NSvNOLj46FQKF7bLQwo/trYvHkzDA0NERUVpXJjf/PmTY3batmyJVq2bIktW7Zg/vz5CA4OFgd2K8lkMpiZmSEzM1Or4BAAjh07hocPHyIoKEjtxX4zZ85U+Vs5Y4ryCWNhmtIaNGiAR48eoWvXrlp1AXqT4uLikJeXp9JqkZubi7i4OJWn5ps3b4aNjQ0iIiJU6hIZGam2TXt7e4SFhSElJaXYVouSTuagpHxCfP36dbVlN2/eREFBQZme0L9pyjJdv35dbcDw33//rZJH+e/NmzeLzKtkZ2cHiUSCvLw8rT8HhZX2OFerVk1jt1ZN31ElOefKVvrCXj1Oyv1qephR1v2+Cdu2bUN+fj4iIiJUWjhycnKQlJQEOzs7ccY3X19ffP/99+IMbnp6ehg3bhzGjRsHV1dXREREYP/+/Rpn4CqJe/fuYcSIEeIsXf/++6/G2bYA1f93XvVufpMRUYn16NEDNWrUgK+vr8YPuVwuR1ZWFoD/e3Lx6pOKa9euad0nViaToWnTpuJ0liVx4sQJjX3ICwoKxL6yyibusigoKMDGjRvRvHlzfP3113B3d1f7GTJkCK5evYrY2Ngy70cTmUyGXr16Yc+ePdi6dSsyMzPVnhqWx/lQtsIcPXpUJf3XX39Vy6scg/LDDz+oTQkJlK4blPI8f/7556/NW9y1oaurC4lEovJEWxAELFiwoMjtjRw5Ev/++y+2bduG48ePY9CgQSr9gHV0dPDVV1/hr7/+KnIa3ZJOtVnUOTp8+LDalI0ODg6wsLDAxo0bVbr+ZGdnY82aNWrbHjFiBJKTk4tssSjN+XhTMjMzsWrVKpW0VatWITMzE/369RPTlOex8HFSKBTw9fVV26byCeyMGTPUWjIKr6+cgaakraA1atRAx44dER4ejmvXrqls8+effwYAjU9fK1rfvn0hkUjwyy+/qHQFTEpKwoYNG2BtbY3WrVur5F26dKnKZ/jChQtq3wHm5uZwdXXFnj17NH72BEEQxz+VRmmPs729PbKysvDXX3+JaQUFBfjtt9/Utl2Sc75161Y8ePBA/DsvLw+//fYbdHV10bt3b5X93rx5U+XhVG5uLvz9/cu03zehqO+Xn376Se2z0adPHwCAn5+fyrKrV6+qzbpWHoo7JvXq1YOenp7aNXf69Gm2WBC974yMjBAcHIx+/fqhYcOGGD16NOzs7JCeno6bN29iz5492Lt3Lzp37ozGjRujadOmWLx4MZ49e4aGDRvi9u3bWLt2LZo3b67xqVJpfPnll5g/fz6SkpJUnswXZcmSJYiJiUGfPn3Qpk0bmJqaIjk5Gbt378b58+fRpUsXuLm5lbk8hw8fRkJCAsaMGVNkngEDBmDOnDlYv3492rVrV+Z9aTJy5Ejs378f06ZNg6mpqcqNGIByOR9DhgzBDz/8AE9PT9y8eRPVqlVDZGSkxil527Vrhzlz5mDOnDlo1aoVvvzyS1haWiIpKQnnz5/HoUOHkJeXV6K6HTp0CNWrVy/yrbCvKuracHd3x+7du9G1a1eMGDECL168wL59+4qdOvirr77CjBkz4O3tjYKCAo3dPBYuXIiYmBgMHDgQAwcORIcOHaCvr49///0Xhw4dQtu2bTXOwf6qTp06oVatWpg2bRri4+NRp04dXLp0CZs3b0bz5s1x9epVMa+enh6WLFmCr776Cu3bt8eYMWOgp6eHjRs3wtzcHPfu3VN5Mjp58mQcOXIE3377LY4fP46uXbvCxMQE9+/fx7Fjx8SWnIpka2uLuXPn4tq1a2jbti3Onz+PoKAgNGrUSGX6YHd3d3z//ffo1asXvvjiC2RmZmLbtm0aX7D15ZdfYtCgQQgODsadO3fQt29fVK1aFbdv38bvv/8u3qy2a9cOOjo6WLhwIZ4+fQojIyPUq1cPjo6ORZbXz88Pn3/+OT777DNxGtQDBw7g999/x9ChQ4t8Z05FatiwIb799lssXrwYTk5OGDRokDjdbHZ2NrZu3SregDZq1AjffPMNVq5cia5du2LAgAFITU3FypUr0bJlS7X3n6xevRqdOnWCk5MTRowYgdatW6OgoABxcXEICwtTeUJdGqU5zp6envj111/Rv39/TJ48Gfr6+ti1a5fGLklNmjSBVCrFqlWrUKVKFZiZmaFGjRrigHrgZcDg6OiI8ePHQyqVYtu2bYiNjcX//vc/lfFIEyZMQEhICFxcXDB+/Hjk5eVh8+bNGrs8luVaKw/9+/fHb7/9BldXV3h6ekJfXx9HjhzBlStX1Mb9NW3aFJ6enggICICLiwv69++PR48ewd/fH61bt8b58+fLteXF3NwcdnZ2CAkJga2tLWrWrAkjIyP06dMHxsbGGDVqFNatW4chQ4agc+fOuHPnDjZs2MDpZokqUnFT3OGVqUKVippe9OrVq8JXX30lWFpaCpUqVRJq1KghfPLJJ8K8efOEtLQ0MV98fLzg7u4uVK9eXahcubLQrl07Yc+ePVpPZSoIL6dH1NPTE5YsWaKx3K9OOXjmzBlh6tSpgoODg1CjRg1BT09PMDU1FTp06CD8+uuvwvPnz1Xyf/7554KRkZHG8gjC/039qJxK093dXQAgXLlypch1BEEQ7O3tBVNTU3HaU2tra6Fp06bFrlMSubm5QrVq1QQAwtdff60xT2nOh6Y0QRCEP//8U+jYsaNgYGAgmJubC2PHjhWePn1a5DV04MABoXv37kLVqlUFfX19oU6dOkLPnj2F1atXq+QrarrZ7OxswcjISJg+fXqJj0Vx10ZAQIDQuHFjwcDAQKhVq5YwduxYIS0trcjyC4Ig9O7dWwAgNGjQoMh95uTkCPPmzROaNWsmGBoaCsbGxkKjRo2Er7/+Wvjzzz/V6lnUVJOXL18WevToIZiZmQnGxsbC559/Lpw8ebLIz8fOnTuF5s2bC/r6+kLdunWFOXPmCHv27FGbPlcQXk5R6+fnJzg4OAhVqlQRqlSpItjZ2QlDhw4Vfv/99yLrVlzZy+t7RTld5/nz54UuXboIVapUEczMzIRhw4YJycnJKnkVCoXw008/Cba2toK+vr5gZWUlfPvtt8Lff/+tNo2lILycVnblypVC69athcqVKwvGxsZC8+bNhTlz5qjk27hxo9C4cWOhUqVKxV4PhV26dEn4z3/+I17fjRo1EhYtWqQyPWtRdX7dcXpVUZ9JTdN3KhU1/WpAQIDQqlUrwcDAQJBKpYKLi4tw8uRJtXz5+fnCggULBCsrK0FfX19o2rSpsGXLliLL8ujRI2H69OlCgwYNBAMDA8HU1FRo1qyZMGnSJJUpsUs75WpJj7MgCMLBgweFli1bCvr6+oKFhYUwY8YM4ebNmxqP0cGDB4XWrVsLBgYGAgBxytjCU5z6+fkJdnZ2gr6+vmBnZycsW7ZMYxk3btwo2NvbC5UqVRJsbGyERYsWCceOHdM4VWppr7Wirp/ipmLVNAXu3r17hTZt2ghVqlQRzM3NhUGDBgn//vuvxrwKhUKYM2eOULduXUFfX19o3ry5sGPHDmHatGkCACElJeW15RME9eu7qOv17NmzQseOHYUqVaoIAFSu26ysLGHMmDFCtWrVhMqVKwudOnUSYmJiBMn/3wERUbkYP348Dh8+jFu3bqk8rRw1ahROnDih8W2i9G7auHEjPDw8cO/ePZV+u35+fvjxxx/F2X1Kqqhr42Pw66+/Yvr06Thz5gw6dOhQ0cUpEeX0lIXf6k1UUU6cOIEuXbpgw4YNJXoD+8ekT58+OH78ODIzM9/I5AylwTEWRFSu5s2bh7S0tJdNovTBkcvl8PX1xbfffluqoAL4OK6NvLw8tfEr2dnZ8Pf3h7m5uco7TIiISkPTmMQrV64gIiICXbt2rfCgAuCsUERUzmrUqIGMjIyKLga9IZUrV0ZSUlKZ1v0Yro24uDj06tULgwcPRr169ZCUlIRNmzbh3r17WL16tdo7IYiISmrTpk0IDg6Gm5sbZDIZbt68iYCAAOjr62PevHkVXTwADCyIiIjKjUwmQ4cOHbB161akpqZCT08PzZs3h6+vLwYOHFjRxSOi91ibNm2wd+9eLF++HE+ePIFUKkXXrl0xe/ZsceawisYxFkREREREpDWOsSAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq0xsCAiIiIiIq39P0CP64Ui4KMkAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x950 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAxYAAAOsCAYAAADX7yC0AAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjkuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8hTgPZAAAACXBIWXMAAA9hAAAPYQGoP6dpAAEAAElEQVR4nOz9e1xVdd7//z82hzwAgjKkmAoeUi9Ty/LQ1RjphWVBdGmikl+zARNBmbQ8zFxdXp7G6zPmlJcYiIdAxfKEJwSF0QqwLE9pKo6Bx1BAyBQS3Ths2L8//LHH7UYSN6YzPe+3m7dbvNd7vddrvffqdluv9V7v9zKYzWYzIiIiIiIidnC43wGIiIiIiMg/PyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIlKrpUuXUlFRcb/DEBERkQecEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbwWw2m+93ECLy4DK8b7rfIYiIiMhtmCc73e8QLDRiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidlNiISIiIiIidnugE4uZM2fSs2fPO6pbUFBAz549WbJkyT2O6oa6xBYeHk5QUNA9jqh2de2fnJwcIiMj6d+//y/aryIiIiLyz+nB+aKGPDBMJhNTp07FZDIRERGBm5sbjz766P0O6xeXmZlJTk4OY8eOveN9Vq9ejZubW70nktnZ2aSlpXH8+HFOnDiB0WhkxowZtR6nqKiIjz76iK+++opLly7RpEkTOnXqxMSJE2nXrl29xiciIiLyQCcW06ZN47/+67/udxi/Ovn5+eTn5zNx4kSGDx9+v8O5bzIzM0lNTa1TYrFmzRq8vb3rPbHYvXs3SUlJ+Pr68uijj3LkyJFa63/33XeMHz+exo0b88orr9CiRQt++ukn/va3v3H58uV6jU1EREQE6iGxqKyspKKigoYNG9ZHPFacnJxwcnqgc59/ST/++CMA7u7u9dqu2WzGaDTSuHHjem33n1l4eDgAS5curbVecHAwo0aNolGjRnz66ae1JhbXr1/nv/7rv2jevDlLly7F1dW1XmMWERERqUmd7tpTUlKYNWsWsbGxHD16lJSUFC5cuMC0adMICgrCbDazceNGtmzZwpkzZ3BwcKBLly6MGTPGZj5Camoq69evJy8vD5PJhKenJ926dWPSpEk0bdoUuDGPITU1lQMHDljt++2337Jw4UJycnJwcXHB39+fIUOG3DbexYsX2xw/PDycwsJCUlJSLGV79uwhOTmZv/3tb1y8eBFnZ2cee+wxwsLCeOqpp+rSVXfk4MGDfPTRRxw7dgyTyYSvry9Dhw5l0KBBVvWys7PZsGEDR44coaioCEdHRzp06MDrr79O//79bdq90/6pSXh4OAcPHgRg1qxZzJo1C4CtW7fSsmVLjEYj8fHx7Ny5k+LiYpo0aUKfPn2IjIzE29vb0s6BAweIiIhgxowZGI1GkpKSOH/+PL/73e8sIwA7duxg3bp1nDhxgsrKSss5DRgwwCauAwcOsGrVKrKzszEajXh5efHUU0/x1ltv4eHhAUBSUhKZmZmcPn2ay5cv4+7uTu/evYmMjKRly5ZW7X355ZckJiZy6tQpysvL8fDwoEuXLkRFReHj42PVDzdfO7W9flRdr7Cw0Gqf6r6zh6en5x3X3blzJ+fOnWP+/Pm4urry97//HYCHHnrIrhhEREREanNXwwHR0dGYTCYGDx6Mi4sLPj4+AEyfPp2//vWv+Pv7ExQUREVFBWlpaYwfP5558+bx3HPPAbBt2zZmzpxJjx49iIiIoEGDBhQVFbF7924uXbpkSSxqkp2dzbhx42jcuDGjRo3Czc2NHTt2MGPGjLs5FSspKSmUlpYSEBBA8+bNKS4uJjk5mXHjxrF48WJ69Ohh9zGq7dq1iylTpuDp6cnIkSNp3LgxO3bsYM6cOeTn5zN+/HhL3czMTM6ePcuAAQPw9vamtLSU1NRUpkyZwpw5c3jxxRctde3tn7CwMB5//HGWL1/O4MGDLefctGlTTCYTUVFRHD58GH9/f0aOHEleXh4bN25k7969JCYm0rx5c6v21qxZQ2lpKYMGDcLT09OyfdGiRSQkJPDMM88QERGBg4MDGRkZ/PGPf2Tq1KkMGzbM0sbGjRuZO3cuDz/8MEOGDMHb25sLFy7wxRdfUFRUZEksPv74Y7p27crw4cNxd3fn1KlTbNmyhf3797N27VpLvW+++YZ33nmH9u3bExoaiqurKxcvXmTfvn2cO3cOHx8fwsLCMJvNHDp0iNmzZ1ti6d69+237bvbs2cyfPx8PDw/CwsIs5bVdz/fC7t27AXBzc2PMmDF8++23mM1mOnbsyO9//3v+/d///ReNR0RERH4d7iqxKC8vZ/Xq1VavP2VkZJCWlsa7777Lq6++aikPCQkhNDSUDz74AD8/PwwGA5mZmbi4uBAXF2f1qlNERMTPHnv+/PlUVVURHx9vSWiGDh3K6NGj7+ZUrEybNo1GjRpZlQ0ZMoRhw4axfPnyekssKisrmTdvHo0aNWLlypV4eXkBMGzYMMaOHcvKlSsJCgqiTZs2AIwePZqoqCirNkJCQhgxYgTx8fFWiYW9/fP000/j5OTE8uXL6d69OwEBAZZtmzdv5vDhw7z++utMmDDBUt6nTx8mTpxITEwMf/rTn6zau3DhAhs2bKBZs2aWsu+++46EhARCQ0OtEqiQkBAmTZpEbGwsgYGBuLi4UFRUxPvvv4+vry8JCQm4ublZ6kdGRlJVVWX5e+3atTa/n5+fH+PGjSM5OZk33ngDgKysLKqqqoiNjbWK680337Tqh/T0dA4dOmTVB7UJCAggLi6OZs2a3fE+98L3338PwNSpU+natSv/7//9P0pLS1m+fDkTJkzgww8/pE+fPvctPhEREfnXdFfLzQYHB9vMqdi+fTsuLi7069ePkpISy7+ysjKeffZZCgoKyMvLA8DV1ZXy8nK+/PJLzGbzHR/30qVLHDlyhOeee85y0wzg7OzMiBEj7uZUrNx8U3rt2jVKSkpwdHSka9euHDt2zO72qx0/fpwLFy7wyiuvWJIKuHEeo0aNoqqqiqysrBrjKi8vp6SkhPLycnr16sWZM2coKysD7n3/ZGRk4ODgQGhoqFV537596dixI7t27bK60QcIDAy0unkHSEtLw2AwEBgYaHWtlJSU4Ofnx9WrVzl69CgAn376KRUVFYwZM8Yqqajm4PCPS7i6n6qqqigrK6OkpISOHTvi6upKdna2pV71nIPPP/8ck8lkR4/UTfU1dfM/k8mEyWSyKb927ZpdxwHw9fVl/vz5PP/88wQHBxMXF4fBYGDRokX1dUoiIiIiFnc1YlH9JP1mZ8+e5erVq7zwwgu33e/SpUv4+PgQGhrKwYMHmTx5Mu7u7jz55JP89re/5fnnn8fFxeW2++fn5wM3bphuVR/LZ54/f57Y2Fj27NnDlStXrLYZDAa7269WUFAA1Bxz+/btgX+cK9zot7i4OLKysrh06ZLNPmVlZbi6ut7z/ikoKMDLy4smTZrUGHdubi4lJSVWiURN18qZM2cwm80EBwff9ljVE8jPnTsHQKdOnX42vv3797Ns2TKOHTvG9evXrbbd/HsOGzaMrKws5s6dy4cffsjjjz/OM888w8CBA+/pa0vz5s0jNTW1xm23zit5+eWXmTlz5l0dp0GDBsCNpO7m67ZNmzY8/vjjHDp0CKPRaDO6IyIiImKPu0osaloBymw207RpU+bMmXPb/apvmtu0aUNSUhL79u1j//79HDx4kDlz5rBkyRKWLVtGq1at7iYsG7UlA5WVlVZ/X7t2jTFjxmA0Gnnttdfo0KEDLi4uGAwGVqxYwf79++slproym81ERUVx5swZQkJC6NKlC66urjg4OJCSkkJ6errNKMGD5HarhRkMBhYuXGg14nCz6mvlTh07doyoqChatWpFVFQULVu2pEGDBhgMBt59912rPvLw8CAxMZFDhw6xd+9eDh06xPz581myZAnR0dG1zqOwx6hRo3jppZesyhYsWADAxIkTrcpvHsmqq+bNm3Pq1KkaJ3x7enpiNpspKytTYiEiIiL1qt7Wcm3dujV5eXl069btjpYTfeihh+jbty99+/YFbqzSM3HiRD755BP+8Ic/1LhP9co6Z8+etdl2+vRpm7LqJ+s//fSTzbaCggKr+R379u3jhx9+YPr06bzyyitWdePi4n72fOrikUceAWqOubqsus6JEyfIzc1lzJgxNt9T2LJli9Xfde2funrkkUf4+uuvuXLlis1rSadPn8bFxcUyQbo2rVu35quvvqJFixa0bdu21rrVIx65ublWr3fdKj09ncrKShYuXGjpOwCj0Wgz+gTg6OhIz549Las3nThxgpEjRxIfH090dDRwd6NUte3Trl07m5Gj6n6szzkPjz32GF999RVFRUU224qLi3F0dKxx1ElERETEHnc1x6ImgYGBVFVVERMTU+P26ldbAEpKSmy2d+7cGYDS0tLbHqN6SdqsrCzLBFWAiooKVq9ebVO/+qZ03759VuXp6en88MMPVmWOjo4ANnM+9uzZY/V+fn3o3LkzLVq0ICUlhYsXL1rKTSYTq1atwmAwWFbQqn6if2tcJ0+eJDMz06qsrv1TV/369aOqqooVK1ZYle/evZucnBz8/PxuOwJxs+qJzbGxsTYjR2B9rfj7++Ps7MyyZcssc0luVt0vt/v9EhISbEZ0arr+fH19adiwoVUSWv1Ev7Zr8laNGjWqMZH9JQ0cOBBHR0eSk5Ot5pDk5uZy9OhRevbsaXldSkRERKS+1NuIxYABAwgKCmL9+vV89913PPvss3h4eFBcXMyRI0c4f/48ycnJAIwfPx43Nzd69OhB8+bNuXLlCikpKRgMhp9dTeftt99m7NixjB49mqFDh1qWU63pBtXX15fevXuzadMmy3Kbubm5ZGZm0rp1a6ubrieeeAJPT08WLFhAYWEhDz/8MLm5uWzfvp0OHTpw8uTJ+uoqHB0dmTp1KlOmTOGNN95g8ODBNG7cmJ07d3L06FFCQ0MtSVHbtm1p164diYmJlJeX4+PjQ15eHps2baJDhw4cP378rvunroKCgkhNTWXlypUUFBTw5JNPcu7cOTZs2ICnp6fVCk+1eeyxxwgPD2fp0qWMGDGCAQMG4OXlxcWLFzl+/Di7d+9mz549wI3XeiZNmsR7771HSEgIgYGBeHt7U1xcTFZWFtOnT6dTp07069eP1atXM2HCBAYPHoyzszN79+7l5MmTNqMoc+bMobi4mD59+uDt7c3169fZuXMnV69eJTAw0FKvW7durF+/nrlz59K3b1+cnJzo2rWr1YjIrbp160ZycjJxcXG0bdsWg8GAn5+f3a8dFRYWsm3bNuAfo0+7du2yjEpU9wvcuO5HjRrF8uXLCQ8P54UXXuCnn35i3bp1NGzY0Oa1KxEREZH6UK+ftZ4xYwY9e/Zk8+bNrFixgoqKCjw9PencubPVTWdwcDA7d+5k06ZNlJaW4u7uTqdOnZg6darNh+xu1b17d2JjY4mJiWHlypW4urpaPgAXEhJiU3/27Nn85S9/IT09ne3bt9OjRw8WL17Mn//8ZwoLCy313NzciImJYeHChaxbt47Kyko6d+5MdHQ0ycnJ9ZpYwI1lUBctWkR8fDyrVq2ioqICX19fpk2bZvWBPEdHR6Kjo1mwYAGpqakYjUbat2/PzJkzyc3NtUks6to/deHk5ERMTIzlA3kZGRm4ubnh7+/PuHHjaNGixR23FR4eTpcuXVi7di1r1qzBaDTSrFkz2rdvz+TJk63qBgcH06pVKxITE1m7di0VFRV4eXnRq1cvy3cxnnjiCebNm8dHH33E4sWLadCgAb1792bp0qWMGTPGqr2AgABSUlLYtm0bly9fxsXFhXbt2vHee+/h7+9vqTdw4EBycnLYsWMHn332GVVVVcyYMaPWxGLcuHGUlpaSlJTElStXMJvNbN261e7EIj8/n8WLF1uVZWRkkJGRYTn/mz9QOH78eLy9vUlKSmLhwoU0aNCAnj17EhERUef5KyIiIiJ3wmCuy3qvIvKrY3j/l1uSV0REROrGPLlexwnsUm9zLERERERE5NdLiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNhNiYWIiIiIiNjtwVmfSkQeSEuaJBAaGoqzs/P9DkVEREQeYBqxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuxnMZrP5fgchIg8uw/um+x2CiIjIPyXzZKf7HcIvSiMWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJiNyUWIiIiIiJitwc6sZg5cyY9e/a8o7oFBQX07NmTJUuW3OOobqhLbOHh4QQFBd3jiGpX1/7JyckhMjKS/v37/6L9KiIiIiL/nH5dX+2QO2IymZg6dSomk4mIiAjc3Nx49NFH73dYv7jMzExycnIYO3bsHe+zevVq3Nzc6j2RzM7OJi0tjePHj3PixAmMRiMzZsyo8TgFBQW88sorNbbTrl071q9fX6+xiYiIiMADnlhMmzaN//qv/7rfYfzq5Ofnk5+fz8SJExk+fPj9Due+yczMJDU1tU6JxZo1a/D29q73xGL37t0kJSXh6+vLo48+ypEjR352n/79+9O/f3+rMjc3t3qNS0RERKSa3YlFZWUlFRUVNGzYsD7iseLk5IST0wOd+/xL+vHHHwFwd3ev13bNZjNGo5HGjRvXa7v/zMLDwwFYunRprfWCg4MZNWoUjRo14tNPP72jxKJDhw4EBATUS5wiIiIiP6dOd+0pKSnMmjWL2NhYjh49SkpKChcuXGDatGkEBQVhNpvZuHEjW7Zs4cyZMzg4ONClSxfGjBljMx8hNTWV9evXk5eXh8lkwtPTk27dujFp0iSaNm0K3JjHkJqayoEDB6z2/fbbb1m4cCE5OTm4uLjg7+/PkCFDbhvv4sWLbY4fHh5OYWEhKSkplrI9e/aQnJzM3/72Ny5evIizszOPPfYYYWFhPPXUU3Xpqjty8OBBPvroI44dO4bJZMLX15ehQ4cyaNAgq3rZ2dls2LCBI0eOUFRUhKOjIx06dOD111+3eSINd94/NQkPD+fgwYMAzJo1i1mzZgGwdetWWrZsidFoJD4+np07d1JcXEyTJk3o06cPkZGReHt7W9o5cOAAERERzJgxA6PRSFJSEufPn+d3v/udZQRgx44drFu3jhMnTlBZWWk5pwEDBtjEdeDAAVatWkV2djZGoxEvLy+eeuop3nrrLTw8PABISkoiMzOT06dPc/nyZdzd3enduzeRkZG0bNnSqr0vv/ySxMRETp06RXl5OR4eHnTp0oWoqCh8fHys+uHma+d2rx/dXK+wsNBqn+q+s4enp+dd7Xf9+nXMZvM9SfxFREREbnZXwwHR0dGYTCYGDx6Mi4sLPj4+AEyfPp2//vWv+Pv7ExQUREVFBWlpaYwfP5558+bx3HPPAbBt2zZmzpxJjx49iIiIoEGDBhQVFbF7924uXbpkSSxqkp2dzbhx42jcuDGjRo3Czc2NHTt2MGPGjLs5FSspKSmUlpYSEBBA8+bNKS4uJjk5mXHjxrF48WJ69Ohh9zGq7dq1iylTpuDp6cnIkSNp3LgxO3bsYM6cOeTn5zN+/HhL3czMTM6ePcuAAQPw9vamtLSU1NRUpkyZwpw5c3jxxRctde3tn7CwMB5//HGWL1/O4MGDLefctGlTTCYTUVFRHD58GH9/f0aOHEleXh4bN25k7969JCYm0rx5c6v21qxZQ2lpKYMGDcLT09OyfdGiRSQkJPDMM88QERGBg4MDGRkZ/PGPf2Tq1KkMGzbM0sbGjRuZO3cuDz/8MEOGDMHb25sLFy7wxRdfUFRUZEksPv74Y7p27crw4cNxd3fn1KlTbNmyhf3797N27VpLvW+++YZ33nmH9u3bExoaiqurKxcvXmTfvn2cO3cOHx8fwsLCMJvNHDp0iNmzZ1ti6d69+237bvbs2cyfPx8PDw/CwsIs5bVdz/fSJ598wkcffYTZbKZ58+YEBQURFhbGQw89dF/iERERkX9td5VYlJeXs3r1aqunoBkZGaSlpfHuu+/y6quvWspDQkIIDQ3lgw8+wM/PD4PBQGZmJi4uLsTFxVm96hQREfGzx54/fz5VVVXEx8dbEpqhQ4cyevTouzkVK9OmTaNRo0ZWZUOGDGHYsGEsX7683hKLyspK5s2bR6NGjVi5ciVeXl4ADBs2jLFjx7Jy5UqCgoJo06YNAKNHjyYqKsqqjZCQEEaMGEF8fLxVYmFv/zz99NM4OTmxfPlyunfvbvUqzebNmzl8+DCvv/46EyZMsJT36dOHiRMnEhMTw5/+9Cer9i5cuMCGDRto1qyZpey7774jISGB0NBQqwQqJCSESZMmERsbS2BgIC4uLhQVFfH+++/j6+tLQkKC1RyByMhIqqqqLH+vXbvW5vfz8/Nj3LhxJCcn88YbbwCQlZVFVVUVsbGxVnG9+eabVv2Qnp7OoUOH7vh1ooCAAOLi4mjWrNl9fQXJwcGBXr168dxzz+Ht7c3ly5f59NNP+eijjzhy5Agffvghjo6O9y0+ERER+dd0V8vNBgcH27xasX37dlxcXOjXrx8lJSWWf2VlZTz77LMUFBSQl5cHgKurK+Xl5Xz55ZeYzeY7Pu6lS5c4cuQIzz33nOWmGcDZ2ZkRI0bczalYufmm9Nq1a5SUlODo6EjXrl05duyY3e1XO378OBcuXOCVV16xJBVw4zxGjRpFVVUVWVlZNcZVXl5OSUkJ5eXl9OrVizNnzlBWVgbc+/7JyMjAwcGB0NBQq/K+ffvSsWNHdu3aZXWjDxAYGGh18w6QlpaGwWAgMDDQ6lopKSnBz8+Pq1evcvToUQA+/fRTKioqGDNmTI0Tjx0c/nEJV/dTVVUVZWVllJSU0LFjR1xdXcnOzrbUc3V1BeDzzz/HZDLZ0SN1U31N3fzPZDJhMplsyq9du3bXx2nRogVxcXGEhITw3HPPMWjQIGJiYhg8eDD79u1jx44d9XhWIiIiIjfc1YhF9ZP0m509e5arV6/ywgsv3Ha/S5cu4ePjQ2hoKAcPHmTy5Mm4u7vz5JNP8tvf/pbnn38eFxeX2+6fn58PgK+vr822du3a1f1EbnH+/HliY2PZs2cPV65csdpmMBjsbr9aQUEBUHPM7du3B/5xrnCj3+Li4sjKyuLSpUs2+5SVleHq6nrP+6egoAAvLy+aNGlSY9y5ubmUlJRYJRI1XStnzpzBbDYTHBx822NVTyA/d+4cAJ06dfrZ+Pbv38+yZcs4duwY169ft9p28+85bNgwsrKymDt3Lh9++CGPP/44zzzzDAMHDrynry3NmzeP1NTUGrfdOq/k5ZdfZubMmfV6/LCwMDZv3syXX37JSy+9VK9ti4iIiNxVYlHTRFCz2UzTpk2ZM2fObfervmlu06YNSUlJ7Nu3j/3793Pw4EHmzJnDkiVLWLZsGa1atbqbsGzUlgxUVlZa/X3t2jXGjBmD0Wjktddeo0OHDri4uGAwGFixYgX79++vl5jqymw2ExUVxZkzZwgJCaFLly64urri4OBASkoK6enpNqMED5LbTRo2GAwsXLjQasThZtXXyp06duwYUVFRtGrViqioKFq2bEmDBg0wGAy8++67Vn3k4eFBYmIihw4dYu/evRw6dIj58+ezZMkSoqOja51HYY9Ro0bZ3NAvWLAAgIkTJ1qV3zySVV+aN2+Oo6MjJSUl9d62iIiISL2t5dq6dWvy8vLo1q3bHS0n+tBDD9G3b1/69u0L3FilZ+LEiXzyySf84Q9/qHGf6pV1zp49a7Pt9OnTNmXVT9Z/+uknm20FBQVW8zv27dvHDz/8wPTp020+LhYXF/ez51MXjzzyCFBzzNVl1XVOnDhBbm4uY8aMsfmewpYtW6z+rmv/1NUjjzzC119/zZUrV2xeSzp9+jQuLi6WCdK1ad26NV999RUtWrSgbdu2tdatHvHIzc21er3rVunp6VRWVrJw4UJL3wEYjUab0ScAR0dHevbsaVm96cSJE4wcOZL4+Hiio6OBuxulqm2fdu3a2YwcVfdjnz596nysusrPz6eystLm1TQRERGR+nBXcyxqEhgYSFVVFTExMTVur361BajxiWnnzp0BKC0tve0xqpekzcrK4vvvv7eUV1RUsHr1apv61Tel+/btsypPT0/nhx9+sCqrnsx665yPPXv2WL2fXx86d+5MixYtSElJ4eLFi5Zyk8nEqlWrMBgMlhW0qp/o3xrXyZMnyczMtCqra//UVb9+/aiqqmLFihVW5bt37yYnJwc/P7/bjkDcrHpic2xsrM3IEVhfK/7+/jg7O7Ns2TLLXJKbVffL7X6/hIQEmxGdmq4/X19fGjZsaJWEVs/ZqO2avFWjRo1qTGR/STWdX1VVFYsWLQJuTGgXERERqW/1NmIxYMAAgoKCWL9+Pd999x3PPvssHh4eFBcXc+TIEc6fP09ycjIA48ePx83NjR49etC8eXOuXLlCSkoKBoPhZ1fTefvttxk7diyjR49m6NChluVUa7pB9fX1pXfv3mzatAmz2UzHjh3Jzc0lMzOT1q1bW03cfeKJJ/D09GTBggUUFhby8MMPk5uby/bt2+nQoQMnT56sr67C0dGRqVOnMmXKFN544w0GDx5M48aN2blzJ0ePHiU0NNSSFLVt25Z27dqRmJhIeXk5Pj4+5OXlsWnTJjp06MDx48fvun/qKigoiNTUVFauXElBQQFPPvkk586dY8OGDXh6elqt8FSbxx57jPDwcJYuXcqIESMYMGAAXl5eXLx4kePHj7N792727NkD3Hh9Z9KkSbz33nuEhIQQGBiIt7c3xcXFZGVlMX36dDp16kS/fv1YvXo1EyZMYPDgwTg7O7N3715OnjxpM4oyZ84ciouL6dOnD97e3ly/fp2dO3dy9epVAgMDLfW6devG+vXrmTt3Ln379sXJyYmuXbtajYjcqlu3biQnJxMXF0fbtm0xGAz4+fnZrFZVV4WFhWzbtg34x+jTrl27KCoqArD0C8D//u//cvXqVbp3707z5s0pKSnh888/5/jx4zz33HP4+/vbFYuIiIhITer1s9YzZsygZ8+ebN68mRUrVlBRUYGnpyedO3e2uukMDg5m586dbNq0idLSUtzd3enUqRNTp061+ZDdrbp3705sbCwxMTGsXLkSV1dXywfgQkJCbOrPnj2bv/zlL6Snp7N9+3Z69OjB4sWL+fOf/0xhYaGlnpubGzExMSxcuJB169ZRWVlJ586diY6OJjk5uV4TC7jx1HjRokXEx8ezatUqKioq8PX1Zdq0aVYfyHN0dCQ6OpoFCxaQmpqK0Wikffv2zJw5k9zcXJvEoq79UxdOTk7ExMRYPpCXkZGBm5sb/v7+jBs3jhYtWtxxW+Hh4XTp0oW1a9eyZs0ajEYjzZo1o3379kyePNmqbnBwMK1atSIxMZG1a9dSUVGBl5cXvXr1snwX44knnmDevHl89NFHLF68mAYNGtC7d2+WLl3KmDFjrNoLCAggJSWFbdu2cfnyZVxcXGjXrh3vvfee1U33wIEDycnJYceOHXz22WdUVVUxY8aMWhOLcePGUVpaSlJSEleuXMFsNrN161a7E4v8/HwWL15sVZaRkUFGRobl/KsTi9/+9rds376dzZs3U1paykMPPUS7du34wx/+wJAhQ+5oVElERESkrgzmuqz3KiK/Oob3f7kleUVERP6VmCfX6zP8B54eXYqIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN1+XYvrikidLWmSQGhoKM7Ozvc7FBEREXmAacRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETsZjCbzeb7HYSIPLgM75vudwgiIiL3hXmy0/0O4Z+KRixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuSixERERERMRuD3RiMXPmTHr27HlHdQsKCujZsydLliy5x1HdUJfYwsPDCQoKuscR1a6u/ZOTk0NkZCT9+/f/RftVRERERP456asfYsNkMjF16lRMJhMRERG4ubnx6KOP3u+wfnGZmZnk5OQwduzYO95n9erVuLm51XsimZ2dTVpaGsePH+fEiRMYjUZmzJhR43FmzpxJamrqbdtq3bo1mzdvrtf4RERERB7oxGLatGn813/91/0O41cnPz+f/Px8Jk6cyPDhw+93OPdNZmYmqampdUos1qxZg7e3d70nFrt37yYpKQlfX18effRRjhw5ctu6r776Kr1797Yp379/PykpKTz77LP1GpuIiIgI1ENiUVlZSUVFBQ0bNqyPeKw4OTnh5PRA5z7/kn788UcA3N3d67Vds9mM0WikcePG9druP7Pw8HAAli5dWmu94OBgRo0aRaNGjfj0009rTSy6d+9O9+7dbcq3b98OwH/+53/aEbGIiIhIzep0156SksKsWbOIjY3l6NGjpKSkcOHCBaZNm0ZQUBBms5mNGzeyZcsWzpw5g4ODA126dGHMmDE28xFSU1NZv349eXl5mEwmPD096datG5MmTaJp06bAP17pOHDggNW+3377LQsXLiQnJwcXFxf8/f0ZMmTIbeNdvHixzfHDw8MpLCwkJSXFUrZnzx6Sk5P529/+xsWLF3F2duaxxx4jLCyMp556qi5ddUcOHjzIRx99xLFjxzCZTPj6+jJ06FAGDRpkVS87O5sNGzZw5MgRioqKcHR0pEOHDrz++uv079/fpt077Z+ahIeHc/DgQQBmzZrFrFmzANi6dSstW7bEaDQSHx/Pzp07KS4upkmTJvTp04fIyEi8vb0t7Rw4cICIiAhmzJiB0WgkKSmJ8+fP87vf/c4yArBjxw7WrVvHiRMnqKystJzTgAEDbOI6cOAAq1atIjs7G6PRiJeXF0899RRvvfUWHh4eACQlJZGZmcnp06e5fPky7u7u9O7dm8jISFq2bGnV3pdffkliYiKnTp2ivLwcDw8PunTpQlRUFD4+Plb9cPO1c7vXj26uV1hYaLVPdd/Zw9PT0679CwsL2bdvH926daN9+/Z2tSUiIiJSk7saDoiOjsZkMjF48GBcXFzw8fEBYPr06fz1r3/F39+foKAgKioqSEtLY/z48cybN4/nnnsOgG3btjFz5kx69OhBREQEDRo0oKioiN27d3Pp0iVLYlGT7Oxsxo0bR+PGjRk1ahRubm7s2LGDGTNm3M2pWElJSaG0tJSAgACaN29OcXExycnJjBs3jsWLF9OjRw+7j1Ft165dTJkyBU9PT0aOHEnjxo3ZsWMHc+bMIT8/n/Hjx1vqZmZmcvbsWQYMGIC3tzelpaWkpqYyZcoU5syZw4svvmipa2//hIWF8fjjj7N8+XIGDx5sOeemTZtiMpmIiori8OHD+Pv7M3LkSPLy8ti4cSN79+4lMTGR5s2bW7W3Zs0aSktLGTRoEJ6enpbtixYtIiEhgWeeeYaIiAgcHBzIyMjgj3/8I1OnTmXYsGGWNjZu3MjcuXN5+OGHGTJkCN7e3ly4cIEvvviCoqIiS2Lx8ccf07VrV4YPH467uzunTp1iy5Yt7N+/n7Vr11rqffPNN7zzzju0b9+e0NBQXF1duXjxIvv27ePcuXP4+PgQFhaG2Wzm0KFDzJ492xJLTSMB1WbPns38+fPx8PAgLCzMUl7b9fxL2bp1K1VVVRqtEBERkXvmrhKL8vJyVq9ebfX6U0ZGBmlpabz77ru8+uqrlvKQkBBCQ0P54IMP8PPzw2AwkJmZiYuLC3FxcVavOkVERPzssefPn09VVRXx8fGWhGbo0KGMHj36bk7FyrRp02jUqJFV2ZAhQxg2bBjLly+vt8SisrKSefPm0ahRI1auXImXlxcAw4YNY+zYsaxcuZKgoCDatGkDwOjRo4mKirJqIyQkhBEjRhAfH2+VWNjbP08//TROTk4sX76c7t27ExAQYNm2efNmDh8+zOuvv86ECRMs5X369GHixInExMTwpz/9yaq9CxcusGHDBpo1a2Yp++6770hISCA0NNQqgQoJCWHSpEnExsYSGBiIi4sLRUVFvP/++/j6+pKQkICbm5ulfmRkJFVVVZa/165da/P7+fn5MW7cOJKTk3njjTcAyMrKoqqqitjYWKu43nzzTat+SE9P59ChQ1Z9UJuAgADi4uJo1qzZHe/zS6iqqiIlJYXGjRvzwgsv3O9wRERE5F/UXS03GxwcbDOnYvv27bi4uNCvXz9KSkos/8rKynj22WcpKCggLy8PAFdXV8rLy/nyyy8xm813fNxLly5x5MgRnnvuOctNM4CzszMjRoy4m1OxcvNN6bVr1ygpKcHR0ZGuXbty7Ngxu9uvdvz4cS5cuMArr7xiSSrgxnmMGjWKqqoqsrKyaoyrvLyckpISysvL6dWrF2fOnKGsrAy49/2TkZGBg4MDoaGhVuV9+/alY8eO7Nq1y+pGHyAwMNDq5h0gLS0Ng8FAYGCg1bVSUlKCn58fV69e5ejRowB8+umnVFRUMGbMGKukopqDwz8u4ep+qqqqoqysjJKSEjp27IirqyvZ2dmWeq6urgB8/vnnmEwmO3qkbqqvqZv/mUwmTCaTTfm1a9fq7bh79+7lwoULPP/885rfIiIiIvfMXY1YVD9Jv9nZs2e5evVqrU9EL126hI+PD6GhoRw8eJDJkyfj7u7Ok08+yW9/+1uef/55XFxcbrt/fn4+AL6+vjbb2rVrV/cTucX58+eJjY1lz549XLlyxWqbwWCwu/1qBQUFQM0xV7//Xn2ucKPf4uLiyMrK4tKlSzb7lJWV4erqes/7p6CgAC8vL5o0aVJj3Lm5uZSUlFglEjVdK2fOnMFsNhMcHHzbY1VPID937hwAnTp1+tn49u/fz7Jlyzh27BjXr1+32nbz7zls2DCysrKYO3cuH374IY8//jjPPPMMAwcOvKevLc2bN++2y8DeOq/k5ZdfZubMmfVy3OTkZACbuTsiIiIi9emuEouaVoAym800bdqUOXPm3Ha/6pvmNm3akJSUxL59+9i/fz8HDx5kzpw5LFmyhGXLltGqVau7CctGbclAZWWl1d/Xrl1jzJgxGI1GXnvtNTp06ICLiwsGg4EVK1awf//+eomprsxmM1FRUZw5c4aQkBC6dOmCq6srDg4OpKSkkJ6ebjNK8CC53WphBoOBhQsXWo043KyuE4yPHTtGVFQUrVq1IioqipYtW9KgQQMMBgPvvvuuVR95eHiQmJjIoUOH2Lt3L4cOHWL+/PksWbKE6OjoWudR2GPUqFG89NJLVmULFiwAYOLEiVblN49k2aOkpISsrCzat29Pt27d6qVNERERkZrU21qurVu3Ji8vj27dut3R6xYPPfQQffv2pW/fvsCNVXomTpzIJ598wh/+8Ica96leWefs2bM2206fPm1TVv1k/aeffrLZVlBQYDW/Y9++ffzwww9Mnz6dV155xapuXFzcz55PXTzyyCNAzTFXl1XXOXHiBLm5uYwZM8bmewpbtmyx+ruu/VNXjzzyCF9//TVXrlyxeS3p9OnTuLi4WCZI16Z169Z89dVXtGjRgrZt29Zat3rEIzc31+r1rlulp6dTWVnJwoULLX0HYDQabUafABwdHenZs6dl9aYTJ04wcuRI4uPjiY6OBu5ulKq2fdq1a2czclTdj3369Knzse7Etm3bqKio0KRtERERuefuao5FTQIDA6mqqiImJqbG7dWvtsCNp6i36ty5MwClpaW3PUb1krRZWVl8//33lvKKigpWr15tU7/6pnTfvn1W5enp6fzwww9WZY6OjgA2cz727Nlj9X5+fejcuTMtWrQgJSWFixcvWspNJhOrVq3CYDBYVtCqfqJ/a1wnT54kMzPTqqyu/VNX/fr1o6qqihUrVliV7969m5ycHPz8/G47AnGz6onNsbGxNiNHYH2t+Pv74+zszLJlyyxzSW5W3S+3+/0SEhJsRnRquv58fX1p2LChVRJaPWejtmvyVo0aNaoxkb1fkpOTcXZ2fqAmk4uIiMi/pnobsRgwYABBQUGsX7+e7777jmeffRYPDw+Ki4s5cuQI58+ft7zrPX78eNzc3OjRowfNmzfnypUrpKSkYDAYfvYG6O2332bs2LGMHj2aoUOHWpZTrekG1dfXl969e7Np0ybMZjMdO3YkNzeXzMxMWrdubTVx94knnsDT05MFCxZQWFjIww8/TG5uLtu3b6dDhw6cPHmyvroKR0dHpk6dypQpU3jjjTcYPHgwjRs3ZufOnRw9epTQ0FBLUtS2bVvatWtHYmIi5eXl+Pj4kJeXx6ZNm+jQoQPHjx+/6/6pq6CgIFJTU1m5ciUFBQU8+eSTnDt3jg0bNuDp6Wm1wlNtHnvsMcLDw1m6dCkjRoxgwIABeHl5cfHiRY4fP87u3bvZs2cPAM2bN2fSpEm89957hISEEBgYiLe3N8XFxWRlZTF9+nQ6depEv379WL16NRMmTGDw4ME4Ozuzd+9eTp48aTOKMmfOHIqLi+nTpw/e3t5cv36dnTt3cvXqVQIDAy31unXrxvr165k7dy59+/bFycmJrl27Wo2I3Kpbt24kJycTFxdH27ZtMRgM+Pn52axWVVeFhYVs27YN+Mfo065duygqKgKw9MvNsrOzOX36NM8///wdjSSJiIiI2KNeP2s9Y8YMevbsyebNm1mxYgUVFRV4enrSuXNnq5vO4OBgdu7cyaZNmygtLcXd3Z1OnToxdepUmw/Z3ap79+7ExsYSExPDypUrcXV1tXwALiQkxKb+7Nmz+ctf/kJ6ejrbt2+nR48eLF68mD//+c8UFhZa6rm5uRETE8PChQtZt24dlZWVdO7cmejoaJKTk+s1sYAby6AuWrSI+Ph4Vq1aRUVFBb6+vkybNs1qkq2joyPR0dEsWLCA1NRUjEYj7du3Z+bMmeTm5tokFnXtn7pwcnIiJibG8oG8jIwM3Nzc8Pf3Z9y4cbRo0eKO2woPD6dLly6sXbuWNWvWYDQaadasGe3bt2fy5MlWdYODg2nVqhWJiYmsXbuWiooKvLy86NWrl+W7GE888QTz5s3jo48+YvHixTRo0IDevXuzdOlSxowZY9VeQEAAKSkpbNu2jcuXL+Pi4kK7du1477338Pf3t9QbOHAgOTk57Nixg88++4yqqipmzJhRa2Ixbtw4SktLSUpK4sqVK5jNZrZu3Wp3YpGfn8/ixYutyjIyMsjIyLCc/62JRXUir9egRERE5JdgMNdlvVcR+dUxvP/LLckrIiLyIDFPrtdn8P/y6m2OhYiIiIiI/HopsRAREREREbspsRAREREREbspsRAREREREbspsRAREREREbspsRAREREREbtpDS0RqdWSJgmEhobi7Ox8v0MRERGRB5hGLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG5KLERERERExG4Gs9lsvt9BiMiDy/C+6X6HICIics+YJzvd7xD+ZWjEQkRERERE7KbEQkRERERE7KbEQkRERERE7KbEQkRERERE7KbEQkRERERE7KbEQkRERERE7PZAJxYzZ86kZ8+ed1S3oKCAnj17smTJknsc1Q11iS08PJygoKB7HFHt6to/OTk5REZG0r9//1+0X0VERETkn5MW7hUbJpOJqVOnYjKZiIiIwM3NjUcfffR+h/WLy8zMJCcnh7Fjx97xPqtXr8bNza3eE8ns7GzS0tI4fvw4J06cwGg0MmPGjDs6zsWLFxk6dChXrlxhwoQJvP766/Uam4iIiAg84CMW06ZNY/fu3fc7jF+d/Px88vPzee211xg+fDgBAQG/2sRi2bJlddpnzZo1pKSk1Hssu3fvJikpibKysjr/FvPmzaOysrLeYxIRERG5md2JRWVlJeXl5fURiw0nJycaNGhwT9qW2/vxxx8BcHd3r9d2zWYz165dq9c2/9mFh4cTHh7+s/WCg4PJyspi/fr1jBgx4o7bz8rKIjMzkzfffNOeMEVERER+Vp1ehUpJSWHWrFnExsZy9OhRUlJSuHDhAtOmTSMoKAiz2czGjRvZsmULZ86cwcHBgS5dujBmzBib+QipqamsX7+evLw8TCYTnp6edOvWjUmTJtG0aVPgxjyG1NRUDhw4YLXvt99+y8KFC8nJycHFxQV/f3+GDBly23gXL15sc/zw8HAKCwutni7v2bOH5ORk/va3v3Hx4kWcnZ157LHHCAsL46mnnqpLV92RgwcP8tFHH3Hs2DFMJhO+vr4MHTqUQYMGWdXLzs5mw4YNHDlyhKKiIhwdHenQoQOvv/46/fv3t2n3TvunJuHh4Rw8eBCAWbNmMWvWLAC2bt1Ky5YtMRqNxMfHs3PnToqLi2nSpAl9+vQhMjISb29vSzsHDhwgIiKCGTNmYDQaSUpK4vz58/zud7+zvFq0Y8cO1q1bx4kTJ6isrLSc04ABA2ziOnDgAKtWrSI7Oxuj0YiXlxdPPfUUb731Fh4eHgAkJSWRmZnJ6dOnuXz5Mu7u7vTu3ZvIyEhatmxp1d6XX35JYmIip06dory8HA8PD7p06UJUVBQ+Pj5W/XDztVPb60fV9QoLC632qe47e3h6etZ5n6tXrzJv3jyGDBlCly5d7Dq+iIiIyM+5qzkW0dHRmEwmBg8ejIuLCz4+PgBMnz6dv/71r/j7+xMUFERFRQVpaWmMHz+eefPm8dxzzwGwbds2Zs6cSY8ePYiIiKBBgwYUFRWxe/duLl26ZEksapKdnc24ceNo3Lgxo0aNws3NjR07djBjxoy7ORUrKSkplJaWEhAQQPPmzSkuLiY5OZlx48axePFievToYfcxqu3atYspU6bg6enJyJEjady4MTt27GDOnDnk5+czfvx4S93MzEzOnj3LgAED8Pb2prS0lNTUVKZMmcKcOXN48cUXLXXt7Z+wsDAef/xxli9fzuDBgy3n3LRpU0wmE1FRURw+fBh/f39GjhxJXl4eGzduZO/evSQmJtK8eXOr9tasWUNpaSmDBg3C09PTsn3RokUkJCTwzDPPEBERgYODAxkZGfzxj39k6tSpDBs2zNLGxo0bmTt3Lg8//DBDhgzB29ubCxcu8MUXX1BUVGRJLD7++GO6du3K8OHDcXd359SpU2zZsoX9+/ezdu1aS71vvvmGd955h/bt2xMaGoqrqysXL15k3759nDt3Dh8fH8LCwjCbzRw6dIjZs2dbYunevftt+2727NnMnz8fDw8PwsLCLOW1Xc/3UkxMDJWVlYwfP57vvvvuvsQgIiIivx53lViUl5ezevVqGjZsaCnLyMggLS2Nd999l1dffdVSHhISQmhoKB988AF+fn4YDAYyMzNxcXEhLi4OJ6d/hBAREfGzx54/fz5VVVXEx8dbEpqhQ4cyevTouzkVK9OmTaNRo0ZWZUOGDGHYsGEsX7683hKLyspK5s2bR6NGjVi5ciVeXl4ADBs2jLFjx7Jy5UqCgoJo06YNAKNHjyYqKsqqjZCQEEaMGEF8fLxVYmFv/zz99NM4OTmxfPlyunfvTkBAgGXb5s2bOXz4MK+//joTJkywlPfp04eJEycSExPDn/70J6v2Lly4wIYNG2jWrJml7LvvviMhIYHQ0FCrBCokJIRJkyYRGxtLYGAgLi4uFBUV8f777+Pr60tCQgJubm6W+pGRkVRVVVn+Xrt2rc3v5+fnx7hx40hOTuaNN94AbrweVFVVRWxsrFVcN78u9PTTT5Oens6hQ4es+qA2AQEBxMXF0axZszve5145evQoGzduZM6cObi6ut7XWEREROTX4a7mWAQHB1slFQDbt2/HxcWFfv36UVJSYvlXVlbGs88+S0FBAXl5eQC4urpSXl7Ol19+idlsvuPjXrp0iSNHjvDcc89ZbpoBnJ2d6/Te+e3cfFN67do1SkpKcHR0pGvXrhw7dszu9qsdP36cCxcu8Morr1iSCrhxHqNGjaKqqoqsrKwa4yovL6ekpITy8nJ69erFmTNnKCsrA+59/2RkZODg4EBoaKhVed++fenYsSO7du2yutEHCAwMtLp5B0hLS8NgMBAYGGh1rZSUlODn58fVq1c5evQoAJ9++ikVFRWMGTPGKqmo5uDwj0u4up+qqqooKyujpKSEjh074urqSnZ2tqVe9Y32559/jslksqNH6qb6mrr5n8lkwmQy2ZTbMxfFZDIxZ84c+vTpwwsvvFCPZyAiIiJye3c1YlH9JP1mZ8+e5erVq7XeyFy6dAkfHx9CQ0M5ePAgkydPxt3dnSeffJLf/va3PP/887i4uNx2//z8fAB8fX1ttrVr167uJ3KL8+fPExsby549e7hy5YrVNoPBYHf71QoKCoCaY27fvj3wj3OFG/0WFxdHVlYWly5dstmnrKwMV1fXe94/BQUFeHl50aRJkxrjzs3NpaSkxCqRqOlaOXPmDGazmeDg4Nseq3oC+blz5wDo1KnTz8a3f/9+li1bxrFjx7h+/brVtpt/z2HDhpGVlcXcuXP58MMPefzxx3nmmWcYOHDgPX1tad68eaSmpta47dZ5JS+//DIzZ868q+OsWLGC8+fP88EHH9zV/iIiIiJ3464Si1tHK+DGij9NmzZlzpw5t92v+qa5TZs2JCUlsW/fPvbv38/BgweZM2cOS5YsYdmyZbRq1epuwrJRWzJw6/Kb165dY8yYMRiNRl577TU6dOiAi4sLBoOBFStWsH///nqJqa7MZjNRUVGcOXOGkJAQunTpgqurKw4ODqSkpJCenm4zSvAgqelagRu/zcKFC61GHG5Wfa3cqWPHjhEVFUWrVq2IioqiZcuWNGjQAIPBwLvvvmvVRx4eHiQmJnLo0CH27t3LoUOHmD9/PkuWLCE6OrrWeRT2GDVqFC+99JJV2YIFCwCYOHGiVfnNI1l1cfHiRZYvX05gYCBms9mSmP3www8AlJaWcu7cOX7zm9/YvDYmIiIiYo96+0Be69atycvLo1u3bjRu3Phn6z/00EP07duXvn37AjdW6Zk4cSKffPIJf/jDH2rcp3plnbNnz9psO336tE1Z9ZP1n376yWZbQUGB1fyOffv28cMPPzB9+nReeeUVq7pxcXE/ez518cgjjwA1x1xdVl3nxIkT5ObmMmbMGJsPtW3ZssXq77r2T1098sgjfP3111y5csXmtaTTp0/j4uJimSBdm9atW/PVV1/RokUL2rZtW2vd6hGP3Nxcq9e7bpWenk5lZSULFy609B2A0Wi0GX0CcHR0pGfPnpbVm06cOMHIkSOJj48nOjoauLtRqtr2adeunc3IUXU/9unTp87HqsmPP/7I9evX2bRpE5s2bbLZvmLFClasWMHcuXNrXH1LRERE5G7V2wfyAgMDqaqqIiYmpsbt1a+2AJSUlNhs79y5M3DjiertVC9Jm5WVxffff28pr6ioYPXq1Tb1q29K9+3bZ1Wenp5ueYJbzdHREcBmzseePXus3s+vD507d6ZFixakpKRw8eJFS7nJZGLVqlUYDAbLClrVT/RvjevkyZNkZmZaldW1f+qqX79+VFVVsWLFCqvy3bt3k5OTg5+f321HIG5WPbE5Nja2xg+33Xyt+Pv74+zszLJlyyxzSW5W3S+3+/0SEhJsRnRquv58fX1p2LChVRJa/US/tmvyVo0aNaoxkf2lPPLII8ydO9fmX/W3MgIDA5k7d+49G5URERGRX696G7EYMGAAQUFBrF+/nu+++45nn30WDw8PiouLOXLkCOfPnyc5ORmA8ePH4+bmRo8ePWjevDlXrlwhJSUFg8Hws6vpvP3224wdO5bRo0czdOhQy3KqNd2g+vr60rt3bzZt2oTZbKZjx47k5uaSmZlJ69atrSbuPvHEE3h6erJgwQIKCwt5+OGHyc3NZfv27XTo0IGTJ0/WV1fh6OjI1KlTmTJlCm+88QaDBw+mcePG7Ny5k6NHjxIaGmpJitq2bUu7du1ITEykvLwcHx8f8vLy2LRpEx06dOD48eN33T91FRQURGpqKitXrqSgoIAnn3ySc+fOsWHDBjw9Pa1WeKrNY489Rnh4OEuXLmXEiBEMGDAALy8vLl68yPHjx9m9ezd79uwBoHnz5kyaNIn33nuPkJAQAgMD8fb2pri4mKysLKZPn06nTp3o168fq1evZsKECQwePBhnZ2f27t3LyZMnbUZR5syZQ3FxMX369MHb25vr16+zc+dOrl69SmBgoKVet27dWL9+PXPnzqVv3744OTnRtWtXqxGRW3Xr1o3k5GTi4uJo27YtBoMBPz8/u187KiwsZNu2bcA/Rp927dpFUVERgKVfXF1db/sdEIAOHTpopEJERETuiXpLLODGx8N69uzJ5s2bWbFiBRUVFXh6etK5c2erm87g4GB27tzJpk2bKC0txd3dnU6dOjF16lSbD9ndqnv37sTGxhITE8PKlStxdXW1fAAuJCTEpv7s2bP5y1/+Qnp6Otu3b6dHjx4sXryYP//5zxQWFlrqubm5ERMTw8KFC1m3bh2VlZV07tyZ6OhokpOT6zWxgBvLoC5atIj4+HhWrVpFRUUFvr6+TJs2zeoDeY6OjkRHR7NgwQJSU1MxGo20b9+emTNnkpuba5NY1LV/6sLJyYmYmBjLB/IyMjJwc3PD39+fcePG0aJFiztuKzw8nC5durB27VrWrFmD0WikWbNmtG/fnsmTJ1vVDQ4OplWrViQmJrJ27VoqKirw8vKiV69elu9iPPHEE8ybN4+PPvqIxYsX06BBA3r37s3SpUsZM2aMVXsBAQGkpKSwbds2Ll++jIuLC+3ateO9997D39/fUm/gwIHk5OSwY8cOPvvsM6qqqpgxY0aticW4ceMoLS0lKSmJK1euYDab2bp1q92JRX5+PosXL7Yqy8jIICMjw3L+N3+gUEREROSXZjDXZb1XEfnVMbz/yy3JKyIi8kszT67X5+y/avU2x0JERERERH69lFiIiIiIiIjdlFiIiIiIiIjdlFiIiIiIiIjdlFiIiIiIiIjdlFiIiIiIiIjdlFiIiIiIiIjdtHCviNRqSZMEQkNDcXZ2vt+hiIiIyANMIxYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3g9lsNt/vIETkwWV433S/QxAREbkj5slO9zuEXzWNWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN0e6MRi5syZ9OzZ847qFhQU0LNnT5YsWXKPo7qhLrGFh4cTFBR0jyOqXV37Jycnh8jISPr37/+L9quIiIiI/HPSV0TEhslkYurUqZhMJiIiInBzc+PRRx+932H94jIzM8nJyWHs2LF3vM/q1atxc3Or10TSbDaTlpbGF198wfHjx/nhhx/w8PCgY8eOjB49mq5du1rV//7770lLS2PPnj2cP3+ev//977Rq1Qp/f39GjBhBo0aN6i02ERERkWoP9IjFtGnT2L179/0O41cnPz+f/Px8XnvtNYYPH05AQMCvNrFYtmxZnfZZs2YNKSkp9RrH3//+d6ZPn87333/PCy+8wJQpUxg8eDA5OTmEhoayfft2q/pbt25l9erVtGrVijfffJO33noLHx8f4uLiCAsLo7y8vF7jExEREYF6GLGorKykoqKChg0b1kc8VpycnHBy0qDKL+3HH38EwN3dvV7bNZvNGI1GGjduXK/t/jMLDw8HYOnSpbet4+joyJIlS3jqqaesygcPHsywYcNYsGABL774Ig4ON54T+Pv7Exoaiqurq6VucHAwrVu3JiEhgeTkZIYPH34PzkZERER+zep0156SksKsWbOIjY3l6NGjpKSkcOHCBaZNm0ZQUBBms5mNGzeyZcsWzpw5g4ODA126dGHMmDE28xFSU1NZv349eXl5mEwmPD096datG5MmTaJp06bAjXkMqampHDhwwGrfb7/9loULF5KTk4OLiwv+/v4MGTLktvEuXrzY5vjh4eEUFhZaPV3es2cPycnJ/O1vf+PixYs4Ozvz2GOPERYWZnNTVx8OHjzIRx99xLFjxzCZTPj6+jJ06FAGDRpkVS87O5sNGzZw5MgRioqKcHR0pEOHDrz++uv079/fpt077Z+ahIeHc/DgQQBmzZrFrFmzgBtPwVu2bInRaCQ+Pp6dO3dSXFxMkyZN6NOnD5GRkXh7e1vaOXDgABEREcyYMQOj0UhSUhLnz5/nd7/7neXVoh07drBu3TpOnDhBZWWl5ZwGDBhgE9eBAwdYtWoV2dnZGI1GvLy8eOqpp3jrrbfw8PAAICkpiczMTE6fPs3ly5dxd3end+/eREZG0rJlS6v2vvzySxITEzl16hTl5eV4eHjQpUsXoqKi8PHxseqHm6+dGTNm3PY1p+p6hYWFVvtU993dcnJyqvH68/T05MknnyQjI4NLly7xm9/8BoAuXbrU2M4LL7xAQkICp06duutYRERERG7nroYDoqOjMZlMDB48GBcXF3x8fACYPn06f/3rX/H39ycoKIiKigrS0tIYP3488+bN47nnngNg27ZtzJw5kx49ehAREUGDBg0oKipi9+7dXLp0yZJY1CQ7O5tx48bRuHFjRo0ahZubGzt27GDGjBl3cypWUlJSKC0tJSAggObNm1NcXExycjLjxo1j8eLF9OjRw+5jVNu1axdTpkzB09OTkSNH0rhxY3bs2MGcOXPIz89n/PjxlrqZmZmcPXuWAQMG4O3tTWlpKampqUyZMoU5c+bw4osvWura2z9hYWE8/vjjLF++nMGDB1vOuWnTpphMJqKiojh8+DD+/v6MHDmSvLw8Nm7cyN69e0lMTKR58+ZW7a1Zs4bS0lIGDRqEp6enZfuiRYtISEjgmWeeISIiAgcHBzIyMvjjH//I1KlTGTZsmKWNjRs3MnfuXB5++GGGDBmCt7c3Fy5c4IsvvqCoqMiSWHz88cd07dqV4cOH4+7uzqlTp9iyZQv79+9n7dq1lnrffPMN77zzDu3bt7c82b948SL79u3j3Llz+Pj4EBYWhtls5tChQ8yePdsSS/fu3W/bd7Nnz2b+/Pl4eHgQFhZmKa/terZXcXExzs7OuLm5/WzdoqIi4EZCIiIiIlLf7iqxKC8vZ/Xq1VavP2VkZJCWlsa7777Lq6++aikPCQkhNDSUDz74AD8/PwwGA5mZmbi4uBAXF2f1qlNERMTPHnv+/PlUVVURHx9vSWiGDh3K6NGj7+ZUrEybNs1mYuuQIUMYNmwYy5cvr7fEorKyknnz5tGoUSNWrlyJl5cXAMOGDWPs2LGsXLmSoKAg2rRpA8Do0aOJioqyaiMkJIQRI0YQHx9vlVjY2z9PP/00Tk5OLF++nO7duxMQEGDZtnnzZg4fPszrr7/OhAkTLOV9+vRh4sSJxMTE8Kc//cmqvQsXLrBhwwaaNWtmKfvuu+9ISEggNDTUKoEKCQlh0qRJxMbGEhgYiIuLC0VFRbz//vv4+vqSkJBgdQMdGRlJVVWV5e+1a9fa/H5+fn6MGzeO5ORk3njjDQCysrKoqqoiNjbWKq4333zTqh/S09M5dOiQVR/UJiAggLi4OJo1a3bH+9jjyy+/5NixYwQEBNCgQYNa61ZWVhIfH4+joyMDBw6857GJiIjIr89dTd4ODg62mVOxfft2XFxc6NevHyUlJZZ/ZWVlPPvssxQUFJCXlweAq6sr5eXlfPnll5jN5js+7qVLlzhy5AjPPfec5aYZwNnZmREjRtzNqVi5+ab02rVrlJSU4OjoSNeuXTl27Jjd7Vc7fvw4Fy5c4JVXXrEkFXDjPEaNGkVVVRVZWVk1xlVeXk5JSQnl5eX06tWLM2fOUFZWBtz7/snIyMDBwYHQ0FCr8r59+9KxY0d27dpldaMPEBgYaHXzDpCWlobBYCAwMNDqWikpKcHPz4+rV69y9OhRAD799FMqKioYM2ZMjU/lq+cVwD/6qaqqirKyMkpKSujYsSOurq5kZ2db6lXPPfj8888xmUx29EjdVF9TN/8zmUyYTCab8mvXrtXaVl5eHjNmzODhhx/m7bff/tljf/DBBxw5coSIiAh8fX3r6YxERERE/uGuRiyqn6Tf7OzZs1y9epUXXnjhtvtdunQJHx8fQkNDOXjwIJMnT8bd3Z0nn3yS3/72tzz//PO4uLjcdv/8/HyAGm+M2rVrV/cTucX58+eJjY1lz549XLlyxWqbwWCwu/1qBQUFQM0xt2/fHvjHucKNfouLiyMrK4tLly7Z7FNWVoarq+s975+CggK8vLxo0qRJjXHn5uZSUlJilUjUdK2cOXMGs9lMcHDwbY9VPYH83LlzAHTq1Oln49u/fz/Lli3j2LFjXL9+3Wrbzb/nsGHDyMrKYu7cuXz44Yc8/vjjPPPMMwwcOPCevrY0b948UlNTa9x267ySl19+mZkzZ9ZYNz8/n8jISAAWLlz4szHHxcWxfv16Bg8ebJMUioiIiNSXu0osaloBymw207RpU+bMmXPb/apvmtu0aUNSUhL79u1j//79HDx4kDlz5rBkyRKWLVtGq1at7iYsG7UlA5WVlVZ/X7t2jTFjxmA0Gnnttdfo0KEDLi4uGAwGVqxYwf79++slproym81ERUVx5swZQkJC6NKlC66urjg4OJCSkkJ6errNKMGD5HarhRkMBhYuXGg14nCz6mvlTh07doyoqChatWpFVFQULVu2pEGDBhgMBt59912rPvLw8CAxMZFDhw6xd+9eDh06xPz581myZAnR0dG1zqOwx6hRo3jppZesyhYsWADAxIkTrcpvHsm6WUFBARERERiNRhYtWkSHDh1qPeaSJUuIj48nKCiId999965jFxEREfk59baWa+vWrcnLy6Nbt253tJzoQw89RN++fenbty9w433xiRMn8sknn/CHP/yhxn2qV9Y5e/aszbbTp0/blFU/Wf/pp59sthUUFFjN79i3bx8//PAD06dP55VXXrGqGxcX97PnUxePPPIIUHPM1WXVdU6cOEFubi5jxoyx+VDbli1brP6ua//U1SOPPMLXX3/NlStXbF5LOn36NC4uLpYJ0rVp3bo1X331FS1atKBt27a11q0e8cjNzbV6vetW6enpVFZWsnDhQkvfARiNRpvRJ7ixhGvPnj0tqzedOHGCkSNHEh8fT3R0NHB3o1S17dOuXTubkaPqfuzTp8/Ptl1QUMDYsWMpKytj0aJFdO7cudb61Yn6yy+/zP/8z//U66ibiIiIyK3q7QN5gYGBVFVVERMTU+P26ldbAEpKSmy2V98klZaW3vYY1UvSZmVl8f3331vKKyoqWL16tU396pvSffv2WZWnp6fzww8/WJU5OjoC2Mz52LNnj9X7+fWhc+fOtGjRgpSUFC5evGgpN5lMrFq1CoPBYFlBq/qJ/q1xnTx5kszMTKuyuvZPXfXr14+qqipWrFhhVb57925ycnLw8/O77QjEzaonNsfGxtqMHIH1teLv74+zszPLli2zzCW5WXW/3O73S0hIsBnRqen68/X1pWHDhlZJaPWcjdquyVs1atSoxkTWXoWFhURERHDlyhViYmL4t3/7t1rrL1u2jGXLlhEQEMD06dPv6HcRERERsUe9jVgMGDCAoKAg1q9fz3fffcezzz6Lh4cHxcXFHDlyhPPnz5OcnAzA+PHjcXNzo0ePHjRv3pwrV66QkpKCwWD42dV03n77bcaOHcvo0aMZOnSoZTnVmm5QfX196d27N5s2bcJsNtOxY0dyc3PJzMykdevWVhN3n3jiCTw9PVmwYAGFhYU8/PDD5Obmsn37djp06MDJkyfrq6twdHRk6tSpTJkyhTfeeIPBgwfTuHFjdu7cydGjRwkNDbUkRW3btqVdu3YkJiZSXl6Oj48PeXl5bNq0iQ4dOnD8+PG77p+6CgoKIjU1lZUrV1JQUMCTTz7JuXPn2LBhA56enlYrPNXmscceIzw8nKVLlzJixAgGDBiAl5cXFy9e5Pjx4+zevZs9e/YA0Lx5cyZNmsR7771HSEgIgYGBeHt7U1xcTFZWFtOnT6dTp07069eP1atXM2HCBAYPHoyzszN79+7l5MmTNqMoc+bMobi4mD59+uDt7c3169fZuXMnV69eJTAw0FKvW7durF+/nrlz59K3b1+cnJzo2rWr1YjIrbp160ZycjJxcXG0bdsWg8GAn5+fzWpVdXH16lUiIiIoKChg+PDhfP/991aJI9wY8aheRnb9+vUsWbKEFi1a0Lt3b9LT063qNmvWjKeffvqu4xERERGpSb1+1nrGjBn07NmTzZs3s2LFCioqKvD09KRz585WN53BwcHs3LmTTZs2UVpairu7O506dWLq1Kk2H7K7Vffu3YmNjSUmJoaVK1fi6upq+QBcSEiITf3Zs2fzl7/8hfT0dLZv306PHj1YvHgxf/7znyksLLTUc3NzIyYmhoULF7Ju3ToqKyvp3Lkz0dHRJCcn12tiATeWQV20aBHx8fGsWrWKiooKfH19mTZtmtUH8hwdHYmOjmbBggWkpqZiNBpp3749M2fOJDc31yaxqGv/1IWTkxMxMTGWD+RlZGTg5uaGv78/48aNo0WLFnfcVnh4OF26dGHt2rWsWbMGo9FIs2bNaN++PZMnT7aqGxwcTKtWrUhMTGTt2rVUVFTg5eVFr169LN/FeOKJJ5g3bx4fffQRixcvpkGDBvTu3ZulS5cyZswYq/YCAgJISUlh27ZtXL58GRcXF9q1a8d7772Hv7+/pd7AgQPJyclhx44dfPbZZ1RVVTFjxoxaE4tx48ZRWlpKUlISV65cwWw2s3XrVrsSi9LSUsvE/HXr1tVYZ/HixZbE4m9/+xtwY6nfmiaAP/nkk0osREREpN4ZzHVZ71VEfnUM7/9yS/KKiIjYwzy5Xp+ZSx3pxWsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGbEgsREREREbGb1uQSkVotaZJAaGgozs7O9zsUEREReYBpxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROymxEJEREREROxmMJvN5vsdhIg8uAzvm+53CCIiIgCYJzvd7xCkFhqxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuymxEBERERERuz3QicXMmTPp2bPnHdUtKCigZ8+eLFmy5B5HdUNdYgsPDycoKOgeR1S7uvZPTk4OkZGR9O/f/xftVxERERH556TFgMWGyWRi6tSpmEwmIiIicHNz49FHH73fYf3iMjMzycnJYezYsXe8z+rVq3Fzc6v3RDI7O5u0tDSOHz/OiRMnMBqNzJgx47bHKSkpYeXKlezatYsLFy7g6upK27ZtCQkJoV+/fvUam4iIiAg84CMW06ZNY/fu3fc7jF+d/Px88vPzee211xg+fDgBAQG/2sRi2bJlddpnzZo1pKSk1Hssu3fvJikpibKysp/9LcrLywkLC2P9+vU8/fTTTJkyhREjRvDjjz8yefJkNmzYUO/xiYiIiNg9YlFZWUlFRQUNGzasj3isODk54eSkQZVf2o8//giAu7t7vbZrNpsxGo00bty4Xtv9ZxYeHg7A0qVLa60XHBzMqFGjaNSoEZ9++ilHjhy5bd3MzEzy8vKYNGkSr732mqX81VdfJSAggE2bNhEcHFw/JyAiIiLy/1enu/aUlBRmzZpFbGwsR48eJSUlhQsXLjBt2jSCgoIwm81s3LiRLVu2cObMGRwcHOjSpQtjxoyxmY+QmprK+vXrycvLw2Qy4enpSbdu3Zg0aRJNmzYFbsxjSE1N5cCBA1b7fvvttyxcuJCcnBxcXFzw9/dnyJAht4138eLFNscPDw+nsLDQ6unynj17SE5O5m9/+xsXL17E2dmZxx57jLCwMJ566qm6dNUdOXjwIB999BHHjh3DZDLh6+vL0KFDGTRokFW97OxsNmzYwJEjRygqKsLR0ZEOHTrw+uuv079/f5t277R/ahIeHs7BgwcBmDVrFrNmzQJg69attGzZEqPRSHx8PDt37qS4uJgmTZrQp08fIiMj8fb2trRz4MABIiIimDFjBkajkaSkJM6fP8/vfvc7y6tFO3bsYN26dZw4cYLKykrLOQ0YMMAmrgMHDrBq1Sqys7MxGo14eXnx1FNP8dZbb+Hh4QFAUlISmZmZnD59msuXL+Pu7k7v3r2JjIykZcuWVu19+eWXJCYmcurUKcrLy/Hw8KBLly5ERUXh4+Nj1Q83Xzu1vX5UXa+wsNBqn+q+s4enp+cd17169SoAXl5eVuWurq40atTonjwEEBEREbmr4YDo6GhMJhODBw/GxcUFHx8fAKZPn85f//pX/P39CQoKoqKigrS0NMaPH8+8efN47rnnANi2bRszZ86kR48eRERE0KBBA4qKiti9ezeXLl2yJBY1yc7OZty4cTRu3JhRo0bh5ubGjh07mDFjxt2cipWUlBRKS0sJCAigefPmFBcXk5yczLhx41i8eDE9evSw+xjVdu3axZQpU/D09GTkyJE0btyYHTt2MGfOHPLz8xk/frylbmZmJmfPnmXAgAF4e3tTWlpKamoqU6ZMYc6cObz44ouWuvb2T1hYGI8//jjLly9n8ODBlnNu2rQpJpOJqKgoDh8+jL+/PyNHjiQvL4+NGzeyd+9eEhMTad68uVV7a9asobS0lEGDBuHp6WnZvmjRIhISEnjmmWeIiIjAwcGBjIwM/vjHPzJ16lSGDRtmaWPjxo3MnTuXhx9+mCFDhuDt7c2FCxf44osvKCoqsiQWH3/8MV27dmX48OG4u7tz6tQptmzZwv79+1m7dq2l3jfffMM777xD+/btCQ0NxdXVlYsXL7Jv3z7OnTuHj48PYWFhmM1mDh06xOzZsy2xdO/e/bZ9N3v2bObPn4+HhwdhYWGW8tqu53uhV69eODo6EhMTQ8OGDXn00Ue5cuUKn3zyCVeuXLGKTURERKS+3FViUV5ezurVq62efGZkZJCWlsa7777Lq6++aikPCQkhNDSUDz74AD8/PwwGA5mZmbi4uBAXF2f1qlNERMTPHnv+/PlUVVURHx9vSWiGDh3K6NGj7+ZUrEybNo1GjRpZlQ0ZMoRhw4axfPnyekssKisrmTdvHo0aNWLlypWWJ8vDhg1j7NixrFy5kqCgINq0aQPA6NGjiYqKsmojJCSEESNGEB8fb5VY2Ns/Tz/9NE5OTixfvpzu3bsTEBBg2bZ582YOHz7M66+/zoQJEyzlffr0YeLEicTExPCnP/3Jqr0LFy6wYcMGmjVrZin77rvvSEhIIDQ01CqBCgkJYdKkScTGxhIYGIiLiwtFRUW8//77+Pr6kpCQgJubm6V+ZGQkVVVVlr/Xrl1r8/v5+fkxbtw4kpOTeeONNwDIysqiqqqK2NhYq7jefPNNq35IT0/n0KFDVn1Qm4CAAOLi4mjWrNkd73MvtGnThj//+c988MEHTJw40VLu6elJXFwcTzzxxH2LTURERP513dXk7eDgYJvXKbZv346Liwv9+vWjpKTE8q+srIxnn32WgoIC8vLygBuvZJSXl/Pll19iNpvv+LiXLl3iyJEjPPfcc5abZgBnZ2dGjBhxN6di5eab0mvXrlFSUoKjoyNdu3bl2LFjdrdf7fjx41y4cIFXXnnF6nUVZ2dnRo0aRVVVFVlZWTXGVV5eTklJCeXl5fTq1YszZ85QVlYG3Pv+ycjIwMHBgdDQUKvyvn370rFjR3bt2mV1ow8QGBhodfMOkJaWhsFgIDAw0OpaKSkpwc/Pj6tXr3L06FEAPv30UyoqKhgzZoxVUlHNweEfl3B1P1VVVVFWVkZJSQkdO3bE1dWV7OxsSz1XV1cAPv/8c0wmkx09UjfV19TN/0wmEyaTyab82rVrdh3Lzc2NDh06EB4ezvvvv88f/vAHGjZsyKRJk8jNza2nMxIRERH5h7sasah+kn6zs2fPcvXqVV544YXb7nfp0iV8fHwIDQ3l4MGDTJ48GXd3d5588kl++9vf8vzzz+Pi4nLb/fPz8wHw9fW12dauXbu6n8gtzp8/T2xsLHv27OHKlStW2wwGg93tVysoKABqjrl9+/bAP84VbvRbXFwcWVlZXLp0yWafsrIyXF1d73n/FBQU4OXlRZMmTWqMOzc3l5KSEqtEoqZr5cyZM5jN5lonEFdPID937hwAnTp1+tn49u/fz7Jlyzh27BjXr1+32nbz7zls2DCysrKYO3cuH374IY8//jjPPPMMAwcOvKevLc2bN4/U1NQat906r+Tll19m5syZd3Wcr7/+mgkTJrBgwQKeeeYZS3n//v0JDg7mvffeIz4+/q7aFhEREbmdu0osapr8aTabadq0KXPmzLntftU3zW3atCEpKYl9+/axf/9+Dh48yJw5c1iyZAnLli2jVatWdxOWjdqSgcrKSqu/r127xpgxYzAajbz22mt06NABFxcXDAYDK1asYP/+/fUSU12ZzWaioqI4c+YMISEhdOnSBVdXVxwcHEhJSSE9Pd1mlOBBcruJwgaDgYULF1qNONys+lq5U8eOHSMqKopWrVoRFRVFy5YtadCgAQaDgXfffdeqjzw8PEhMTOTQoUPs3buXQ4cOMX/+fJYsWUJ0dHSt8yjsMWrUKF566SWrsgULFgBYvbIEthOv62LlypU0atTIKqkA+M1vfkOPHj346quvqKiowNnZ+a6PISIiInKrelvLtXXr1uTl5dGtW7c7Wk70oYceom/fvvTt2xe4sUrPxIkT+eSTT/jDH/5Q4z7VK+ucPXvWZtvp06dtyqqfrP/000822woKCqzmd+zbt48ffviB6dOn88orr1jVjYuL+9nzqYtHHnkEqDnm6rLqOidOnCA3N5cxY8bYfKhty5YtVn/XtX/q6pFHHuHrr7/mypUrNq8lnT59GhcXF8sE6dq0bt2ar776ihYtWtC2bdta61aPeOTm5lq93nWr9PR0KisrWbhwoaXvAIxGo83oE4CjoyM9e/a0rN504sQJRo4cSXx8PNHR0cDdjVLVtk+7du1sRo6q+7FPnz51PtbtFBcXU1VVhdlstomnsrKSysrKBzoZFRERkX9O9faBvMDAQKqqqoiJialxe/WrLXDjq8C36ty5MwClpaW3PUb1krRZWVl8//33lvKKigpWr15tU7/6pnTfvn1W5enp6fzwww9WZY6OjgA2cz727Nlj9X5+fejcuTMtWrQgJSWFixcvWspNJhOrVq3CYDBYVtCqfqJ/a1wnT54kMzPTqqyu/VNX/fr1o6qqihUrVliV7969m5ycHPz8/G47AnGz6onNsbGxNiNHYH2t+Pv74+zszLJlyyxzSW5W3S+3+/0SEhJsbqJruv58fX1p2LChVRJaPWejtmvyVo0aNaoxkf0ltWvXDqPRyKeffmpVnp+fz8GDB+nQoQMNGjS4T9GJiIjIv6p6G7EYMGAAQUFBrF+/nu+++45nn30WDw8PiouLOXLkCOfPnyc5ORmA8ePH4+bmRo8ePWjevDlXrlwhJSUFg8Hws6vpvP3224wdO5bRo0czdOhQy3KqNd2g+vr60rt3bzZt2oTZbKZjx47k5uaSmZlJ69atrSbuPvHEE3h6erJgwQIKCwt5+OGHyc3NZfv27XTo0IGTJ0/WV1fh6OjI1KlTmTJlCm+88QaDBw+mcePG7Ny5k6NHjxIaGmpJitq2bUu7du1ITEykvLwcHx8f8vLy2LRpEx06dOD48eN33T91FRQURGpqKitXrqSgoIAnn3ySc+fOsWHDBjw9Pa1WeKrNY489Rnh4OEuXLmXEiBEMGDAALy8vLl68yPHjx9m9ezd79uwBoHnz5kyaNIn33nuPkJAQAgMD8fb2pri4mKysLKZPn06nTp3o168fq1evZsKECQwePBhnZ2f27t3LyZMnbUZR5syZQ3FxMX369MHb25vr16+zc+dOrl69SmBgoKVet27dWL9+PXPnzqVv3744OTnRtWtXqxGRW3Xr1o3k5GTi4uJo27YtBoMBPz8/m9Wq6qqwsJBt27YB/xh92rVrF0VFRQCWfgEIDQ3l66+/5n/+53/45ptv6NixI8XFxWzYsIG///3vd/w7iYiIiNRFvX7WesaMGfTs2ZPNmzezYsUKKioq8PT0pHPnzlY3M8HBwezcuZNNmzZRWlqKu7s7nTp1YurUqTYfsrtV9+7diY2NJSYmhpUrV+Lq6mr5AFxISIhN/dmzZ/OXv/yF9PR0tm/fTo8ePVi8eDF//vOfKSwstNRzc3MjJiaGhQsXsm7dOiorK+ncuTPR0dEkJyfXa2IBN5ZBXbRoEfHx8axatYqKigp8fX2ZNm2a1QfyHB0diY6OZsGCBaSmpmI0Gmnfvj0zZ84kNzfXJrGoa//UhZOTEzExMZYP5GVkZODm5oa/vz/jxo2jRYsWd9xWeHg4Xbp0Ye3ataxZswaj0UizZs1o3749kydPtqobHBxMq1atSExMZO3atVRUVODl5UWvXr0s38V44oknmDdvHh999BGLFy+mQYMG9O7dm6VLlzJmzBir9gICAkhJSWHbtm1cvnwZFxcX2rVrx3vvvYe/v7+l3sCBA8nJyWHHjh189tlnVFVVMWPGjFoTi3HjxlFaWkpSUhJXrlzBbDazdetWuxOL/Px8Fi9ebFWWkZFBRkaG5fyrE4vHHnuM+Ph4EhIS+Pzzz9m8eTONGzema9euvPHGGz/7/5iIiIjI3TCY67Leq4j86hje/+WW5BUREamNeXK9PhOXelZvcyxEREREROTXS4mFiIiIiIjYTYmFiIiIiIjYTYmFiIiIiIjYTYmFiIiIiIjYTYmFiIiIiIjYTYmFiIiIiIjYTYsBi0itljRJIDQ0FGdn5/sdioiIiDzANGIhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2U2IhIiIiIiJ2M5jNZvP9DkJEHlyG9033OwQREfkXYZ7sdL9DkHtIIxYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYPoAMHDtCzZ09SUlLuWww5OTlERkbSv39/evbsyZIlS+5bLCIiIiLy4NNXSsSGyWRi6tSpmEwmIiIicHNz49FHH73fYf3iMjMzycnJYezYsXe8z+rVq3FzcyMoKKheY8nOziYtLY3jx49z4sQJjEYjM2bMqPE4M2fOJDU19bZttW7dms2bN9drfCIiIiJKLB5ATz75JLt378bJ6f78PPn5+eTn5zNx4kSGDx9+X2J4EGRmZpKamlqnxGLNmjV4e3vXe2Kxe/dukpKS8PX15dFHH+XIkSO3rfvqq6/Su3dvm/L9+/eTkpLCs88+W6+xiYiIiIASiwfK1atXcXFxwcHBgQYNGty3OH788UcA3N3d67Vds9mM0WikcePG9druP7Pw8HAAli5dWmu94OBgRo0aRaNGjfj0009rTSy6d+9O9+7dbcq3b98OwH/+53/aEbGIiIhIzZRY1JOUlBRmzZpFbGws3377LSkpKfz444/4+PgQGhrKwIEDreoHBQXh7e3NO++8Q0xMDEePHsXd3Z2tW7dy4MABIiIibF51MZvNbNmyhS1btnD69GkAWrZsSf/+/YmIiLDU+/vf/87HH39Meno658+f56GHHqJHjx6MHTuWzp0713oe4eHhHDx4EIBZs2Yxa9YsALZu3UrLli0xGo3Ex8ezc+dOiouLadKkCX369CEyMhJvb29LOzefg9FoJCkpifPnz/O73/3OMgKwY8cO1q1bx4kTJ6isrKRDhw68/vrrDBgwwCauAwcOsGrVKrKzszEajXh5efHUU0/x1ltv4eHhAUBSUhKZmZmcPn2ay5cv4+7uTu/evYmMjKRly5ZW7X355ZckJiZy6tQpysvL8fDwoEuXLkRFReHj42PVDz179rTsd7vXj26uV1hYaLVPdd/Zw9PT0679CwsL2bdvH926daN9+/Z2tSUiIiJSEyUW9ezDDz/EaDQSHBwM3Eg4/vu//5u///3vNjekRUVFREZGMmDAAP7jP/6Da9eu1dr29OnTSUtLo2vXroSFheHm5sbZs2f57LPPLImFyWTi97//PUeOHCEgIIBhw4ZRVlbG5s2bGT16NMuWLaNLly63PUZYWBiPP/44y5cvZ/DgwfTo0QOApk2bYjKZiIqK4vDhw/j7+zNy5Ejy8vLYuHEje/fuJTExkebNm1u1t2bNGkpLSxk0aBCenp6W7YsWLSIhIYFnnnmGiIgIHBwcyMjI4I9//CNTp05l2LBhljY2btzI3LlzefjhhxkyZAje3t5cuHCBL774gqKiIkti8fHHH9O1a1eGDx+Ou7s7p06dYsuWLezfv5+1a9da6n3zzTe88847tG/fntDQUFxdXbl48SL79u3j3Llz+Pj4EBYWhtls5tChQ8yePdsSS00jAdVmz57N/Pnz8fDwICwszFLetGnTWn/XX8LWrVupqqrSaIWIiIjcM0os6llJSQlr167F1dUVuPEKS0hICP/3f//H888/T8OGDS118/PzmTZtGoMGDfrZdnfu3ElaWhovvfQSs2bNwsHhHwt6VVVVWf573bp1fPPNN3z44Yf8+7//u6U8ODiY4cOHs2DBglpfu3n66adxcnJi+fLldO/enYCAAMu2zZs3c/jwYV5//XUmTJhgKe/Tpw8TJ04kJiaGP/3pT1btXbhwgQ0bNtCsWTNL2XfffUdCQgKhoaGMHz/eUh4SEsKkSZOIjY0lMDAQFxcXioqKeP/99/H19SUhIQE3NzdL/cjISKtzX7t2LY0aNbI6vp+fH+PGjSM5OZk33ngDgKysLKqqqoiNjbWK680337Tqh/T0dA4dOmTVB7UJCAggLi6OZs2a3fE+v4SqqipSUlJo3LgxL7zwwv0OR0RERP5FabnZehYcHGxJKgBcXV0ZMmQIP/30E998841VXXd39zue5JuWlgbAxIkTrZIKwOrvtLQ0fH19+bd/+zdKSkos/0wmE3369OHw4cOUl5ff1bllZGTg4OBAaGioVXnfvn3p2LEju3btsrrRBwgMDLS6ea+O0WAwEBgYaBVjSUkJfn5+XL16laNHjwLw6aefUlFRwZgxY6ySiprOvTqpqKqqoqysjJKSEjp27IirqyvZ2dmWetW/z+eff47JZLqrvrgb165dszlfk8mEyWSyKf+50au62Lt3LxcuXOD555/X/BYRERG5ZzRiUc98fX1tytq2bQvcGKG42SOPPIKjo+MdtXvu3Dl+85vf/Oy79mfOnOH69es1zlOoVlJSQosWLe7ouDcrKCjAy8uLJk2a2Gxr3749ubm5lJSUWCUSbdq0qTFGs9lseV2sJtUTyM+dOwdAp06dfja+/fv3s2zZMo4dO8b169ettl25csXy38OGDSMrK4u5c+fy4Ycf8vjjj/PMM88wcODAe/ra0rx58267DOytv9fLL7/MzJkz6+W4ycnJAHc0MiYiIiJyt5RY3Ec3vxZVnzp06MDbb7992+2/5Dv/tztHg8HAwoULbUZfqtV1gvGxY8eIioqiVatWREVF0bJlSxo0aIDBYODdd9+1Gknx8PAgMTGRQ4cOsXfvXg4dOsT8+fNZsmQJ0dHRtc6jsMeoUaN46aWXrMoWLFgA3BiJupmXl1e9HLOkpISsrCzat29Pt27d6qVNERERkZoosahnZ8+etSk7c+YMcGOE4m61adOGrKwsfvzxx1pHLVq3bs3ly5fp1avXbW/a79YjjzzC119/zZUrV2xeSzp9+jQuLi6WCdK1ad26NV999RUtWrSwjObcTvWIR25uLj4+Pretl56eTmVlJQsXLrTqZ6PRaDVaUc3R0ZGePXtaVm86ceIEI0eOJD4+nujoaOBG8lNXte3Trl072rVrZ1VW3Y99+vSp87HuxLZt26ioqNCkbREREbnnNMeinm3YsIGysjLL32VlZWzcuBE3Nzeeeuqpu263+kn3woULbeYxmM1my38HBgby448/8sknn9TYTvUrRnejX79+VFVVsWLFCqvy3bt3k5OTg5+f3x0lM9UTm2NjY6msrKw1Rn9/f5ydnVm2bJlVv1arPvfqV8pu7guAhIQEm/4qKSmxacfX15eGDRvy008/Wcqq52yUlpb+7DndvM/NbdxvycnJODs7P1CTyUVERORfk0Ys6pmHhwdvvPGGZVJ2SkoKFy5cYNq0aXa9+jRgwACef/55tm3bxrlz5/Dz88PNzY28vDy+/vpr1q9fD8Brr73G3r17iY6OZv/+/fTq1QsXFxcuXLjA/v37eeihh1iyZMldxRAUFERqaiorV66koKCAJ598knPnzrFhwwY8PT2tVniqzWOPPUZ4eDhLly5lxIgRDBgwAC8vLy5evMjx48fZvXs3e/bsAaB58+ZMmjSJ9957j5CQEAIDA/H29qa4uJisrCymT59Op06d6NevH6tXr2bChAkMHjwYZ2dn9u7dy8mTJ21GUebMmUNxcTF9+vTB29ub69evs3PnTq5evUpgYKClXrdu3Vi/fj1z586lb9++ODk50bVr11pHnrp160ZycjJxcXG0bdsWg8GAn5+fzWpVdVVYWMi2bdsALN8w2bVrF0VFRQCWfrlZdnY2p0+f5vnnn7+jkSQREREReyixqGe///3v+fbbb0lKSuLSpUu0adOGOXPm8OKLL9rd9v/+7//So0cPkpOTWbZsGY6OjrRs2dJq4q+TkxMLFixgw4YNbN++3ZJEeHl58dhjj/Hyyy/f9fGdnJyIiYmxfCAvIyMDNzc3/P39GTduXJ0mhIeHh9OlSxfWrl3LmjVrMBqNNGvWjPbt2zN58mSrusHBwbRq1YrExETWrl1LRUUFXl5e9OrVy/JdjCeeeIJ58+bx0UcfsXjxYho0aEDv3r1ZunQpY8aMsWovICCAlJQUtm3bxuXLl3FxcaFdu3a89957+Pv7W+oNHDiQnJwcduzYwWeffUZVVRUzZsyoNbEYN24cpaWlJCUlceXKFcxmM1u3brU7scjPz2fx4sVWZRkZGWRkZFjO/9bEonrStl6DEhERkV+CwXzruyNyV6q/vL148WKrry6L/LMzvP/LLckrIiL/2syT9Uz7X5nmWIiIiIiIiN2UWIiIiIiIiN2UWIiIiIiIiN00x0JEaqU5FiIiUl80x+Jfm0YsRERERETEbkosRERERETEbhqPEpFaLWmSQGhoKM7Ozvc7FBEREXmAacRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETspsRCRERERETsZjCbzeb7HYSIPLgM75vudwgiIvKAMU92ut8hyANIIxYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYiIiIiImI3JRYPoAMHDtCzZ09SUlLuWww5OTlERkbSv39/evbsyZIlS+5bLCIiIiLy4NMixGLDZDIxdepUTCYTERERuLm58eijj97vsH5xmZmZ5OTkMHbs2DveZ/Xq1bi5uREUFFSvsWRnZ5OWlsbx48c5ceIERqORGTNm1Hico0ePsmrVKnJzc7l06RIALVq0YMCAAYwYMQJXV9d6jU1EREQElFg8kJ588kl2796Nk9P9+Xny8/PJz89n4sSJDB8+/L7E8CDIzMwkNTW1TonFmjVr8Pb2rvfEYvfu3SQlJeHr68ujjz7KkSNHblv3+++/p7y8nJdeeonf/OY3mM1mjh07RkJCAp999hkrV66kYcOG9RqfiIiIiBKLB8jVq1dxcXHBwcGBBg0a3Lc4fvzxRwDc3d3rtV2z2YzRaKRx48b12u4/s/DwcACWLl1aa73g4GBGjRpFo0aN+PTTT2tNLF5++WVefvllm/3btm3LwoUL+eKLL3j++eftD15ERETkJkos6klKSgqzZs0iNjaWb7/9lpSUFH788Ud8fHwIDQ1l4MCBVvWDgoLw9vbmnXfeISYmhqNHj+Lu7s7WrVs5cOAAERERNq+6mM1mtmzZwpYtWzh9+jQALVu2pH///kRERFjq/f3vf+fjjz8mPT2d8+fP89BDD9GjRw/Gjh1L586daz2P8PBwDh48CMCsWbOYNWsWAFu3bqVly5YYjUbi4+PZuXMnxcXFNGnShD59+hAZGYm3t7elnZvPwWg0kpSUxPnz5/nd735nGQHYsWMH69at48SJE1RWVtKhQwdef/11BgwYYBPXgQMHWLVqFdnZ2RiNRry8vHjqqad466238PDwACApKYnMzExOnz7N5cuXcXd3p3fv3kRGRtKyZUur9r788ksSExM5deoU5eXleHh40KVLF6KiovDx8bHqh549e1r2u93rRzfXKywstNqnuu/s4enpadf+gOX3+emnn+xuS0RERORWSizq2YcffojRaCQ4OBi4kXD893//N3//+99tbkiLioqIjIxkwIAB/Md//AfXrl2rte3p06eTlpZG165dCQsLw83NjbNnz/LZZ59ZEguTycTvf/97jhw5QkBAAMOGDaOsrIzNmzczevRoli1bRpcuXW57jLCwMB5//HGWL1/O4MGD6dGjBwBNmzbFZDIRFRXF4cOH8ff3Z+TIkeTl5bFx40b27t1LYmIizZs3t2pvzZo1lJaWMmjQIDw9PS3bFy1aREJCAs888wwRERE4ODiQkZHBH//4R6ZOncqwYcMsbWzcuJG5c+fy8MMPM2TIELy9vblw4QJffPEFRUVFlsTi448/pmvXrgwfPhx3d3dOnTrFli1b2L9/P2vXrrXU++abb3jnnXdo3749oaGhuLq6cvHiRfbt28e5c+fw8fEhLCwMs9nMoUOHmD17tiWW7t2737bvZs+ezfz58/Hw8CAsLMxS3rRp01p/13ulvLzc8u/48eN8+OGHODs706dPn/sSj4iIiPxrU2JRz0pKSli7dq1lgmxwcDAhISH83//9H88//7zVu+35+flMmzaNQYMG/Wy7O3fuJC0tjZdeeolZs2bh4PCPBb2qqqos/71u3Tq++eYbPvzwQ/793//dUh4cHMzw4cNZsGBBra/dPP300zg5ObF8+XK6d+9OQECAZdvmzZs5fPgwr7/+OhMmTLCU9+nTh4kTJxITE8Of/vQnq/YuXLjAhg0baNasmaXsu+++IyEhgdDQUMaPH28pDwkJYdKkScTGxhIYGIiLiwtFRUW8//77+Pr6kpCQgJubm6V+ZGSk1bmvXbuWRo0aWR3fz8+PcePGkZyczBtvvAFAVlYWVVVVxMbGWsX15ptvWvVDeno6hw4dsuqD2gQEBBAXF0ezZs3ueJ97afHixXz88ceWv9u1a8f//d//0apVq/sYlYiIiPyr0nKz9Sw4ONhq1R1XV1eGDBnCTz/9xDfffGNV193d/Y4n+aalpQEwceJEq6QCsPo7LS0NX19f/u3f/o2SkhLLP5PJRJ8+fTh8+DDl5eV3dW4ZGRk4ODgQGhpqVd63b186duzIrl27rG70AQIDA61u3qtjNBgMBAYGWsVYUlKCn58fV69e5ejRowB8+umnVFRUMGbMGKukoqZzr04qqqqqKCsro6SkhI4dO+Lq6kp2dralXvXv8/nnn2Myme6qL+7GtWvXbM7XZDJhMplsyn9u9OpOvPrqq8TGxjJ37lz+v//v/+Ohhx6ipKTE/hMRERERqYFGLOqZr6+vTVnbtm2BGyMUN3vkkUdwdHS8o3bPnTvHb37zm5991/7MmTNcv369xnkK1UpKSmjRosUdHfdmBQUFeHl50aRJE5tt7du3Jzc3l5KSEqtEok2bNjXGaDabLa+L1aR6Avm5c+cA6NSp08/Gt3//fpYtW8axY8e4fv261bYrV65Y/nvYsGFkZWUxd+5cPvzwQx5//HGeeeYZBg4ceE9fW5o3bx6pqak1brv193r55ZeZOXOmXcdr06aNpf8HDBjA119/ze9//3sAXnzxRbvaFhEREbmVEov76F4t+dmhQwfefvvt227/Jd/5v905GgwGFi5caDP6Uq19+/Z1Os6xY8eIioqiVatWREVF0bJlSxo0aIDBYODdd9+1Gknx8PAgMTGRQ4cOsXfvXg4dOsT8+fNZsmQJ0dHRtc6jsMeoUaN46aWXrMoWLFgA3BiJupmXl1e9H//f//3f8fT0ZMOGDUosREREpN4psahnZ8+etSk7c+YMcGOE4m61adOGrKwsfvzxx1pHLVq3bs3ly5fp1avXbW/a79YjjzzC119/zZUrV2xeSzp9+jQuLi6WCdK1ad26NV999RUtWrSwjObcTvUT99zcXHx8fG5bLz09ncrKShYuXGjVz0aj0Wq0opqjoyM9e/a0rN504sQJRo4cSXx8PNHR0cCN5KeuatunXbt2tGvXzqqsuh9/qQnV169f16pQIiIick9ojkU927BhA2VlZZa/y8rK2LhxI25ubjz11FN33W71k+6FCxfazGMwm82W/w4MDOTHH3/kk08+qbGd6leM7ka/fv2oqqpixYoVVuW7d+8mJycHPz+/O0pmqic2x8bGUllZWWuM/v7+ODs7s2zZMqt+rVZ97tWvlN3cFwAJCQk2/VXTPANfX18aNmxoddNdPWejtLT0Z8/p5n3u9437xYsXayxPTU2lrKyMrl27/sIRiYiIyK+BRizqmYeHB2+88YZlUnZKSgoXLlxg2rRpdr36NGDAgP8fe/8eVlW19///z8UhU0BQNiqmgofU21NpHvqUkd5YFkRX5In8qm00EJA7LQ+7b18vUeNzbbO2txgIHkDFtqKoSeAhrQDTnae0PKTgMRQQMoVEwc2C9fvDH2u7XGjiQm3vXo/r4rpYY4455nuONf+Y7zXmGJMXXniBTZs2ce7cOXx8fHBxcSEvL49vv/2WtWvXAvDGG2+wZ88eYmJi2LdvH3369MHJyYkLFy6wb98+HnnkERYtWnRPMQQEBJCRkcGKFSsoKCigV69enDt3jnXr1uHu7m6xwtOddO3aldDQUBYvXszIkSMZNGgQHh4eXLx4kWPHjrFr1y52794NQPPmzZk8eTIffvghQUFB+Pv74+npSXFxMdnZ2cyYMYNOnToxYMAAVq1axcSJEwkMDMTR0ZE9e/Zw8uRJq1GU6OhoiouL6devH56enly/fp3t27dz9epV/P39zfW6d+/O2rVrmTNnDv3798fBwYFu3brdceSpe/fupKWlER8fT9u2bTEYDPj4+FitVlVXhYWFbNq0CcD8DpMdO3ZQVFQEYO4XgIkTJ+Lq6kqPHj1o0aIFZWVlfP/992RnZ9O8eXPzS/lERERE6pMSi3r2P//zP3z//fekpqZy6dIl2rRpQ3R0dL080/5//+//pWfPnqSlpbFkyRLs7e1p2bKlxcRfBwcH5s+fz7p169i8ebM5ifDw8KBr165Wb2SuCwcHB2JjY80vyMvMzMTFxQVfX18iIiLqNCE8NDSULl26kJKSwurVqykvL6dp06a0b9+eKVOmWNQdOnQorVq1Ijk5mZSUFCorK/Hw8KBPnz7m92I8+eSTzJ07l6VLl5KQkECDBg3o27cvixcvJiQkxKI9Pz8/0tPT2bRpE5cvX8bJyYl27drx4Ycf4uvra643ePBgcnJy2LZtG1999RXV1dVERUXdMbGIiIigtLSU1NRUrly5gslk4vPPP7c5scjPzychIcGiLDMzk8zMTPP51yQWgYGBfP3112zcuJGSkhIcHBxo1aoVb775JqNGjbqrx9VERERE6spguvXZEbknNW/eTkhIsHjrssi/O8PHD25JXhER+fdgmqLfpsWa5liIiIiIiIjNlFiIiIiIiIjNlFiIiIiIiIjNNMdCRO5IcyxERORWmmMhtdGIhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EwPyInIHS1qnERwcDCOjo4POxQRERH5HdOIhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2MxgMplMDzsIEfn9MnxsfNghiIjIQ2aa4vCwQ5B/AxqxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERm/2uE4uZM2fSu3fvu6pbUFBA7969WbRo0X2O6oa6xBYaGkpAQMB9jujO6to/OTk5hIeHM3DgwAfaryIiIiLy70lvOxErRqORadOmYTQaCQsLw8XFhccff/xhh/XAZWVlkZOTw/jx4+96n1WrVuHi4lKviaTJZGLLli188803HDt2jJ9//hk3Nzc6duzIuHHj6Natm9U+y5Yt4/jx4xw/fpz8/Hw8PT1JT0+vt5hEREREbvW7HrGYPn06u3btethh/OHk5+eTn5/PG2+8wYgRI/Dz8/vDJhZLliyp0z6rV6+u9xv4f/7zn8yYMYOffvqJF198kalTpxIYGEhOTg7BwcFs3rzZap+4uDj279/PY489RuPGjes1HhEREZHa2DxiUVVVRWVlJY8++mh9xGPBwcEBBwcNqjxov/zyCwCurq712q7JZKK8vJxGjRrVa7v/zkJDQwFYvHjxbevY29uzaNEinnrqKYvywMBAhg8fzvz583nppZews/vX7wQbN26kVatWAAwfPpzy8vL7EL2IiIjIv9Tprj09PZ1Zs2YRFxfH4cOHSU9P58KFC0yfPp2AgABMJhPr169n48aNnDlzBjs7O7p06UJISIjVfISMjAzWrl1LXl4eRqMRd3d3unfvzuTJk2nSpAlwYx5DRkYG+/fvt9j3+++/Z8GCBeTk5ODk5ISvry9Dhgy5bbwJCQlWxw8NDaWwsNDi1+Xdu3eTlpbGjz/+yMWLF3F0dKRr166MHTvW6qauPhw4cIClS5dy9OhRjEYj3t7eDBs2jNdee82i3pEjR1i3bh2HDh2iqKgIe3t7OnTowOjRoxk4cKBVu3fbP7UJDQ3lwIEDAMyaNYtZs2YB8Pnnn9OyZUvKy8tJTExk+/btFBcX07hxY/r160d4eDienp7mdvbv309YWBhRUVGUl5eTmprK+fPn+fOf/2x+tGjbtm2sWbOGEydOUFVVZT6nQYMGWcW1f/9+Vq5cyZEjRygvL8fDw4OnnnqKt99+Gzc3NwBSU1PJysri9OnTXL58GVdXV/r27Ut4eDgtW7a0aG/nzp0kJydz6tQpKioqcHNzo0uXLkRGRuLl5WXRDzdfO1FRUbd9zKmmXmFhocU+NX13rxwcHGq9/tzd3enVqxeZmZlcunSJP/3pT+ZtNUmFiIiIyINyT8MBMTExGI1GAgMDcXJywsvLC4AZM2bwxRdf4OvrS0BAAJWVlWzZsoUJEyYwd+5cnn/+eQA2bdrEzJkz6dmzJ2FhYTRo0ICioiJ27drFpUuXzIlFbY4cOUJERASNGjVizJgxuLi4sG3bNqKiou7lVCykp6dTWlqKn58fzZs3p7i4mLS0NCIiIkhISKBnz542H6PGjh07mDp1Ku7u7owaNYpGjRqxbds2oqOjyc/PZ8KECea6WVlZnD17lkGDBuHp6UlpaSkZGRlMnTqV6OhoXnrpJXNdW/tn7NixPPHEEyxbtozAwEDzOTdp0gSj0UhkZCQ//PADvr6+jBo1iry8PNavX8+ePXtITk6mefPmFu2tXr2a0tJSXnvtNdzd3c3bFy5cSFJSEs888wxhYWHY2dmRmZnJe++9x7Rp0xg+fLi5jfXr1zNnzhyaNWvGkCFD8PT05MKFC3zzzTcUFRWZE4tPP/2Ubt26MWLECFxdXTl16hQbN25k3759pKSkmOt99913vPvuu7Rv357g4GCcnZ25ePEie/fu5dy5c3h5eTF27FhMJhMHDx5k9uzZ5lh69Ohx276bPXs28+bNw83NjbFjx5rL73Q926q4uBhHR0dcXFzu2zFERERE7sY9JRYVFRWsWrXK4vGnzMxMtmzZwvvvv8/rr79uLg8KCiI4OJi//e1v+Pj4YDAYyMrKwsnJifj4eItHncLCwn7z2PPmzaO6uprExERzQjNs2DDGjRt3L6diYfr06TRs2NCibMiQIQwfPpxly5bVW2JRVVXF3LlzadiwIStWrMDDwwO48cjK+PHjWbFiBQEBAbRp0waAcePGERkZadFGUFAQI0eOJDEx0SKxsLV/nn76aRwcHFi2bBk9evTAz8/PvO2zzz7jhx9+YPTo0UycONFc3q9fPyZNmkRsbCwffPCBRXsXLlxg3bp1NG3a1Fx2/PhxkpKSCA4OtkiggoKCmDx5MnFxcfj7++Pk5ERRUREff/wx3t7eJCUlWdxAh4eHU11dbf6ckpJi9f35+PgQERFBWloab775JgDZ2dlUV1cTFxdnEddbb71l0Q9bt27l4MGDFn1wJ35+fsTHx9O0adO73scWO3fu5OjRo/j5+dGgQYP7fjwRERGRO7mnydtDhw61mlOxefNmnJycGDBgACUlJea/srIynnvuOQoKCsjLywPA2dmZiooKdu7ciclkuuvjXrp0iUOHDvH888+bb5oBHB0dGTly5L2cioWbb0qvXbtGSUkJ9vb2dOvWjaNHj9rcfo1jx45x4cIFXn31VXNSATfOY8yYMVRXV5OdnV1rXBUVFZSUlFBRUUGfPn04c+YMZWVlwP3vn8zMTOzs7AgODrYo79+/Px07dmTHjh0WN/oA/v7+FjfvAFu2bMFgMODv729xrZSUlODj48PVq1c5fPgwAF9++SWVlZWEhITU+qv8zfMKavqpurqasrIySkpK6NixI87Ozhw5csRcz9nZGYCvv/4ao9FoQ4/UTc01dfOf0WjEaDRalV+7du2ObeXl5REVFUWzZs145513HtAZiIiIiNzePY1Y1PySfrOzZ89y9epVXnzxxdvud+nSJby8vAgODubAgQNMmTIFV1dXevXqxbPPPssLL7yAk5PTbffPz88HwNvb22pbu3bt6n4itzh//jxxcXHs3r2bK1euWGwzGAw2t1+joKAAqD3m9u3bA/86V7jRb/Hx8WRnZ3Pp0iWrfcrKynB2dr7v/VNQUICHh0etqwy1b9+e3NxcSkpKLBKJ2q6VM2fOYDKZGDp06G2PVTOB/Ny5cwB06tTpN+Pbt28fS5Ys4ejRo1y/ft1i283f5/Dhw8nOzmbOnDl88sknPPHEEzzzzDMMHjz4vj62NHfuXDIyMmrdduu8kldeeYWZM2fWWjc/P5/w8HAAFixYcF9jFhEREblb95RY1LYClMlkokmTJkRHR992v5qb5jZt2pCamsrevXvZt28fBw4cIDo6mkWLFrFkyZJ6m3h6p2SgqqrK4vO1a9cICQmhvLycN954gw4dOuDk5ITBYGD58uXs27evXmKqK5PJRGRkJGfOnCEoKIguXbrg7OyMnZ0d6enpbN261WqU4PfkdquFGQwGFixYYDHicLOaa+VuHT16lMjISFq1akVkZCQtW7akQYMGGAwG3n//fYs+cnNzIzk5mYMHD7Jnzx4OHjzIvHnzWLRoETExMXecR2GLMWPG8PLLL1uUzZ8/H4BJkyZZlN88knWzgoICwsLCKC8vZ+HChXTo0OF+hCoiIiJSZ/W2lmvr1q3Jy8uje/fud7Wc6COPPEL//v3p378/cON58UmTJvH3v/+dv/zlL7XuU7OyztmzZ622nT592qqs5pf1X3/91WpbQUGBxfyOvXv38vPPPzNjxgxeffVVi7rx8fG/eT518dhjjwG1x1xTVlPnxIkT5ObmEhISYvWito0bN1p8rmv/1NVjjz3Gt99+y5UrV6weSzp9+jROTk7mCdJ30rp1a/7xj3/QokUL2rZte8e6NSMeubm5Fo933Wrr1q1UVVWxYMECc98BlJeXW40+wY0lXHv37m1evenEiROMGjWKxMREYmJigHsbpbrTPu3atbMaOarpx379+v1m2wUFBYwfP56ysjIWLlxI586d6xyfiIiIyP1Sby/I8/f3p7q6mtjY2Fq31zzaAlBSUmK1veYmqbS09LbHqFmSNjs7m59++slcXllZyapVq6zq19yU7t2716J869at/PzzzxZl9vb2AFZzPnbv3m3xfH596Ny5My1atCA9PZ2LFy+ay41GIytXrsRgMJhX0Kr5Rf/WuE6ePElWVpZFWV37p64GDBhAdXU1y5cvtyjftWsXOTk5+Pj43HYE4mY1E5vj4uKsRo7A8lrx9fXF0dGRJUuWmOeS3KymX273/SUlJVmN6NR2/Xl7e/Poo49aJKE1czbudE3eqmHDhrUmsrYqLCwkLCyMK1euEBsby3/913/V+zFEREREbFFvIxaDBg0iICCAtWvXcvz4cZ577jnc3NwoLi7m0KFDnD9/nrS0NAAmTJiAi4sLPXv2pHnz5ly5coX09HQMBsNvrqbzzjvvMH78eMaNG8ewYcPMy6nWdoPq7e1N37592bBhAyaTiY4dO5Kbm0tWVhatW7e2mLj75JNP4u7uzvz58yksLKRZs2bk5uayefNmOnTowMmTJ+urq7C3t2fatGlMnTqVN998k8DAQBo1asT27ds5fPgwwcHB5qSobdu2tGvXjuTkZCoqKvDy8iIvL48NGzbQoUMHjh07ds/9U1cBAQFkZGSwYsUKCgoK6NWrF+fOnWPdunW4u7tbrPB0J127diU0NJTFixczcuRIBg0ahIeHBxcvXuTYsWPs2rWL3bt3A9C8eXMmT57Mhx9+SFBQEP7+/nh6elJcXEx2djYzZsygU6dODBgwgFWrVjFx4kQCAwNxdHRkz549nDx50moUJTo6muLiYvr164enpyfXr19n+/btXL16FX9/f3O97t27s3btWubMmUP//v1xcHCgW7duFiMit+revTtpaWnEx8fTtm1bDAYDPj4+VqtV1cXVq1cJCwujoKCAESNG8NNPP1kkjnBjxMPd3d38edOmTRQWFgI3EqnKykqWLl0KgKenp8V5ioiIiNSHen2tdVRUFL179+azzz5j+fLlVFZW4u7uTufOnS1uOocOHcr27dvZsGEDpaWluLq60qlTJ6ZNm2b1Irtb9ejRg7i4OGJjY1mxYgXOzs7mF8AFBQVZ1Z89ezYfffQRW7duZfPmzfTs2ZOEhAT++te/mm+84MYjKbGxsSxYsIA1a9ZQVVVF586diYmJIS0trV4TC7ixDOrChQtJTExk5cqVVFZW4u3tzfTp0y1ekGdvb09MTAzz588nIyOD8vJy2rdvz8yZM8nNzbVKLOraP3Xh4OBAbGys+QV5mZmZuLi44OvrS0REBC1atLjrtkJDQ+nSpQspKSmsXr2a8vJymjZtSvv27ZkyZYpF3aFDh9KqVSuSk5NJSUmhsrISDw8P+vTpY34vxpNPPsncuXNZunQpCQkJNGjQgL59+7J48WJCQkIs2vPz8yM9PZ1NmzZx+fJlnJycaNeuHR9++CG+vr7meoMHDyYnJ4dt27bx1VdfUV1dTVRU1B0Ti4iICEpLS0lNTeXKlSuYTCY+//xzmxKL0tJS88T8NWvW1FonISHBIrFIS0szv+Dv5joAvXr1UmIhIiIi9c5gqst6ryLyh2P4+MEtySsiIr9Ppin1+lu0/IeqtzkWIiIiIiLyx6XEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKa1w0TkjhY1TiI4OBhHR8eHHYqIiIj8jmnEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbKbEQkREREREbGYwmUymhx2EiPx+GT42PuwQRESknpmmODzsEOQ/kEYsRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosfof2799P7969SU9Pf2gx5OTkEB4ezsCBA+nduzeLFi16aLGIiIiIyO+fFjEWK0ajkWnTpmE0GgkLC8PFxYXHH3/8YYf1wGVlZZGTk8P48ePvep9Vq1bh4uJCQEBAvcZy5MgRtmzZwrFjxzhx4gTl5eVERUXd1XEuXrzIsGHDuHLlChMnTmT06NH1GpuIiIgIaMTid6lXr17s2rULPz+/h3L8/Px88vPzeeONNxgxYgR+fn5/2MRiyZIlddpn9erV92WkadeuXaSmplJWVlbn72Lu3LlUVVXVe0wiIiIiN1Ni8Tty9epVAOzs7GjQoAH29vYPJY5ffvkFAFdX13pt12Qyce3atXpt899daGgooaGhv1lv6NChZGdns3btWkaOHHnX7WdnZ5OVlcVbb71lS5giIiIiv0mPQtWT9PR0Zs2aRVxcHN9//z3p6en88ssveHl5ERwczODBgy3qBwQE4OnpybvvvktsbCyHDx/G1dWVzz//nP379xMWFmb1qIvJZGLjxo1s3LiR06dPA9CyZUsGDhxIWFiYud4///lPPv30U7Zu3cr58+d55JFH6NmzJ+PHj6dz5853PI/Q0FAOHDgAwKxZs5g1axYAn3/+OS1btqS8vJzExES2b99OcXExjRs3pl+/foSHh+Pp6Wlu5+ZzKC8vJzU1lfPnz/PnP//Z/GjRtm3bWLNmDSdOnKCqqooOHTowevRoBg0aZBXX/v37WblyJUeOHKG8vBwPDw+eeuop3n77bdzc3ABITU0lKyuL06dPc/nyZVxdXenbty/h4eG0bNnSor2dO3eSnJzMqVOnqKiowM3NjS5duhAZGYmXl5dFP/Tu3du8350eP6qpV1hYaLFPTd/Zwt3dvc77XL16lblz5zJkyBC6dOli0/FFREREfosSi3r2ySefUF5eztChQ4EbCcf/9//9f/zzn/+0uiEtKioiPDycQYMG8d///d+/+Wv+jBkz2LJlC926dWPs2LG4uLhw9uxZvvrqK3NiYTQa+Z//+R8OHTqEn58fw4cPp6ysjM8++4xx48axZMmSO95kjh07lieeeIJly5YRGBhIz549AWjSpAlGo5HIyEh++OEHfH19GTVqFHl5eaxfv549e/aQnJxM8+bNLdpbvXo1paWlvPbaa7i7u5u3L1y4kKSkJJ555hnCwsKws7MjMzOT9957j2nTpjF8+HBzG+vXr2fOnDk0a9aMIUOG4OnpyYULF/jmm28oKioyJxaffvop3bp1Y8SIEbi6unLq1Ck2btzIvn37SElJMdf77rvvePfdd2nfvj3BwcE4Oztz8eJF9u7dy7lz5/Dy8mLs2LGYTCYOHjzI7NmzzbH06NHjtn03e/Zs5s2bh5ubG2PHjjWXN2nS5I7f6/0SGxtLVVUVEyZM4Pjx4w8lBhEREfnjUGJRz0pKSkhJScHZ2Rm48QhLUFAQ//u//8sLL7zAo48+aq6bn5/P9OnTee21136z3e3bt7NlyxZefvllZs2ahZ3dv55iq66uNv+/Zs0avvvuOz755BP+z//5P+byoUOHMmLECObPn8/ixYtve5ynn34aBwcHli1bRo8ePSzmeXz22Wf88MMPjB49mokTJ5rL+/Xrx6RJk4iNjeWDDz6waO/ChQusW7eOpk2bmsuOHz9OUlISwcHBTJgwwVweFBTE5MmTiYuLw9/fHycnJ4qKivj444/x9vYmKSkJFxcXc/3w8HCLc09JSaFhw4YWx/fx8SEiIoK0tDTefPNN4MbjQdXV1cTFxVnEdfPjQk8//TRbt27l4MGDdz3Xxc/Pj/j4eJo2bfrQ5sfUOHz4MOvXryc6Otp8LYqIiIjcT5pjUc+GDh1qcSPn7OzMkCFD+PXXX/nuu+8s6rq6ut716kFbtmwBYNKkSRZJBWDxecuWLXh7e/Nf//VflJSUmP+MRiP9+vXjhx9+oKKi4p7OLTMzEzs7O4KDgy3K+/fvT8eOHdmxY4fFjT6Av7+/xc17TYwGgwF/f3+LGEtKSvDx8eHq1ascPnwYgC+//JLKykpCQkIskorazr0mqaiurqasrIySkhI6duyIs7MzR44cMder+X6+/vprjEbjPfXFvbh27ZrV+RqNRoxGo1W5LXNRjEYj0dHR9OvXjxdffLEez0BERETk9jRiUc+8vb2tytq2bQvcGKG42WOPPXbXE7TPnTvHn/70p9981v7MmTNcv3691nkKNUpKSmjRosVdHfdmBQUFeHh40LhxY6tt7du3Jzc3l5KSEotEok2bNrXGaDKZzI+L1aZmAvm5c+cA6NSp02/Gt2/fPpYsWcLRo0e5fv26xbYrV66Y/x8+fDjZ2dnMmTOHTz75hCeeeIJnnnmGwYMH39fHlubOnUtGRkat2279vl555RVmzpx5T8dZvnw558+f529/+9s97S8iIiJyL5RYPEQ3PxZVnzp06MA777xz2+0P8pn/252jwWBgwYIFVqMvNdq3b1+n4xw9epTIyEhatWpFZGQkLVu2pEGDBhgMBt5//32LkRQ3NzeSk5M5ePAge/bs4eDBg8ybN49FixYRExNzx3kUthgzZgwvv/yyRdn8+fOBGyNRN/Pw8LinY1y8eJFly5bh7++PyWQyJ2Y///wzAKWlpeYk9dbHxkRERERsocSinp09e9aq7MyZM8CNEYp71aZNG7Kzs/nll1/uOGrRunVrLl++TJ8+fW57036vHnvsMb799luuXLli9VjS6dOncXJyMk+QvpPWrVvzj3/8gxYtWphHc26nZsQjNzcXLy+v29bbunUrVVVVLFiwwKKfy8vLLUYratjb29O7d2/z6k0nTpxg1KhRJCYmEhMTA9xIfurqTvu0a9eOdu3aWZTV9GO/fv3qfKza/PLLL1y/fp0NGzawYcMGq+3Lly9n+fLlzJkz546jWiIiIiJ1pTkW9WzdunWUlZWZP5eVlbF+/XpcXFx46qmn7rndml+6FyxYYDWPwWQymf/39/fnl19+4e9//3ut7dQ8YnQvBgwYQHV1NcuXL7co37VrFzk5Ofj4+NxVMlMzsTkuLq7WF7fdHKOvry+Ojo4sWbLEol9r1Jx7zSNlN/cFQFJSklV/lZSUWLXj7e3No48+yq+//mouq/lFv7S09DfP6eZ9bm7jQXvssceYM2eO1V/NuzL8/f2ZM2fOfRuVERERkT8ujVjUMzc3N958803zpOz09HQuXLjA9OnTbXr0adCgQbzwwgts2rSJc+fO4ePjg4uLC3l5eXz77besXbsWgDfeeIM9e/YQExPDvn376NOnD05OTly4cIF9+/bxyCOPsGjRonuKISAggIyMDFasWEFBQQG9evXi3LlzrFu3Dnd3d4sVnu6ka9euhIaGsnjxYkaOHMmgQYPw8PDg4sWLHDt2jF27drF7924AmjdvzuTJk/nwww8JCgrC398fT09PiouLyc7OZsaMGXTq1IkBAwawatUqJk6cSGBgII6OjuzZs4eTJ09ajaJER0dTXFxMv3798PT05Pr162zfvp2rV6/i7+9vrte9e3fWrl3LnDlz6N+/Pw4ODnTr1u2OI0/du3cnLS2N+Ph42rZti8FgwMfHx+bHjgoLC9m0aROA+R0mO3bsoKioCMDcL87Ozrd9DwjceExOIxUiIiJyPyixqGf/8z//w/fff09qaiqXLl2iTZs2REdH89JLL9nc9v/9v/+Xnj17kpaWxpIlS7C3t6dly5YWN4oODg7Mnz+fdevWsXnzZnMS4eHhQdeuXXnllVfu+fgODg7ExsaaX5CXmZmJi4sLvr6+RERE1GlCeGhoKF26dCElJYXVq1dTXl5O06ZNad++PVOmTLGoO3ToUFq1akVycjIpKSlUVlbi4eFBnz59zO/FePLJJ5k7dy5Lly4lISGBBg0a0LdvXxYvXkxISIhFe35+fqSnp7Np0yYuX76Mk5MT7dq148MPP8TX19dcb/DgweTk5LBt2za++uorqquriYqKumNiERERQWlpKampqVy5cgWTycTnn39uc2KRn59PQkKCRVlmZiaZmZnm87/5BYUiIiIiD5rBdOuzI3JPat68nZCQYPHWZZF/d4aPH9ySvCIi8mCYpui3Zal/mmMhIiIiIiI2U2IhIiIiIiI2U2IhIiIiIiI20xwLEbkjzbEQEfnPozkWcj9oxEJERERERGymxEJERERERGymxEJERERERGymB+xE5I4WNU4iODgYR0fHhx2KiIiI/I5pxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGymxEJERERERGxmMJlMpocdhIj8fhk+Nj7sEERExEamKQ4POwT5A9CIhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2EyJhYiIiIiI2Ox3nVjMnDmT3r1731XdgoICevfuzaJFi+5zVDfUJbbQ0FACAgLuc0R3Vtf+ycnJITw8nIEDBz7QfhURERGRf096W4pYMRqNTJs2DaPRSFhYGC4uLjz++OMPO6wHLisri5ycHMaPH3/X+6xatQoXF5d6TSRNJhNbtmzhm2++4dixY/z888+4ubnRsWNHxo0bR7du3Szqnz17lqVLl3L8+HF+/vlnjEYjLVq04Nlnn2XMmDH86U9/qrfYRERERGr8rhOL6dOn8//+v//vww7jDyc/P5/8/HwmTZrEiBEjHnY4D01WVhYZGRl1SixWr16Np6dnvSYW//znP5kxYwYdO3bkxRdfpGXLlly8eJENGzYQHBzMrFmz8PPzM9cvLi7m4sWLDBw4kGbNmmFvb8/Jkyf57LPP2LZtG6tWraJp06b1Fp+IiIgI1ENiUVVVRWVlJY8++mh9xGPBwcEBB4ffde7zH+mXX34BwNXVtV7bNZlMlJeX06hRo3pt999ZaGgoAIsXL75tHXt7exYtWsRTTz1lUR4YGMjw4cOZP38+L730EnZ2N55s7Nu3L3379rVqp1evXrz33nukp6fz5ptv1uNZiIiIiNQxsUhPT2fWrFnExcVx+PBh0tPTuXDhAtOnTycgIACTycT69evZuHEjZ86cwc7Oji5duhASEmI1HyEjI4O1a9eSl5eH0WjE3d2d7t27M3nyZJo0aQLcmMeQkZHB/v37Lfb9/vvvWbBgATk5OTg5OeHr68uQIUNuG29CQoLV8UNDQyksLCQ9Pd1ctnv3btLS0vjxxx+5ePEijo6OdO3albFjx1rd1NWHAwcOsHTpUo4ePYrRaMTb25thw4bx2muvWdQ7cuQI69at49ChQxQVFWFvb0+HDh0YPXo0AwcOtGr3bvunNqGhoRw4cACAWbNmMWvWLAA+//xzWrZsSXl5OYmJiWzfvp3i4mIaN25Mv379CA8Px9PT09zO/v37CQsLIyoqivLyclJTUzl//jx//vOfzSMA27ZtY82aNZw4cYKqqirzOQ0aNMgqrv3797Ny5UqOHDlCeXk5Hh4ePPXUU7z99tu4ubkBkJqaSlZWFqdPn+by5cu4urrSt29fwsPDadmypUV7O3fuJDk5mVOnTlFRUYGbmxtdunQhMjISLy8vi364+dqJioq67WhETb3CwkKLfWr67l45ODjUev25u7vTq1cvMjMzuXTp0m8+4tSiRQsArly5cs+xiIiIiNzOPQ0HxMTEYDQaCQwMxMnJCS8vLwBmzJjBF198ga+vLwEBAVRWVrJlyxYmTJjA3Llzef755wHYtGkTM2fOpGfPnoSFhdGgQQOKiorYtWsXly5dMicWtTly5AgRERE0atSIMWPG4OLiwrZt24iKirqXU7GQnp5OaWkpfn5+NG/enOLiYtLS0oiIiCAhIYGePXvafIwaO3bsYOrUqbi7uzNq1CgaNWrEtm3biI6OJj8/nwkTJpjrZmVlcfbsWQYNGoSnpyelpaVkZGQwdepUoqOjeemll8x1be2fsWPH8sQTT7Bs2TICAwPN59ykSROMRiORkZH88MMP+Pr6MmrUKPLy8li/fj179uwhOTmZ5s2bW7S3evVqSktLee2113B3dzdvX7hwIUlJSTzzzDOEhYVhZ2dHZmYm7733HtOmTWP48OHmNtavX8+cOXNo1qwZQ4YMwdPTkwsXLvDNN99QVFRkTiw+/fRTunXrxogRI3B1deXUqVNs3LiRffv2kZKSYq733Xff8e6779K+fXuCg4Nxdnbm4sWL7N27l3PnzuHl5cXYsWMxmUwcPHiQ2bNnm2Pp0aPHbftu9uzZzJs3Dzc3N8aOHWsuv9P1bKvi4mIcHR1xcXGx2nb9+nXKy8u5fv06Z86cYcGCBQA8++yz9y0eERER+eO6p8SioqKCVatWWTz+lJmZyZYtW3j//fd5/fXXzeVBQUEEBwfzt7/9DR8fHwwGA1lZWTg5OREfH2/xqFNYWNhvHnvevHlUV1eTmJhoTmiGDRvGuHHj7uVULEyfPp2GDRtalA0ZMoThw4ezbNmyekssqqqqmDt3Lg0bNmTFihV4eHgAMHz4cMaPH8+KFSsICAigTZs2AIwbN47IyEiLNoKCghg5ciSJiYkWiYWt/fP000/j4ODAsmXL6NGjh8Wz+5999hk//PADo0ePZuLEiebyfv36MWnSJGJjY/nggw8s2rtw4QLr1q2zeKb/+PHjJCUlERwcbJFABQUFMXnyZOLi4vD398fJyYmioiI+/vhjvL29SUpKsriBDg8Pp7q62vw5JSXF6vvz8fEhIiKCtLQ08+M/2dnZVFdXExcXZxHXW2+9ZdEPW7du5eDBgxZ9cCd+fn7Ex8fTtGnTu97HFjt37uTo0aP4+fnRoEEDq+0bN27ko48+Mn9u2bIlH3zwQb0myCIiIiI17mm52aFDh1rNqdi8eTNOTk4MGDCAkpIS819ZWRnPPfccBQUF5OXlAeDs7ExFRQU7d+7EZDLd9XEvXbrEoUOHeP755803zQCOjo6MHDnyXk7Fws03pdeuXaOkpAR7e3u6devG0aNHbW6/xrFjx7hw4QKvvvqqOamAG+cxZswYqquryc7OrjWuiooKSkpKqKiooE+fPpw5c4aysjLg/vdPZmYmdnZ2BAcHW5T379+fjh07smPHDosbfQB/f3+ricJbtmzBYDDg7+9vca2UlJTg4+PD1atXOXz4MABffvkllZWVhISE1PqrfM28AvhXP1VXV1NWVkZJSQkdO3bE2dmZI0eOmOs5OzsD8PXXX2M0Gm3okbqpuaZu/jMajRiNRqvya9eu3bGtvLw8oqKiaNasGe+8806tdQYMGEBcXBwff/wxISEhODs7U1JSch/OTEREROQeRyxqfkm/2dmzZ7l69Sovvvjibfe7dOkSXl5eBAcHc+DAAaZMmYKrqyu9evXi2Wef5YUXXsDJyem2++fn5wPg7e1tta1du3Z1P5FbnD9/nri4OHbv3m31HLrBYLC5/RoFBQVA7TG3b98e+Ne5wo1+i4+PJzs7m0uXLlntU1ZWhrOz833vn4KCAjw8PGjcuHGtcefm5lJSUmKRSNR2rZw5cwaTycTQoUNve6yaCeTnzp0DoFOnTr8Z3759+1iyZAlHjx7l+vXrFttu/j6HDx9OdnY2c+bM4ZNPPuGJJ57gmWeeYfDgwff1saW5c+eSkZFR67Zb55W88sorzJw5s9a6+fn5hIeHA7BgwYLbxty8eXPzo2cDBgzgv//7vxkzZgwVFRVWyaGIiIiIre4psahtBSiTyUSTJk2Ijo6+7X41N81t2rQhNTWVvXv3sm/fPg4cOEB0dDSLFi1iyZIltGrV6l7CsnKnZKCqqsri87Vr1wgJCaG8vJw33niDDh064OTkhMFgYPny5ezbt69eYqork8lEZGQkZ86cISgoiC5duuDs7IydnR3p6els3brVapTg9+R2q4UZDAYWLFhgMeJws5pr5W4dPXqUyMhIWrVqRWRkJC1btqRBgwYYDAbef/99iz5yc3MjOTmZgwcPsmfPHg4ePMi8efNYtGgRMTExd5xHYYsxY8bw8ssvW5TNnz8fgEmTJlmU3zySdbOCggLCwsIoLy9n4cKFdOjQ4a6P//jjj9OpUyfWrVunxEJERETqXb2t5dq6dWvy8vLo3r37XS0n+sgjj9C/f3/69+8P3HhefNKkSfz973/nL3/5S6371Kysc/bsWattp0+ftiqr+WX9119/tdpWUFBgMb9j7969/Pzzz8yYMYNXX33Vom58fPxvnk9dPPbYY0DtMdeU1dQ5ceIEubm5hISEWL1PYePGjRaf69o/dfXYY4/x7bffcuXKFavHkk6fPo2Tk5N5gvSdtG7dmn/84x+0aNGCtm3b3rFuzYhHbm6uxeNdt9q6dStVVVUsWLDA3HcA5eXlta6CZG9vT+/evc2rN504cYJRo0aRmJhITEwMcG+jVHfap127dlYjRzX92K9fv99su6CggPHjx1NWVsbChQvp3LlzneO7fv06paWldd5PRERE5Lfc0xyL2vj7+1NdXU1sbGyt22sebQFqfc675ibpTjc9NUvSZmdn89NPP5nLKysrWbVqlVX9mpvSvXv3WpRv3bqVn3/+2aLM3t4ewGrOx+7duy2ez68PnTt3pkWLFqSnp3Px4kVzudFoZOXKlRgMBvMKWjW/6N8a18mTJ8nKyrIoq2v/1NWAAQOorq5m+fLlFuW7du0iJycHHx+f245A3KxmYnNcXJzVyBFYXiu+vr44OjqyZMkS81ySm9X0y+2+v6SkJKsRndquP29vbx599FGLJLRmzkZdbsQbNmxYayJrq8LCQsLCwrhy5QqxsbH813/9123r3nxN3Wz//v2cOnWK7t2713t8IiIiIvU2YjFo0CACAgJYu3Ytx48f57nnnsPNzY3i4mIOHTrE+fPnSUtLA2DChAm4uLjQs2dPmjdvzpUrV0hPT8dgMPzmajrvvPMO48ePZ9y4cQwbNsy8nGptN6je3t707duXDRs2YDKZ6NixI7m5uWRlZdG6dWuLibtPPvkk7u7uzJ8/n8LCQpo1a0Zubi6bN2+mQ4cOnDx5sr66Cnt7e6ZNm8bUqVN58803CQwMpFGjRmzfvp3Dhw8THBxsToratm1Lu3btSE5OpqKiAi8vL/Ly8tiwYQMdOnTg2LFj99w/dRUQEEBGRgYrVqygoKCAXr16ce7cOdatW4e7u7vFCk930rVrV0JDQ1m8eDEjR45k0KBBeHh4cPHiRY4dO8auXbvYvXs3cGOewOTJk/nwww8JCgrC398fT09PiouLyc7OZsaMGXTq1IkBAwawatUqJk6cSGBgII6OjuzZs4eTJ09ajaJER0dTXFxMv3798PT05Pr162zfvp2rV6/i7+9vrte9e3fWrl3LnDlz6N+/Pw4ODnTr1s1iRORW3bt3Jy0tjfj4eNq2bYvBYMDHx8dqtaq6uHr1KmFhYRQUFDBixAh++ukni8QRbox4uLu7AzBnzhwuXrxInz59aNGiBf/85z85duwY27Zto1GjRlaPXYmIiIjUh3p9rXVUVBS9e/fms88+Y/ny5VRWVuLu7k7nzp0tbjqHDh3K9u3b2bBhA6Wlpbi6utKpUyemTZtm9SK7W/Xo0YO4uDhiY2NZsWIFzs7O5hfABQUFWdWfPXs2H330EVu3bmXz5s307NmThIQE/vrXv1JYWGiu5+LiQmxsLAsWLGDNmjVUVVXRuXNnYmJiSEtLq9fEAm4sg7pw4UISExNZuXIllZWVeHt7M336dIsX5Nnb2xMTE8P8+fPJyMigvLyc9u3bM3PmTHJzc60Si7r2T104ODgQGxtrfkFeZmYmLi4u+Pr6EhERYX4B290IDQ2lS5cupKSksHr1asrLy2natCnt27dnypQpFnWHDh1Kq1atSE5OJiUlhcrKSjw8POjTp495cvKTTz7J3LlzWbp0KQkJCTRo0IC+ffuyePFiQkJCLNrz8/MjPT2dTZs2cfnyZZycnGjXrh0ffvghvr6+5nqDBw8mJyeHbdu28dVXX1FdXU1UVNQdE4uIiAhKS0tJTU3lypUrmEwmPv/8c5sSi9LSUvPE/DVr1tRaJyEhwZxYDB48mE2bNrF582YuX76MwWCgRYsWvP7664wZM6ZO35OIiIjI3TKY6rLeq4j84Rg+fnBL8oqIyP1hmlKvvyWL1Kre5liIiIiIiMgflxILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmdYeE5E7WtQ4ieDgYBwdHR92KCIiIvI7phELERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmRILERERERGxmcFkMpkedhAi8vtl+Nj4sEMQEZGbmKY4POwQRGqlEQsREREREbGZEgsREREREbGZEgsREREREbGZEgsREREREbGZEgsREREREbGZEgsREREREbHZ7zqxmDlzJr17976rugUFBfTu3ZtFixbd56huqEtsoaGhBAQE3OeI7qyu/ZOTk0N4eDgDBw58oP0qIiIiIv+etBCyWDEajUybNg2j0UhYWBguLi48/vjjDzusBy4rK4ucnBzGjx9/1/usWrUKFxeXek8kjxw5wpYtWzh27BgnTpygvLycqKioWo9z7do1Pv30U44dO0ZOTg7FxcX06tWLxYsX12tMIiIiIjf7XY9YTJ8+nV27dj3sMP5w8vPzyc/P54033mDEiBH4+fn9YROLJUuW1Gmf1atXk56eXu+x7Nq1i9TUVMrKyn7zuygpKWHx4sX8+OOPPP7449jb29d7PCIiIiK3snnEoqqqisrKSh599NH6iMeCg4MDDg4aVHnQfvnlFwBcXV3rtV2TyUR5eTmNGjWq13b/nYWGhgL85mjC0KFDGTNmDA0bNuTLL7/k0KFDt637pz/9iU2bNtG8eXMAnnvuufoLWEREROQ26nTXnp6ezqxZs4iLi+Pw4cOkp6dz4cIFpk+fTkBAACaTifXr17Nx40bOnDmDnZ0dXbp0ISQkxGo+QkZGBmvXriUvLw+j0Yi7uzvdu3dn8uTJNGnSBLgxjyEjI4P9+/db7Pv999+zYMECcnJycHJywtfXlyFDhtw23oSEBKvjh4aGUlhYaPHr8u7du0lLS+PHH3/k4sWLODo60rVrV8aOHctTTz1Vl666KwcOHGDp0qUcPXoUo9GIt7c3w4YN47XXXrOod+TIEdatW8ehQ4coKirC3t6eDh06MHr0aAYOHGjV7t32T21CQ0M5cOAAALNmzWLWrFkAfP7557Rs2ZLy8nISExPZvn07xcXFNG7cmH79+hEeHo6np6e5nf379xMWFkZUVBTl5eWkpqZy/vx5/vznP5sfLdq2bRtr1qzhxIkTVFVVmc9p0KBBVnHt37+flStXcuTIEcrLy/Hw8OCpp57i7bffxs3NDYDU1FSysrI4ffo0ly9fxtXVlb59+xIeHk7Lli0t2tu5cyfJycmcOnWKiooK3Nzc6NKlC5GRkXh5eVn0w83Xzu0eP7q5XmFhocU+NX1nC3d397uu+8gjj5iTChEREZEH5Z6GA2JiYjAajQQGBuLk5ISXlxcAM2bM4IsvvsDX15eAgAAqKyvZsmULEyZMYO7cuTz//PMAbNq0iZkzZ9KzZ0/CwsJo0KABRUVF7Nq1i0uXLpkTi9ocOXKEiIgIGjVqxJgxY3BxcWHbtm1ERUXdy6lYSE9Pp7S0FD8/P5o3b05xcTFpaWlERESQkJBAz549bT5GjR07djB16lTc3d0ZNWoUjRo1Ytu2bURHR5Ofn8+ECRPMdbOysjh79iyDBg3C09OT0tJSMjIymDp1KtHR0bz00kvmurb2z9ixY3niiSdYtmwZgYGB5nNu0qQJRqORyMhIfvjhB3x9fRk1ahR5eXmsX7+ePXv2kJycbHVDu3r1akpLS3nttddwd3c3b1+4cCFJSUk888wzhIWFYWdnR2ZmJu+99x7Tpk1j+PDh5jbWr1/PnDlzaNasGUOGDMHT05MLFy7wzTffUFRUZE4sPv30U7p168aIESNwdXXl1KlTbNy4kX379pGSkmKu99133/Huu+/Svn17goODcXZ25uLFi+zdu5dz587h5eXF2LFjMZlMHDx4kNmzZ5tj6dGjx237bvbs2cybNw83NzfGjh1rLr/T9SwiIiLyn+KeEouKigpWrVpl8fhTZmYmW7Zs4f333+f11183lwcFBREcHMzf/vY3fHx8MBgMZGVl4eTkRHx8vMWjTmFhYb957Hnz5lFdXU1iYqI5oRk2bBjjxo27l1OxMH36dBo2bGhRNmTIEIYPH86yZcvqLbGoqqpi7ty5NGzYkBUrVuDh4QHA8OHDGT9+PCtWrCAgIIA2bdoAMG7cOCIjIy3aCAoKYuTIkSQmJlokFrb2z9NPP42DgwPLli2jR48e+Pn5mbd99tln/PDDD4wePZqJEyeay/v168ekSZOIjY3lgw8+sGjvwoULrFu3jqZNm5rLjh8/TlJSEsHBwRYJVFBQEJMnTyYuLg5/f3+cnJwoKiri448/xtvbm6SkJFxcXMz1w8PDqa6uNn9OSUmx+v58fHyIiIggLS2NN998E4Ds7Gyqq6uJi4uziOutt96y6IetW7dy8OBBiz64Ez8/P+Lj42natOld7yMiIiLyn+KeJm8PHTrUak7F5s2bcXJyYsCAAZSUlJj/ysrKeO655ygoKCAvLw8AZ2dnKioq2LlzJyaT6a6Pe+nSJQ4dOsTzzz9vvmkGcHR0ZOTIkfdyKhZuvim9du0aJSUl2Nvb061bN44ePWpz+zWOHTvGhQsXePXVV81JBdw4jzFjxlBdXU12dnatcVVUVFBSUkJFRQV9+vThzJkzlJWVAfe/fzIzM7GzsyM4ONiivH///nTs2JEdO3ZY3OgD+Pv7W9y8A2zZsgWDwYC/v7/FtVJSUoKPjw9Xr17l8OHDAHz55ZdUVlYSEhJikVTUsLP71yVc00/V1dWUlZVRUlJCx44dcXZ25siRI+Z6zs7OAHz99dcYjUYbeqRuaq6pm/+MRiNGo9Gq/Nq1aw8sLhEREZH6cE8jFjW/pN/s7NmzXL16lRdffPG2+126dAkvLy+Cg4M5cOAAU6ZMwdXVlV69evHss8/ywgsv4OTkdNv98/PzAfD29rba1q5du7qfyC3Onz9PXFwcu3fv5sqVKxbbDAaDze3XKCgoAGqPuX379sC/zhVu9Ft8fDzZ2dlcunTJap+ysjKcnZ3ve/8UFBTg4eFB48aNa407NzeXkpISi0SitmvlzJkzmEwmhg4dettj1UwgP3fuHACdOnX6zfj27dvHkiVLOHr0KNevX7fYdvP3OXz4cLKzs5kzZw6ffPIJTzzxBM888wyDBw++r48tzZ07l4yMjFq33Tqv5JVXXmHmzJn3LRYRERGR+nZPiUVtK0CZTCaaNGlCdHT0bferuWlu06YNqamp7N27l3379nHgwAGio6NZtGgRS5YsoVWrVvcSlpU7JQNVVVUWn69du0ZISAjl5eW88cYbdOjQAScnJwwGA8uXL2ffvn31ElNdmUwmIiMjOXPmDEFBQXTp0gVnZ2fs7OxIT09n69atVqMEvye3Wy3MYDCwYMECixGHm9VcK3fr6NGjREZG0qpVKyIjI2nZsiUNGjTAYDDw/vvvW/SRm5sbycnJHDx4kD179nDw4EHmzZvHokWLiImJueM8CluMGTOGl19+2aJs/vz5AEyaNMmi/OaRLBEREZF/B/W2lmvr1q3Jy8uje/fud7Wc6COPPEL//v3p378/cGOVnkmTJvH3v/+dv/zlL7XuU7OyztmzZ622nT592qqs5pf1X3/91WpbQUGBxfyOvXv38vPPPzNjxgxeffVVi7rx8fG/eT518dhjjwG1x1xTVlPnxIkT5ObmEhISYvWito0bN1p8rmv/1NVjjz3Gt99+y5UrV6weSzp9+jROTk7mCdJ30rp1a/7xj3/QokUL2rZte8e6NSMeubm5Fo933Wrr1q1UVVWxYMECc98BlJeXW40+Adjb29O7d2/z6k0nTpxg1KhRJCYmEhMTA9zbKNWd9mnXrp3VyFFNP/br16/OxxIRERH5Pam3F+T5+/tTXV1NbGxsrdtrHm2BGy/wulXnzp0BKC0tve0xapakzc7O5qeffjKXV1ZWsmrVKqv6NTele/futSjfunUrP//8s0VZzUvEbp3zsXv3bovn8+tD586dadGiBenp6Vy8eNFcbjQaWblyJQaDwbyCVs0v+rfGdfLkSbKysizK6to/dTVgwACqq6tZvny5RfmuXbvIycnBx8fntiMQN6uZ2BwXF2c1cgSW14qvry+Ojo4sWbLEPJfkZjX9crvvLykpyWpEp7brz9vbm0cffdQiCa2Zs3Gna/JWDRs2rDWRFREREflPV28jFoMGDSIgIIC1a9dy/PhxnnvuOdzc3CguLubQoUOcP3+etLQ0ACZMmICLiws9e/akefPmXLlyhfT0dAwGw2+upvPOO+8wfvx4xo0bx7Bhw8zLqdZ2g+rt7U3fvn3ZsGEDJpOJjh07kpubS1ZWFq1bt7aYuPvkk0/i7u7O/PnzKSwspFmzZuTm5rJ582Y6dOjAyZMn66ursLe3Z9q0aUydOpU333yTwMBAGjVqxPbt2zl8+DDBwcHmpKht27a0a9eO5ORkKioq8PLyIi8vjw0bNtChQweOHTt2z/1TVwEBAWRkZLBixQoKCgro1asX586dY926dbi7u1us8HQnXbt2JTQ0lMWLFzNy5EgGDRqEh4cHFy9e5NixY+zatYvdu3cD0Lx5cyZPnsyHH35IUFAQ/v7+eHp6UlxcTHZ2NjNmzKBTp04MGDCAVatWMXHiRAIDA3F0dGTPnj2cPHnSahQlOjqa4uJi+vXrh6enJ9evX2f79u1cvXoVf39/c73u3buzdu1a5syZQ//+/XFwcKBbt24WIyK36t69O2lpacTHx9O2bVsMBgM+Pj5Wq1XVVWFhIZs2bQL+Nfq0Y8cOioqKAMz9UmPNmjXmkRqj0ciFCxdYunQpAB07dsTHx8emeERERERuVa+vtY6KiqJ379589tlnLF++nMrKStzd3encubPFTefQoUPZvn07GzZsoLS0FFdXVzp16sS0adOsXmR3qx49ehAXF0dsbCwrVqzA2dnZ/AK4oKAgq/qzZ8/mo48+YuvWrWzevJmePXuSkJDAX//6VwoLC831XFxciI2NZcGCBaxZs4aqqio6d+5MTEwMaWlp9ZpYwI1lUBcuXEhiYiIrV66ksrISb29vpk+fbvGCPHt7e2JiYpg/fz4ZGRmUl5fTvn17Zs6cSW5urlViUdf+qQsHBwdiY2PNL8jLzMzExcUFX19fIiIiaNGixV23FRoaSpcuXUhJSWH16tWUl5fTtGlT2rdvz5QpUyzqDh06lFatWpGcnExKSgqVlZV4eHjQp08f83sxnnzySebOncvSpUtJSEigQYMG9O3bl8WLFxMSEmLRnp+fH+np6WzatInLly/j5OREu3bt+PDDD/H19TXXGzx4MDk5OWzbto2vvvqK6upqoqKi7phYREREUFpaSmpqKleuXMFkMvH555/bnFjk5+eTkJBgUZaZmUlmZqb5/G9OLD799FOL67ugoMC8/yuvvKLEQkREROqdwVSX9V5F5A/H8PGDW5JXRER+m2lKvf4uLFJv6m2OhYiIiIiI/HEpsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZtpIWQRuaNFjZMIDg7G0dHxYYciIiIiv2MasRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZsZTCaT6WEHISK/X4aPjQ87BBERuYlpisPDDkGkVhqxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERm/1HJRYzZ86kd+/ed1W3oKCA3r17s2jRovsc1Q11iS00NJSAgID7HNGd1bV/cnJyCA8PZ+DAgQ+0X0VERETk90FvWBGbGY1Gpk2bhtFoJCwsDBcXFx5//PGHHdYDl5WVRU5ODuPHj7/rfVatWoWLi0u9J5KffvopO3bs4KeffuLXX3+lcePGeHt7ExQUxMCBA+v1WCIiIiLwHzZiMX36dHbt2vWww/jDyc/PJz8/nzfeeIMRI0bg5+f3h00slixZUqd9Vq9eTXp6er3HcvToUVq2bMnIkSN57733GDVqFBUVFUydOpWlS5fW+/FEREREHviIRVVVFZWVlTz66KP13raDgwMODhqEedB++eUXAFxdXeu1XZPJRHl5OY0aNarXdv+dhYaGArB48eI71vvrX/9qVfbGG28wevRokpOTCQ4Oxt7e/r7EKCIiIn9M9/UuPD09nVmzZhEXF8fhw4dJT0/nwoULTJ8+nYCAAEwmE+vXr2fjxo2cOXMGOzs7unTpQkhIiNV8hIyMDNauXUteXh5GoxF3d3e6d+/O5MmTadKkCXBjHkNGRgb79++32Pf7779nwYIF5OTk4OTkhK+vL0OGDLltvAkJCVbHDw0NpbCw0OLX5d27d5OWlsaPP/7IxYsXcXR0pGvXrowdO5annnqqvrrR7MCBAyxdupSjR49iNBrx9vZm2LBhvPbaaxb1jhw5wrp16zh06BBFRUXY29vToUMHRo8eXetjMHfbP7UJDQ3lwIEDAMyaNYtZs2YB8Pnnn9OyZUvKy8tJTExk+/btFBcX07hxY/r160d4eDienp7mdvbv309YWBhRUVGUl5eTmprK+fPn+fOf/2x+tGjbtm2sWbOGEydOUFVVZT6nQYMGWcW1f/9+Vq5cyZEjRygvL8fDw4OnnnqKt99+Gzc3NwBSU1PJysri9OnTXL58GVdXV/r27Ut4eDgtW7a0aG/nzp0kJydz6tQpKioqcHNzo0uXLkRGRuLl5WXRDzdfO1FRUbd9zKmmXmFhocU+NX1X3xwcHPDw8ODkyZMYjUYlFiIiIlKvHsjP+zExMRiNRgIDA3FycsLLywuAGTNm8MUXX+Dr60tAQACVlZVs2bKFCRMmMHfuXJ5//nkANm3axMyZM+nZsydhYWE0aNCAoqIidu3axaVLl8yJRW2OHDlCREQEjRo1YsyYMbi4uLBt2zaioqJsPq/09HRKS0vx8/OjefPmFBcXk5aWRkREBAkJCfTs2dPmY9TYsWMHU6dOxd3dnVGjRtGoUSO2bdtGdHQ0+fn5TJgwwVw3KyuLs2fPMmjQIDw9PSktLSUjI4OpU6cSHR3NSy+9ZK5ra/+MHTuWJ554gmXLlhEYGGg+5yZNmmA0GomMjOSHH37A19eXUaNGkZeXx/r169mzZw/Jyck0b97cor3Vq1dTWlrKa6+9hru7u3n7woULSUpK4plnniEsLAw7OzsyMzN57733mDZtGsOHDze3sX79eubMmUOzZs0YMmQInp6eXLhwgW+++YaioiJzYvHpp5/SrVs3RowYgaurK6dOnWLjxo3s27ePlJQUc73vvvuOd999l/bt2xMcHIyzszMXL15k7969nDt3Di8vL8aOHYvJZOLgwYPMnj3bHEuPHj1u23ezZ89m3rx5uLm5MXbsWHP5na7nuiotLaW6upqSkhK+/PJLvv32W3r37k2DBg3q7RgiIiIi8IASi4qKClatWmXx+FNmZiZbtmzh/fff5/XXXzeXBwUFERwczN/+9jd8fHwwGAxkZWXh5OREfHy8xaNOYWFhv3nsefPmUV1dTWJiojmhGTZsGOPGjbP5vKZPn07Dhg0tyoYMGcLw4cNZtmxZvSUWVVVVzJ07l4YNG7JixQo8PDwAGD58OOPHj2fFihUEBATQpk0bAMaNG0dkZKRFG0FBQYwcOZLExESLxMLW/nn66adxcHBg2bJl9OjRAz8/P/O2zz77jB9++IHRo0czceJEc3m/fv2YNGkSsbGxfPDBBxbtXbhwgXXr1tG0aVNz2fHjx0lKSiI4ONgigQoKCmLy5MnExcXh7++Pk5MTRUVFfPzxx3h7e5OUlISLi4u5fnh4ONXV1ebPKSkpVt+fj48PERERpKWl8eabbwKQnZ1NdXU1cXFxFnG99dZbFv2wdetWDh48aNEHd+Ln50d8fDxNmza9633q6vXXX6e0tBQAe3t7/vu//5v33nvvvhxLRERE/tgeyOTtoUOHWs2p2Lx5M05OTgwYMICSkhLzX1lZGc899xwFBQXk5eUB4OzsTEVFBTt37sRkMt31cS9dusShQ4d4/vnnzTfNAI6OjowcOdLm87r5pvTatWuUlJRgb29Pt27dOHr0qM3t1zh27BgXLlzg1VdfNScVcOM8xowZQ3V1NdnZ2bXGVVFRQUlJCRUVFfTp04czZ85QVlYG3P/+yczMxM7OjuDgYIvy/v3707FjR3bs2GFxow/g7+9vcfMOsGXLFgwGA/7+/hbXSklJCT4+Ply9epXDhw8D8OWXX1JZWUlISIhFUlHDzu5fl3xNP1VXV1NWVkZJSQkdO3bE2dmZI0eOmOs5OzsD8PXXX2M0Gm3okbqpuaZu/jMajRiNRqvya9eu1drGRx99RGxsLDNmzKBfv35cv36dq1evPrBzEBERkT+OBzJiUfNL+s3Onj3L1atXefHFF2+736VLl/Dy8iI4OJgDBw4wZcoUXF1d6dWrF88++ywvvPACTk5Ot90/Pz8fAG9vb6tt7dq1q/uJ3OL8+fPExcWxe/durly5YrHNYDDY3H6NgoICoPaY27dvD/zrXOFGv8XHx5Odnc2lS5es9ikrK8PZ2fm+909BQQEeHh40bty41rhzc3MpKSmxSCRqu1bOnDmDyWRi6NChtz1WzQTyc+fOAdCpU6ffjG/fvn0sWbKEo0ePcv36dYttN3+fw4cPJzs7mzlz5vDJJ5/wxBNP8MwzzzB48OB6fWzpVnPnziUjI6PWbbfOK3nllVeYOXOmVb1evXqZ/3/11Vd5//33GTduHKmpqbV+LyIiIiL36oEkFrWtAGUymWjSpAnR0dG33a/mprlNmzakpqayd+9e9u3bx4EDB4iOjmbRokUsWbKEVq1a1Uucd0oGqqqqLD5fu3aNkJAQysvLeeONN+jQoQNOTk4YDAaWL1/Ovn376iWmujKZTERGRnLmzBmCgoLo0qULzs7O2NnZkZ6eztatW61GCX5PbrdamMFgYMGCBRYjDjeruVbu1tGjR4mMjKRVq1ZERkbSsmVLGjRogMFg4P3337foIzc3N5KTkzl48CB79uzh4MGDzJs3j0WLFhETE3PHeRS2GDNmDC+//LJF2fz58wGYNGmSRfnNI1l38sorr7Bt2za+/vprq0n/IiIiIrZ4aGuztm7dmry8PLp3735Xy4k+8sgj9O/fn/79+wM3VumZNGkSf//73/nLX/5S6z41K+ucPXvWatvp06etymp+wf3111+tthUUFFjM79i7dy8///wzM2bM4NVXX7WoGx8f/5vnUxePPfYYUHvMNWU1dU6cOEFubi4hISFWL2rbuHGjxee69k9dPfbYY3z77bdcuXLF6rGk06dP4+TkZJ4gfSetW7fmH//4By1atKBt27Z3rFsz4pGbm2vxeNettm7dSlVVFQsWLDD3HUB5ebnV6BPcmJ/Qu3dv8+pNJ06cYNSoUSQmJhITEwPc2yjVnfZp166d1chRTT/269evzscCzCMztV3jIiIiIrZ4aC/I8/f3p7q6mtjY2Fq31zzaAlBSUmK1vXPnzgDmiam1qVmSNjs7m59++slcXllZyapVq6zq19yU7t2716J869at/PzzzxZlNUt13jrnY/fu3RbP59eHzp0706JFC9LT07l48aK53Gg0snLlSgwGg3kFrZpf9G+N6+TJk2RlZVmU1bV/6mrAgAFUV1ezfPlyi/Jdu3aRk5ODj4/PbUcgblYzsTkuLs5q5AgsrxVfX18cHR1ZsmSJeS7JzWr65XbfX1JSktWITm3Xn7e3N48++qjFDXrNnI07XZO3atiwYb3f5JeXl9c656KqqorU1FQAunfvXq/HFBEREXloIxaDBg0iICCAtWvXcvz4cZ577jnc3NwoLi7m0KFDnD9/nrS0NAAmTJiAi4sLPXv2pHnz5ly5coX09HQMBsNvrqbzzjvvMH78eMaNG8ewYcPMy6nWdoPq7e1N37592bBhAyaTiY4dO5Kbm0tWVhatW7e2mLj75JNP4u7uzvz58yksLKRZs2bk5uayefNmOnTowMmTJ+utr+zt7Zk2bRpTp07lzTffJDAwkEaNGrF9+3YOHz5McHCwOSlq27Yt7dq1Izk5mYqKCry8vMjLy2PDhg106NCBY8eO3XP/1FVAQAAZGRmsWLGCgoICevXqxblz51i3bh3u7u4WKzzdSdeuXQkNDWXx4sWMHDmSQYMG4eHhwcWLFzl27Bi7du1i9+7dADRv3pzJkyfz4YcfEhQUhL+/P56enhQXF5Odnc2MGTPo1KkTAwYMYNWqVUycOJHAwEAcHR3Zs2cPJ0+etBpFiY6Opri4mH79+uHp6cn169fZvn07V69exd/f31yve/furF27ljlz5tC/f38cHBzo1q2bxYjIrbp3705aWhrx8fG0bdsWg8GAj4+P1WpVdZGXl0doaCi+vr54eXnh6upKcXExX3zxBT/99BOvvPJKvS6FLCIiIgIPMbGAGy8P6927N5999hnLly+nsrISd3d3OnfubHHTOXToULZv386GDRsoLS3F1dWVTp06MW3aNKsX2d2qR48exMXFERsby4oVK3B2dja/AC4oKMiq/uzZs/noo4/YunUrmzdvpmfPniQkJPDXv/6VwsJCcz0XFxdiY2NZsGABa9asoaqqis6dOxMTE0NaWlq9JhZwYxnUhQsXkpiYyMqVK6msrMTb25vp06dbPCtvb29PTEwM8+fPJyMjg/Lyctq3b8/MmTPJzc21Sizq2j914eDgQGxsrPkFeZmZmbi4uODr60tERAQtWrS467ZCQ0Pp0qULKSkprF69mvLycpo2bUr79u2ZMmWKRd2hQ4fSqlUrkpOTSUlJobKyEg8PD/r06WN+L8aTTz7J3LlzWbp0KQkJCTRo0IC+ffuyePFiQkJCLNrz8/MjPT2dTZs2cfnyZZycnGjXrh0ffvghvr6+5nqDBw8mJyeHbdu28dVXX1FdXU1UVNQdE4uIiAhKS0tJTU3lypUrmEwmPv/8c5sSi+bNm+Pn58f3339PVlYWV69exdnZmU6dOvHWW29ZLDcsIiIiUl8Mprqs3yoifziGjx/cErsiIvLbTFMe6u/CIrf10OZYiIiIiIjIfw4lFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjOtVyYid7SocRLBwcE4Ojo+7FBERETkd0wjFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjMlFiIiIiIiYjODyWQyPewgROT3y/Cx8WGHICLyh2Ga4vCwQxC5ZxqxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERmymxEBERERERm/2uE4uZM2fSu3fvu6pbUFBA7969WbRo0X2O6oa6xBYaGkpAQMB9jujO6to/OTk5hIeHM3DgwAfaryIiIiLy70mLJYsVo9HItGnTMBqNhIWF4eLiwuOPP/6ww3rgsrKyyMnJYfz48Xe9z6pVq3BxcanXRNJkMrFlyxa++eYbjh07xs8//4ybmxsdO3Zk3LhxdOvWzWqf6upqVq9ezYYNGygsLKRJkyYMGjSIsLAwGjZsWG+xiYiIiNT4XY9YTJ8+nV27dj3sMP5w8vPzyc/P54033mDEiBH4+fn9YROLJUuW1Gmf1atXk56eXq9x/POf/2TGjBn89NNPvPjii0ydOpXAwEBycnIIDg5m8+bNVvvMmzeP//3f/6Vdu3ZMnToVX19fUlJSeOedd6iurq7X+ERERESgHkYsqqqqqKys5NFHH62PeCw4ODjg4KBBlQftl19+AcDV1bVe2zWZTJSXl9OoUaN6bfffWWhoKACLFy++bR17e3sWLVrEU089ZVEeGBjI8OHDmT9/Pi+99BJ2djd+Jzh16hRr1qxh4MCBfPTRR+b6LVu25OOPP2bbtm289NJL9+FsRERE5I+sTnft6enpzJo1i7i4OA4fPkx6ejoXLlxg+vTpBAQEYDKZWL9+PRs3buTMmTPY2dnRpUsXQkJCrOYjZGRksHbtWvLy8jAajbi7u9O9e3cmT55MkyZNgBvzGDIyMti/f7/Fvt9//z0LFiwgJycHJycnfH19GTJkyG3jTUhIsDp+aGgohYWFFr8u7969m7S0NH788UcuXryIo6MjXbt2ZezYsVY3dfXhwIEDLF26lKNHj2I0GvH29mbYsGG89tprFvWOHDnCunXrOHToEEVFRdjb29OhQwdGjx7NwIEDrdq92/6pTWhoKAcOHABg1qxZzJo1C4DPP/+cli1bUl5eTmJiItu3b6e4uJjGjRvTr18/wsPD8fT0NLezf/9+wsLCiIqKory8nNTUVM6fP8+f//xn86NF27ZtY82aNZw4cYKqqirzOQ0aNMgqrv3797Ny5UqOHDlCeXk5Hh4ePPXUU7z99tu4ubkBkJqaSlZWFqdPn+by5cu4urrSt29fwsPDadmypUV7O3fuJDk5mVOnTlFRUYGbmxtdunQhMjISLy8vi364+dqJioq67WNONfUKCwst9qnpu3vl4OBQ6/Xn7u5Or169yMzM5NKlS/zpT38C4IsvvsBkMjFy5EiL+oGBgcTGxrJ582YlFiIiIlLv7mk4ICYmBqPRSGBgIE5OTnh5eQEwY8YMvvjiC3x9fQkICKCyspItW7YwYcIE5s6dy/PPPw/Apk2bmDlzJj179iQsLIwGDRpQVFTErl27uHTpkjmxqM2RI0eIiIigUaNGjBkzBhcXF7Zt20ZUVNS9nIqF9PR0SktL8fPzo3nz5hQXF5OWlkZERAQJCQn07NnT5mPU2LFjB1OnTsXd3Z1Ro0bRqFEjtm3bRnR0NPn5+UyYMMFcNysri7NnzzJo0CA8PT0pLS0lIyODqVOnEh0dbXGTaGv/jB07lieeeIJly5YRGBhoPucmTZpgNBqJjIzkhx9+wNfXl1GjRpGXl8f69evZs2cPycnJNG/e3KK91atXU1paymuvvYa7u7t5+8KFC0lKSuKZZ54hLCwMOzs7MjMzee+995g2bRrDhw83t7F+/XrmzJlDs2bNGDJkCJ6enly4cIFvvvmGoqIic2Lx6aef0q1bN0aMGIGrqyunTp1i48aN7Nu3j5SUFHO97777jnfffZf27dsTHByMs7MzFy9eZO/evZw7dw4vLy/Gjh2LyWTi4MGDzJ492xxLjx49btt3s2fPZt68ebi5uTF27Fhz+Z2uZ1sVFxfj6OiIi4uLuezHH3/Ezs6Orl27WtRt0KABHTt25Mcff7xv8YiIiMgf1z0lFhUVFaxatcri8afMzEy2bNnC+++/z+uvv24uDwoKIjg4mL/97W/4+PhgMBjIysrCycmJ+Ph4i0edwsLCfvPY8+bNo7q6msTERHNCM2zYMMaNG3cvp2Jh+vTpVhNbhwwZwvDhw1m2bFm9JRZVVVXMnTuXhg0bsmLFCjw8PAAYPnw448ePZ8WKFQQEBNCmTRsAxo0bR2RkpEUbQUFBjBw5ksTERIvEwtb+efrpp3FwcGDZsmX06NEDPz8/87bPPvuMH374gdGjRzNx4kRzeb9+/Zg0aRKxsbF88MEHFu1duHCBdevW0bRpU3PZ8ePHSUpKIjg42CKBCgoKYvLkycTFxeHv74+TkxNFRUV8/PHHeHt7k5SUZHEDHR4ebjFfICUlxer78/HxISIigrS0NN58800AsrOzqa6uJi4uziKut956y6Iftm7dysGDBy364E78/PyIj4+nadOmd72PLXbu3MnRo0fx8/OjQYMG5vKayd2PPPKI1T7NmjXj0KFDVFZW4ujoeN9jFBERkT+Oe5q8PXToUKs5FZs3b8bJyYkBAwZQUlJi/isrK+O5556joKCAvLw8AJydnamoqGDnzp2YTKa7Pu6lS5c4dOgQzz//vPmmGcDR0dHqsY97cfNN6bVr1ygpKcHe3p5u3bpx9OhRm9uvcezYMS5cuMCrr75qTirgxnmMGTOG6upqsrOza42roqKCkpISKioq6NOnD2fOnKGsrAy4//2TmZmJnZ0dwcHBFuX9+/enY8eO7Nixw2pisL+/v8XNO8CWLVswGAz4+/tbXCslJSX4+Phw9epVDh8+DMCXX35JZWUlISEhFklFjZp5BfCvfqqurqasrIySkhI6duyIs7MzR44cMddzdnYG4Ouvv8ZoNNrQI3VTc03d/Gc0GjEajVbl165du2NbeXl5REVF0axZM9555x2LbRUVFbdNGmqSjYqKivo5KREREZH/v3sasaj5Jf1mZ8+e5erVq7z44ou33e/SpUt4eXkRHBzMgQMHmDJlCq6urvTq1Ytnn32WF154AScnp9vun5+fD4C3t7fVtnbt2tX9RG5x/vx54uLi2L17N1euXLHYZjAYbG6/RkFBAVB7zO3btwf+da5wo9/i4+PJzs7m0qVLVvuUlZXh7Ox83/unoKAADw8PGjduXGvcubm5lJSUWCQStV0rZ86cwWQyMXTo0Nseq2YC+blz5wDo1KnTb8a3b98+lixZwtGjR7l+/brFtpu/z+HDh5Odnc2cOXP45JNPeOKJJ3jmmWcYPHjwfX1sae7cuWRkZNS67dZ5Ja+88gozZ86stW5+fj7h4eEALFiwwCrmRx99lMuXL9e67z//+U9zHREREZH6dE+JRW03JSaTiSZNmhAdHX3b/Wpumtu0aUNqaip79+5l3759HDhwgOjoaBYtWsSSJUto1arVvYRl5U7JQFVVlcXna9euERISQnl5OW+88QYdOnTAyckJg8HA8uXL2bdvX73EVFcmk4nIyEjOnDlDUFAQXbp0wdnZGTs7O9LT09m6devvevnQ293AGgwGFixYYDHicLOaa+VuHT16lMjISFq1akVkZCQtW7akQYMGGAwG3n//fYs+cnNzIzk5mYMHD7Jnzx4OHjzIvHnzWLRoETExMXecR2GLMWPG8PLLL1uUzZ8/H4BJkyZZlN88knWzgoICwsLCKC8vZ+HChXTo0MGqjoeHB2fOnOGf//yn1eNQxcXFuLm56TEoERERqXf1tpZr69atycvLo3v37ne1nOgjjzxC//796d+/P3DjefFJkybx97//nb/85S+17lOzss7Zs2ettp0+fdqqrOaX9V9//dVqW0FBgcX8jr179/Lzzz8zY8YMXn31VYu68fHxv3k+dfHYY48BtcdcU1ZT58SJE+Tm5hISEmL1oraNGzdafK5r/9TVY489xrfffsuVK1esHks6ffo0Tk5O5gnSd9K6dWv+8Y9/0KJFC9q2bXvHujUjHrm5uRaPd91q69atVFVVsWDBAnPfAZSXl1uNPsGNJVx79+5tXr3pxIkTjBo1isTERGJiYoB7G6W60z7t2rWzGjmq6cd+/fr9ZtsFBQWMHz+esrIyFi5cSOfOnWut16VLF3bv3s3Ro0ct5gVdv36d3NxcevXqdTenIiIiIlIn9faCPH9/f6qrq4mNja11e82jLQAlJSVW22tukkpLS297jJolabOzs/npp5/M5ZWVlaxatcqqfs1N6d69ey3Kt27dys8//2xRZm9vD2A152P37t0Wz+fXh86dO9OiRQvS09O5ePGiudxoNLJy5UoMBoN5Ba2aX/RvjevkyZNkZWVZlNW1f+pqwIABVFdXs3z5covyXbt2kZOTg4+Pz21HIG5WM7E5Li7OauQILK8VX19fHB0dWbJkiXkuyc1q+uV2319SUpLViE5t15+3tzePPvqoRRJaM2fjTtfkrRo2bFhrImurwsJCwsLCuHLlCrGxsfzXf/3Xbeu++OKLGAwGq+/8s88+o6KiQkvNioiIyH1RbyMWgwYNIiAggLVr13L8+HGee+453NzcKC4u5tChQ5w/f560tDQAJkyYgIuLCz179qR58+ZcuXKF9PR0DAbDb66m88477zB+/HjGjRvHsGHDzMup1naD6u3tTd++fdmwYQMmk4mOHTuSm5tLVlYWrVu3tpi4++STT+Lu7s78+fMpLCykWbNm5ObmsnnzZjp06MDJkyfrq6uwt7dn2rRpTJ06lTfffJPAwEAaNWrE9u3bOXz4MMHBweakqG3btrRr147k5GQqKirw8vIiLy+PDRs20KFDB44dO3bP/VNXAQEBZGRksGLFCgoKCujVqxfnzp1j3bp1uLu7W6zwdCddu3YlNDSUxYsXM3LkSAYNGoSHhwcXL17k2LFj7Nq1i927dwPQvHlzJk+ezIcffkhQUBD+/v54enpSXFxMdnY2M2bMoFOnTgwYMIBVq1YxceJEAgMDcXR0ZM+ePZw8edJqFCU6Opri4mL69euHp6cn169fZ/v27Vy9ehV/f39zve7du7N27VrmzJlD//79cXBwoFu3bhYjIrfq3r07aWlpxMfH07ZtWwwGAz4+PlarVdXF1atXCQsLo6CggBEjRvDTTz9ZJI5wY8TD3d0dgA4dOjBs2DDWrl3L1KlTefbZZzlz5gwpKSn06tVLiYWIiIjcF/X6WuuoqCh69+7NZ599xvLly6msrMTd3Z3OnTtb3HQOHTqU7du3s2HDBkpLS3F1daVTp05MmzbN6kV2t+rRowdxcXHExsayYsUKnJ2dzS+ACwoKsqo/e/ZsPvroI7Zu3crmzZvp2bMnCQkJ/PWvf6WwsNBcz8XFhdjYWBYsWMCaNWuoqqqic+fOxMTEkJaWVq+JBdxYBnXhwoUkJiaycuVKKisr8fb2Zvr06RYvyLO3tycmJob58+eTkZFBeXk57du3Z+bMmeTm5lolFnXtn7pwcHAgNjbW/IK8zMxMXFxc8PX1JSIighYtWtx1W6GhoXTp0oWUlBRWr15NeXk5TZs2pX379kyZMsWi7tChQ2nVqhXJycmkpKRQWVmJh4cHffr0Mb8X48knn2Tu3LksXbqUhIQEGjRoQN++fVm8eDEhISEW7fn5+ZGens6mTZu4fPkyTk5OtGvXjg8//BBfX19zvcGDB5OTk8O2bdv46quvqK6uJioq6o6JRUREBKWlpaSmpnLlyhVMJhOff/65TYlFaWmpeWL+mjVraq2TkJBgTiwAJk+eTMuWLdmwYQM7d+7Ezc2NESNGmN8ZIiIiIlLfDKa6rPcqIn84ho8f3JK8IiJ/dKYp9fqbr8gDpZ8uRURERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZlosWUTuaFHjJIKDg3F0dHzYoYiIiMjvmEYsRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZkosRERERETEZgaTyWR62EGIyO+X4WPjww5BROQ/nmmKw8MOQcRmGrEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGbKbEQERERERGb/a4Ti5kzZ9K7d++7qltQUEDv3r1ZtGjRfY7qhrrEFhoaSkBAwH2O6M7q2j85OTmEh4czcODAB9qvIiIiIvLvSW9jEStGo5Fp06ZhNBoJCwvDxcWFxx9//GGH9cBlZWWRk5PD+PHj73qfVatW4eLiUu+J5JEjR9iyZQvHjh3jxIkTlJeXExUVVetxDh8+zMqVK8nNzeXSpUsAtGjRgkGDBjFy5EicnZ3rNTYRERER+J2PWEyfPp1du3Y97DD+cPLz88nPz+eNN95gxIgR+Pn5/WETiyVLltRpn9WrV5Oenl7vsezatYvU1FTKysp+87v46aefqKio4OWXX2bixIm8/fbbdO3alaSkJMaNG0dFRUW9xyciIiJi84hFVVUVlZWVPProo/URjwUHBwccHDSo8qD98ssvALi6utZruyaTifLycho1alSv7f47Cw0NBWDx4sV3rDd06FDGjBlDw4YN+fLLLzl06NBt677yyiu88sorVvu3bduWBQsW8M033/DCCy/YHryIiIjITep0156ens6sWbOIi4vj8OHDpKenc+HCBaZPn05AQAAmk4n169ezceNGzpw5g52dHV26dCEkJMRqPkJGRgZr164lLy8Po9GIu7s73bt3Z/LkyTRp0gS4MY8hIyOD/fv3W+z7/fffs2DBAnJycnBycsLX15chQ4bcNt6EhASr44eGhlJYWGjx6/Lu3btJS0vjxx9/5OLFizg6OtK1a1fGjh3LU089VZeuuisHDhxg6dKlHD16FKPRiLe3N8OGDeO1116zqHfkyBHWrVvHoUOHKCoqwt7eng4dOjB69GgGDhxo1e7d9k9tQkNDOXDgAACzZs1i1qxZAHz++ee0bNmS8vJyEhMT2b59O8XFxTRu3Jh+/foRHh6Op6enuZ39+/cTFhZGVFQU5eXlpKamcv78ef785z+bHy3atm0ba9as4cSJE1RVVZnPadCgQVZx7d+/n5UrV3LkyBHKy8vx8PDgqaee4u2338bNzQ2A1NRUsrKyOH36NJcvX8bV1ZW+ffsSHh5Oy5YtLdrbuXMnycnJnDp1ioqKCtzc3OjSpQuRkZF4eXlZ9MPN187tHj+6uV5hYaHFPjV9Zwt3d3eb9gfM38+vv/5qc1siIiIit7qn4YCYmBiMRiOBgYE4OTnh5eUFwIwZM/jiiy/w9fUlICCAyspKtmzZwoQJE5g7dy7PP/88AJs2bWLmzJn07NmTsLAwGjRoQFFREbt27eLSpUvmxKI2R44cISIigkaNGjFmzBhcXFzYtm0bUVFR93IqFtLT0yktLcXPz4/mzZtTXFxMWloaERERJCQk0LNnT5uPUWPHjh1MnToVd3d3Ro0aRaNGjdi2bRvR0dHk5+czYcIEc92srCzOnj3LoEGD8PT0pLS0lIyMDKZOnUp0dDQvvfSSua6t/TN27FieeOIJli1bRmBgoPmcmzRpgtFoJDIykh9++AFfX19GjRpFXl4e69evZ8+ePSQnJ9O8eXOL9lavXk1paSmvvfYa7u7u5u0LFy4kKSmJZ555hrCwMOzs7MjMzOS9995j2rRpDB8+3NzG+vXrmTNnDs2aNWPIkCF4enpy4cIFvvnmG4qKisyJxaeffkq3bt0YMWIErq6unDp1io0bN7Jv3z5SUlLM9b777jveffdd2rdvT3BwMM7Ozly8eJG9e/dy7tw5vLy8GDt2LCaTiYMHDzJ79mxzLD169Lht382ePZt58+bh5ubG2LFjzeV3up7vp4qKCvPfsWPH+OSTT3B0dKRfv34PJR4RERH5z3ZPiUVFRQWrVq2yePwpMzOTLVu28P777/P666+by4OCgggODuZvf/sbPj4+GAwGsrKycHJyIj4+3uJRp7CwsN889rx586iuriYxMdGc0AwbNoxx48bdy6lYmD59Og0bNrQoGzJkCMOHD2fZsmX1llhUVVUxd+5cGjZsyIoVK/Dw8ABg+PDhjB8/nhUrVhAQEECbNm0AGDduHJGRkRZtBAUFMXLkSBITEy0SC1v75+mnn8bBwYFly5bRo0cP/Pz8zNs+++wzfvjhB0aPHs3EiRPN5f369WPSpEnExsbywQcfWLR34cIF1q1bR9OmTc1lx48fJykpieDgYIsEKigoiMmTJxMXF4e/vz9OTk4UFRXx8ccf4+3tTVJSEi4uLub64eHhVFdXmz+npKRYfX8+Pj5ERESQlpbGm2++CUB2djbV1dXExcVZxPXWW29Z9MPWrVs5ePCgRR/ciZ+fH/Hx8TRt2vSu97mfEhIS+PTTT82f27Vrx//+7//SqlWrhxiViIiI/Ke6p8nbQ4cOtZpTsXnzZpycnBgwYAAlJSXmv7KyMp577jkKCgrIy8sDwNnZmYqKCnbu3InJZLrr4166dIlDhw7x/PPPm2+aARwdHRk5cuS9nIqFm29Kr127RklJCfb29nTr1o2jR4/a3H6NY8eOceHCBV599VVzUgE3zmPMmDFUV1eTnZ1da1wVFRWUlJRQUVFBnz59OHPmDGVlZcD975/MzEzs7OwIDg62KO/fvz8dO3Zkx44dFjf6AP7+/hY37wBbtmzBYDDg7+9vca2UlJTg4+PD1atXOXz4MABffvkllZWVhISEWCQVNezs/nUJ1/RTdXU1ZWVllJSU0LFjR5ydnTly5Ii5Xs2qSF9//TVGo9GGHqmbmmvq5j+j0YjRaLQqv3btms3He/3114mLi2POnDn8P//P/8MjjzxCSUmJ7SciIiIiUot7GrGo+SX9ZmfPnuXq1au8+OKLt93v0qVLeHl5ERwczIEDB5gyZQqurq706tWLZ599lhdeeAEnJ6fb7p+fnw+At7e31bZ27drV/URucf78eeLi4ti9ezdXrlyx2GYwGGxuv0ZBQQFQe8zt27cH/nWucKPf4uPjyc7ONi8ferOysjKcnZ3ve/8UFBTg4eFB48aNa407NzeXkpISi0SitmvlzJkzmEwmhg4dettj1UwgP3fuHACdOnX6zfj27dvHkiVLOHr0KNevX7fYdvP3OXz4cLKzs5kzZw6ffPIJTzzxBM888wyDBw++r48tzZ07l4yMjFq33Tqv5JVXXmHmzJk2Ha9Nmzbm/h80aBDffvst//M//wNgMcolIiIiUh/uKbGobQUok8lEkyZNiI6Ovu1+NTfNbdq0ITU1lb1797Jv3z4OHDhAdHQ0ixYtYsmSJfX2qMadkoGqqiqLz9euXSMkJITy8nLeeOMNOnTogJOTEwaDgeXLl7Nv3756iamuTCYTkZGRnDlzhqCgILp06YKzszN2dnakp6ezdetWq1GC35PbrRZmMBhYsGCBxYjDzWqulbt19OhRIiMjadWqFZGRkbRs2ZIGDRpgMBh4//33LfrIzc2N5ORkDh48yJ49ezh48CDz5s1j0aJFxMTE3HEehS3GjBnDyy+/bFE2f/58ACZNmmRRfvNIVn35P//n/+Du7s66deuUWIiIiEi9q7e1XFu3bk1eXh7du3e/q+VEH3nkEfr370///v2BG6v0TJo0ib///e/85S9/qXWfmpV1zp49a7Xt9OnTVmU1v6zXtgpOQUGBxfyOvXv38vPPPzNjxgxeffVVi7rx8fG/eT518dhjjwG1x1xTVlPnxIkT5ObmEhISYvWito0bN1p8rmv/1NVjjz3Gt99+y5UrV6weSzp9+jROTk7mCdJ30rp1a/7xj3/QokUL2rZte8e6Nb+45+bmWjzedautW7dSVVXFggULzH0HUF5ebjX6BGBvb0/v3r3NqzedOHGCUaNGkZiYSExMDHBvo1R32qddu3ZWI0c1/figJlRfv35dq0KJiIjIfVFvL8jz9/enurqa2NjYWrfXPNoC1Pqcd+fOnQEoLS297TFqlqTNzs7mp59+MpdXVlayatUqq/o1N6V79+61KN+6dSs///yzRZm9vT2A1ZyP3bt3WzyfXx86d+5MixYtSE9P5+LFi+Zyo9HIypUrMRgM5hW0an7RvzWukydPkpWVZVFW1/6pqwEDBlBdXc3y5cstynft2kVOTg4+Pj63HYG4Wc3E5ri4OKuRI7C8Vnx9fXF0dGTJkiXmuSQ3q+mX231/SUlJViM6tV1/3t7ePProoxY33TVzNu50Td6qYcOGD/3G/eZr6mYZGRmUlZXRrVu3BxyRiIiI/BHU24jFoEGDCAgIYO3atRw/fpznnnsONzc3iouLOXToEOfPnyctLQ2ACRMm4OLiQs+ePWnevDlXrlwhPT0dg8Hwm6vpvPPOO4wfP55x48YxbNgw83Kqtd2gent707dvXzZs2IDJZKJjx47k5uaSlZVF69atLSbuPvnkk7i7uzN//nwKCwtp1qwZubm5bN68mQ4dOnDy5Mn66irs7e2ZNm0aU6dO5c033yQwMJBGjRqxfft2Dh8+THBwsDkpatu2Le3atSM5OZmKigq8vLzIy8tjw4YNdOjQgWPHjt1z/9RVQEAAGRkZrFixgoKCAnr16sW5c+dYt24d7u7uFis83UnXrl0JDQ1l8eLFjBw5kkGDBuHh4cHFixc5duwYu3btYvfu3QA0b96cyZMn8+GHHxIUFIS/vz+enp4UFxeTnZ3NjBkz6NSpEwMGDGDVqlVMnDiRwMBAHB0d2bNnDydPnrQaRYmOjqa4uJh+/frh6enJ9evX2b59O1evXsXf399cr3v37qxdu5Y5c+bQv39/HBwc6Natm8WIyK26d+9OWloa8fHxtG3bFoPBgI+Pj9VqVXVVWFjIpk2bgH+NPu3YsYOioiIAc78ATJw4EVdXV3r06EGLFi0oKyvj+++/Jzs7m+bNm5tfyiciIiJSn+r1tdZRUVH07t2bzz77jOXLl1NZWYm7uzudO3e2uOkcOnQo27dvZ8OGDZSWluLq6kqnTp2YNm2a1YvsbtWjRw/i4uKIjY1lxYoVODs7m18AFxQUZFV/9uzZfPTRR2zdupXNmzfTs2dPEhIS+Otf/0phYaG5nouLC7GxsSxYsIA1a9ZQVVVF586diYmJIS0trV4TC7ixDOrChQtJTExk5cqVVFZW4u3tzfTp0y1ekGdvb09MTAzz588nIyOD8vJy2rdvz8yZM8nNzbVKLOraP3Xh4OBAbGys+QV5mZmZuLi44OvrS0REBC1atLjrtkJDQ+nSpQspKSmsXr2a8vJymjZtSvv27ZkyZYpF3aFDh9KqVSuSk5NJSUmhsrISDw8P+vTpY34vxpNPPsncuXNZunQpCQkJNGjQgL59+7J48WJCQkIs2vPz8yM9PZ1NmzZx+fJlnJycaNeuHR9++CG+vr7meoMHDyYnJ4dt27bx1VdfUV1dTVRU1B0Ti4iICEpLS0lNTeXKlSuYTCY+//xzmxOL/Px8EhISLMoyMzPJzMw0n39NYhEYGMjXX3/Nxo0bKSkpwcHBgVatWvHmm28yatSou3pcTURERKSuDKa6rPcqIn84ho8f3JK8IiJ/VKYp9fpbr8hDUW9zLERERERE5I9LiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMa5uJyB0tapxEcHAwjo6ODzsUERER+R3TiIWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNhMiYWIiIiIiNjMYDKZTA87CBH5/TJ8bHzYIYiI/NszTXF42CGI3HcasRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZspsRAREREREZv9RyUWM2fOpHfv3ndVt6CggN69e7No0aL7HNUNdYktNDSUgICA+xzRndW1f3JycggPD2fgwIEPtF9FRERE5PdBiyqLzYxGI9OmTcNoNBIWFoaLiwuPP/74ww7rgcvKyiInJ4fx48ff9T6rVq3CxcWl3hPJI0eOsGXLFo4dO8aJEycoLy8nKirqoSesIiIi8p/rP2rEYvr06ezatethh/GHk5+fT35+Pm+88QYjRozAz8/vD5tYLFmypE77rF69mvT09HqPZdeuXaSmplJWVvaH/C5ERETkwXvgIxZVVVVUVlby6KOP1nvbDg4OODhoEOZB++WXXwBwdXWt13ZNJhPl5eU0atSoXtv9dxYaGgrA4sWL71hv6NChjBkzhoYNG/Lll19y6NChBxGeiIiI/IHd17vw9PR0Zs2aRVxcHIcPHyY9PZ0LFy4wffp0AgICMJlMrF+/no0bN3LmzBns7Ozo0qULISEhVvMRMjIyWLt2LXl5eRiNRtzd3enevTuTJ0+mSZMmwI15DBkZGezfv99i3++//54FCxaQk5ODk5MTvr6+DBky5LbxJiQkWB0/NDSUwsJCi1+Xd+/eTVpaGj/++CMXL17E0dGRrl27MnbsWJ566qn66kazAwcOsHTpUo4ePYrRaMTb25thw4bx2muvWdQ7cuQI69at49ChQxQVFWFvb0+HDh0YPXo0AwcOtGr3bvunNqGhoRw4cACAWbNmMWvWLAA+//xzWrZsSXl5OYmJiWzfvp3i4mIaN25Mv379CA8Px9PT09zO/v37CQsLIyoqivLyclJTUzl//jx//vOfzY8Wbdu2jTVr1nDixAmqqqrM5zRo0CCruPbv38/KlSs5cuQI5eXleHh48NRTT/H222/j5uYGQGpqKllZWZw+fZrLly/j6upK3759CQ8Pp2XLlhbt7dy5k+TkZE6dOkVFRQVubm506dKFyMhIvLy8LPrh5mvnTo8f1dQrLCy02Kem72zh7u5u0/4iIiIidfVAft6PiYnBaDQSGBiIk5MTXl5eAMyYMYMvvvgCX19fAgICqKysZMuWLUyYMIG5c+fy/PPPA7Bp0yZmzpxJz549CQsLo0GDBhQVFbFr1y4uXbpkTixqc+TIESIiImjUqBFjxozBxcWFbdu2ERUVZfN5paenU1paip+fH82bN6e4uJi0tDQiIiJISEigZ8+eNh+jxo4dO5g6dSru7u6MGjWKRo0asW3bNqKjo8nPz2fChAnmullZWZw9e5ZBgwbh6elJaWkpGRkZTJ06lejoaF566SVzXVv7Z+zYsTzxxBMsW7aMwMBA8zk3adIEo9FIZGQkP/zwA76+vowaNYq8vDzWr1/Pnj17SE5Opnnz5hbtrV69mtLSUl577TXc3d3N2xcuXEhSUhLPPPMMYWFh2NnZkZmZyXvvvce0adMYPny4uY3169czZ84cmjVrxpAhQ/D09OTChQt88803FBUVmROLTz/9lG7dujFixAhcXV05deoUGzduZN++faSkpJjrfffdd7z77ru0b9+e4OBgnJ2duXjxInv37uXcuXN4eXkxduxYTCYTBw8eZPbs2eZYevTocdu+mz17NvPmzcPNzY2xY8eay+90PYuIiIj8Xj2QxKKiooJVq1ZZPP6UmZnJli1beP/993n99dfN5UFBQQQHB/O3v/0NHx8fDAYDWVlZODk5ER8fb/GoU1hY2G8ee968eVRXV5OYmGhOaIYNG8a4ceNsPq/p06fTsGFDi7IhQ4YwfPhwli1bVm+JRVVVFXPnzqVhw4asWLECDw8PAIYPH8748eNZsWIFAQEBtGnTBoBx48YRGRlp0UZQUBAjR44kMTHRIrGwtX+efvppHBwcWLZsGT169MDPz8+87bPPPuOHH35g9OjRTJw40Vzer18/Jk2aRGxsLB988IFFexcuXGDdunU0bdrUXHb8+HGSkpIIDg62SKCCgoKYPHkycXFx+Pv74+TkRFFRER9//DHe3t4kJSXh4uJirh8eHk51dbX5c0pKitX35+PjQ0REBGlpabz55psAZGdnU11dTVxcnEVcb731lkU/bN26lYMHD1r0wZ34+fkRHx9P06ZN73ofERERkd+rBzJ5e+jQoVZzKjZv3oyTkxMDBgygpKTE/FdWVsZzzz1HQUEBeXl5ADg7O1NRUcHOnTsxmUx3fdxLly5x6NAhnn/+efNNM4CjoyMjR460+bxuvim9du0aJSUl2Nvb061bN44ePWpz+zWOHTvGhQsXePXVV81JBdw4jzFjxlBdXU12dnatcVVUVFBSUkJFRQV9+vThzJkzlJWVAfe/fzIzM7GzsyM4ONiivH///nTs2JEdO3ZY3OgD+Pv7W9y8A2zZsgWDwYC/v7/FtVJSUoKPjw9Xr17l8OH/X3t3HpdT+v8P/HVXKuquyI1CRYmxL5ExpkHZCh9GY5mxxYiMJcv4zOJjn5kYY4QGRcgW2RJqbMloDNmXsY00khai1a3cdX5/+N3n23HfpbojM17Px8Nj6jrXuc51rvt0z3mfazlXAABHjhzB8+fPMXbsWElQoaan93+XvLqdCgsLkZOTg4yMDDg6OsLU1BRXr14V85mamgIAjh07BpVKpUOLlI36mir6T6VSQaVSaaQ/ffr0jdWLiIiISJs30mOhfpJeVEJCAnJzc9GjR49i93v8+DFsbW3h5eWF8+fPY8aMGTA3N0fbtm3xwQcfoHv37jAxMSl2/6SkJACAnZ2dxraGDRuW/URecv/+fQQEBOCPP/5Adna2ZJtMJtO5fLUHDx4A0F5ne3t7AP93rsCLdlu1ahViYmLw+PFjjX1ycnJgamr62tvnwYMHUCgUMDMz01rvW7duISMjQxJIaLtW7t69C0EQ4OnpWeyx1BPIExMTAQCNGzd+Zf3i4uIQFBSEa9euH13YaAAAaWJJREFUIS8vT7Kt6Oc5aNAgxMTEwM/PDytWrECrVq3QqVMn9OzZ87UOW1q8eDH279+vddvL80r69OmDuXPnvra6EBEREb3KGwkstK0AJQgCqlevjoULFxa7n/qm2cbGBmFhYThz5gzi4uJw/vx5LFy4EGvWrEFQUBDq1atXIfUsKRgoKCiQ/P706VOMHTsWSqUSQ4cOhYODA0xMTCCTybBhwwbExcVVSJ3KShAETJw4EXfv3sWQIUPQtGlTmJqaQk9PDxEREYiKitLoJXibFLdamEwmw/LlyyU9DkWpr5XSunbtGiZOnIh69eph4sSJsLa2hpGREWQyGb755htJG1lYWCAkJAQXLlzA6dOnceHCBSxduhRr1qyBv79/ifModDFixAj07t1bkrZs2TIAgK+vryS9aE8WERERUWWotLVZ69evj3v37qFFixalWk7U0NAQnTt3RufOnQG8WKXH19cXW7ZswX//+1+t+6hX1klISNDYFh8fr5GmfrKelZWlse3BgweS+R1nzpzBw4cPMXv2bPTr10+Sd9WqVa88n7KoW7cuAO11Vqep89y+fRu3bt3C2LFjNV7UtnfvXsnvZW2fsqpbty5OnTqF7OxsjWFJ8fHxMDExESdIl6R+/fr4/fffUadOHTRo0KDEvOoej1u3bkmGd70sKioKBQUFWL58udh2AKBUKjV6nwBAX18fTk5O4upNt2/fxrBhw7Bu3Tr4+/sDKF8vVUn7NGzYUKPnSN2Ozs7OZT4WERER0etUaS/I8/DwQGFhIVauXKl1u3poCwBkZGRobG/SpAkAIDMzs9hjqJekjYmJwd9//y2mP3/+HFu3btXIr74pPXPmjCQ9KioKDx8+lKTp6+sDgMacjz/++EMyPr8iNGnSBHXq1EFERAQePXokpqtUKmzatAkymUxcQUv9RP/lev311184fvy4JK2s7VNWXbp0QWFhITZs2CBJj42Nxc2bN+Hi4lJsD0RR6onNAQEBGj1HgPRacXV1RZUqVRAUFCTOJSlK3S7FfX7BwcEaPTrarj87OzsYGxtLglD1nI2SrsmXVa1aVWsgS0RERPRPU2k9Fm5ubujbty927NiBGzdu4MMPP4SFhQXS0tJw+fJl3L9/H+Hh4QCAL774AnK5HG3atEHt2rWRnZ2NiIgIyGSyV66mM3XqVIwbNw5jxozBJ598Ii6nqu0G1c7ODh06dMDu3bshCAIcHR1x69YtHD9+HPXr15dM3G3dujUsLS2xbNkyJCcno1atWrh16xYOHjwIBwcH/PXXXxXWVvr6+pg5cya+/PJLjBw5EgMGDEC1atVw+PBhXLlyBV5eXmJQ1KBBAzRs2BAhISF49uwZbG1tce/ePezevRsODg64fv16udunrPr27Yv9+/dj48aNePDgAdq2bYvExETs3LkTlpaWkhWeStKsWTN4e3sjMDAQn376Kdzc3KBQKPDo0SNcv34dsbGx+OOPPwAAtWvXxvTp07Fo0SIMGTIEHh4esLKyQlpaGmJiYjB79mw0btwYXbp0wdatWzFlyhQMGDAAVapUwenTp/HXX39p9KIsXLgQaWlpcHZ2hpWVFfLy8nD48GHk5ubCw8NDzNeiRQvs2LEDfn5+6Ny5MwwMDNC8eXNJj8jLWrRogfDwcKxatQoNGjSATCaDi4uLxmpVZZWcnIwDBw4A+L/epxMnTiA1NRUAxHYhIiIiqiiV+prqOXPmwMnJCXv27MGGDRvw/PlzWFpaokmTJpKbTk9PTxw+fBi7d+9GZmYmzM3N0bhxY8ycOVPjRXYva9myJQICArBy5Ups3LgRpqam4gvghgwZopF//vz5+PHHHxEVFYWDBw+iTZs2WL16NX744QckJyeL+eRyOVauXInly5dj+/btKCgoQJMmTeDv74/w8PAKDSyAF8ug/vLLL1i3bh02bdqE58+fw87ODrNmzZK8IE9fXx/+/v5YtmwZ9u/fD6VSCXt7e8ydOxe3bt3SCCzK2j5lYWBggJUrV4ovyIuOjoZcLoerqysmTJiAOnXqlLosb29vNG3aFKGhodi2bRuUSiVq1KgBe3t7zJgxQ5LX09MT9erVQ0hICEJDQ/H8+XMoFAq0b99efC9G69atsXjxYqxduxarV6+GkZEROnTogMDAQIwdO1ZSnru7OyIiInDgwAE8efIEJiYmaNiwIRYtWgRXV1cxX8+ePXHz5k0cOnQIR48eRWFhIebMmVNiYDFhwgRkZmYiLCwM2dnZEAQB+/bt0zmwSEpKwurVqyVp0dHRiI6OFs+fgQURERFVJJlQlvVbieidI1vy5pbYJSL6txJmVOqzXKI3otLmWBARERER0b8HAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZF1UmohKtMQuGl5cXqlSpUtlVISIiorcYeyyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnDCyIiIiIiEhnMkEQhMquBBG9vWRLVJVdBSKifyRhhkFlV4HojWKPBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBxVvo7NmzcHJyQkRERKXV4ebNm/Dx8UHXrl3h5OSENWvWVFpdiIiIiOjtxze3kAaVSoWZM2dCpVJh/PjxkMvlaNSoUWVX6407fvw4bt68iXHjxpV6n61bt0Iul6Nv374VWperV68iMjIS169fx+3bt6FUKjFnzhytx7lx4waioqIQFxeHBw8eAADq16+Pvn37YsCAATAw4J89ERERVTzeYbyF2rZti9jY2Eq7AUxKSkJSUhJ8fX0xePDgSqnD2+D48ePYv39/mQKLbdu2wcrKqsIDi9jYWISFhcHOzg6NGjXC5cuXi827ceNGnDlzBl26dMGAAQNQUFCAkydPYtGiRYiJicGKFSsgk8kqtH5EREREDCzeIrm5uTAxMYGenh6MjIwqrR7p6ekAAHNz8wotVxAEKJVKVKtWrULL/Sfz9vYGAAQGBpaYz9PTEyNGjEDVqlVx5MiREgOLwYMHY+7cuZJraPDgwfjf//6HyMhInDx5Eh9++GHFnAARERHR/8fAooJERERg3rx5CAgIwMWLFxEREYH09HTY2trCy8sLPXv2lOTv27cvrKysMG3aNKxcuRJXrlyBubk59u3bh7Nnz2L8+PEaQ10EQcDevXuxd+9exMfHAwCsra3RtWtXjB8/XsyXn5+PzZs3IyoqCvfv34ehoSHatGmDcePGoUmTJiWeh7e3N86fPw8AmDdvHubNmwcA2LdvH6ytraFUKrFu3TocPnwYaWlpMDMzg7OzM3x8fGBlZSWWU/QclEolwsLCcP/+fYwaNUrsATh06BC2b9+O27dvo6CgAA4ODhg+fDjc3Nw06nX27Fls2rQJV69ehVKphEKhQLt27TB58mRYWFgAAMLCwnD8+HHEx8fjyZMnMDc3R4cOHeDj4wNra2tJeSdPnkRISAju3LmDZ8+ewcLCAk2bNsXEiRNha2sraQcnJydxv+KGHxXNl5ycLNlH3Xa6sLS0LHXe1q1ba03v3r07IiMjcefOHQYWREREVOEYWFSwFStWQKlUwtPTE8CLgOPbb79Ffn6+xg1pamoqfHx84Obmhm7duuHp06cllj179mxERkaiefPmGD16NORyORISEnD06FExsFCpVJg0aRIuX74Md3d3DBo0CDk5OdizZw/GjBmDoKAgNG3atNhjjB49Gq1atcL69esxYMAAtGnTBgBQvXp1qFQqTJw4EZcuXYKrqyuGDRuGe/fuYdeuXTh9+jRCQkJQu3ZtSXnbtm1DZmYm+vfvD0tLS3H7L7/8guDgYHTq1Anjx4+Hnp4eoqOj8dVXX2HmzJkYNGiQWMauXbvg5+eHWrVqYeDAgbCyskJKSgp+++03pKamioHF5s2b0bx5cwwePBjm5ua4c+cO9u7di7i4OISGhor5zp07h2nTpsHe3h5eXl4wNTXFo0ePcObMGSQmJsLW1hajR4+GIAi4cOEC5s+fL9alZcuWxbbd/PnzsXTpUlhYWGD06NFievXq1Uv8XN+UtLQ0AECNGjUquSZERET0b8TAooJlZGQgNDQUpqamAF4MYRkyZAh+/vlndO/eHcbGxmLepKQkzJo1C/37939luYcPH0ZkZCR69+6NefPmQU/v/xb0KiwsFH/evn07zp07hxUrVuD9998X0z09PTF48GAsW7asxGE3HTt2hIGBAdavX4+WLVvC3d1d3LZnzx5cunQJw4cPx5QpU8R0Z2dn+Pr6YuXKlViwYIGkvJSUFOzcuVNyM3vjxg0EBwfDy8sLX3zxhZg+ZMgQTJ8+HQEBAfDw8ICJiQlSU1OxZMkS2NnZITg4GHK5XMzv4+MjOffQ0FBUrVpVcnwXFxdMmDAB4eHhGDlyJAAgJiYGhYWFCAgIkNTr888/l7RDVFQULly4IGmDkri7u2PVqlWoUaNGqfd5U54+fYpNmzbB1NQUH330UWVXh4iIiP6FuNxsBfP09BSDCgAwNTXFwIEDkZWVhXPnzknympubl3qSb2RkJADA19dXElQAkPweGRkJOzs7vPfee8jIyBD/qVQqODs749KlS3j27Fm5zi06Ohp6enrw8vKSpHfu3BmOjo44ceKE5EYfADw8PDSekEdGRkImk8HDw0NSx4yMDLi4uCA3NxdXrlwBABw5cgTPnz/H2LFjJUGFtnNXBxWFhYXIyclBRkYGHB0dYWpqiqtXr4r51J/PsWPHoFKpytUW5fH06VON81WpVFCpVBrpr+q9KouCggL873//Q1JSEr766qsKnztDREREBLDHosLZ2dlppDVo0ADAix6KourWrQt9ff1SlZuYmIiaNWu+cqz93bt3kZeXp3WeglpGRgbq1KlTquMW9eDBAygUCpiZmWlss7e3x61bt5CRkSEJJGxsbLTWURAEcbiYNuoJ5ImJiQCAxo0bv7J+cXFxCAoKwrVr15CXlyfZlp2dLf48aNAgxMTEwM/PDytWrECrVq3QqVMn9OzZ87UOW1q8eDH279+vddvLn1efPn0wd+5cnY9ZWFiI+fPnIyYmBhMmTECvXr10LpOIiIhIGwYWlajosKiK5ODggKlTpxa7/U2O+S/uHGUyGZYvX67R+6Jmb29fpuNcu3YNEydORL169TBx4kRYW1vDyMgIMpkM33zzjaQnxcLCAiEhIbhw4QJOnz6NCxcuYOnSpVizZg38/f1LnEehixEjRqB3796StGXLlgF40RNVlEKh0Pl4hYWFWLBgAQ4cOICxY8dK5n0QERERVTQGFhUsISFBI+3u3bsAXvRQlJeNjQ1iYmKQnp5eYq9F/fr18eTJE7Rv377Ym/byqlu3Lk6dOoXs7GyNYUnx8fEwMTERJ0iXpH79+vj9999Rp04dsTenOOoej1u3bsHW1rbYfFFRUSgoKMDy5csl7axUKiW9FWr6+vpwcnISV2+6ffs2hg0bhnXr1sHf3x8AyvWuh5L2adiwIRo2bChJU7ejs7NzmY9VEnVQERERgTFjxpTpXRxERERE5cE5FhVs586dyMnJEX/PycnBrl27IJfL0a5du3KXq37SvXz5co15DIIgiD97eHggPT0dW7Zs0VqOeohReXTp0gWFhYXYsGGDJD02NhY3b96Ei4tLqYIZ9cTmgIAAFBQUlFhHV1dXVKlSBUFBQZJ2VVOfu3pIWdG2AIDg4GCN9srIyNAox87ODsbGxsjKyhLT1HM2MjMzX3lORfcpWkZlEAQBCxcuREREBLy8vODj41Op9SEiIqJ3A3ssKpiFhQVGjhwpTsqOiIhASkoKZs2apdPQJzc3N3Tv3h0HDhxAYmIiXFxcIJfLce/ePZw6dQo7duwAAAwdOhSnT5+Gv78/4uLi0L59e5iYmCAlJQVxcXEwNDTEmjVrylWHvn37Yv/+/di4cSMePHiAtm3bIjExETt37oSlpaVkhaeSNGvWDN7e3ggMDMSnn34KNzc3KBQKPHr0CNevX0dsbCz++OMPAEDt2rUxffp0LFq0CEOGDIGHhwesrKyQlpaGmJgYzJ49G40bN0aXLl2wdetWTJkyBQMGDECVKlVw+vRp/PXXXxq9KAsXLkRaWhqcnZ1hZWWFvLw8HD58GLm5ufDw8BDztWjRAjt27ICfnx86d+4MAwMDNG/evMSepxYtWiA8PByrVq1CgwYNIJPJ4OLiorFaVVklJyfjwIEDACC+w+TEiRNITU0FALFdAMDf3x/79u2Do6MjGjRogIMHD0rKqlev3msb7kVERETvLgYWFWzSpEm4ePEiwsLC8PjxY9jY2GDhwoUVMmn2u+++Q5s2bRAeHo6goCDo6+vD2tpaMvHXwMAAy5Ytw86dO3Hw4EExiFAoFGjWrBn69OlT7uMbGBhg5cqV4gvyoqOjIZfL4erqigkTJpRpQri3tzeaNm2K0NBQbNu2DUqlEjVq1IC9vT1mzJghyevp6Yl69eohJCQEoaGheP78ORQKBdq3by++F6N169ZYvHgx1q5di9WrV8PIyAgdOnRAYGAgxo4dKynP3d0dEREROHDgAJ48eQITExM0bNgQixYtgqurq5ivZ8+euHnzJg4dOoSjR4+isLAQc+bMKTGwmDBhAjIzMxEWFobs7GwIgoB9+/bpHFgkJSVh9erVkrTo6GhER0eL568OLP78808AL4aPzZ49W6OsPn36MLAgIiKiCicTXh47QuWifvP26tWrJW9dJvqnky15c0vyEhH9mwgz+PyW3i2cY0FERERERDpjYEFERERERDpjYEFERERERDrjHAsiKhHnWBARlQ/nWNC7hj0WRERERESkMwYWRERERESkM/bREVGJ1pgFw8vLC1WqVKnsqhAREdFbjD0WRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkMwYWRERERESkM5kgCEJlV4KI3l6yJarKrgIR0VtJmGFQ2VUgequwx4KIiIiIiHTGwIKIiIiIiHTGwIKIiIiIiHTGwIKIiIiIiHTGwIKIiIiIiHTGwIKIiIiIiHTGwOItdPbsWTg5OSEiIqLS6nDz5k34+Piga9eucHJywpo1ayqtLkRERET09uMCzKRBpVJh5syZUKlUGD9+PORyORo1alTZ1Xrjjh8/jps3b2LcuHGl3mfr1q2Qy+Xo27dvhdbl6tWriIyMxPXr13H79m0olUrMmTNH63GePn2KzZs34/r167h58ybS0tLQtm1bBAYGVmidiIiIiIpij8VbqG3btoiNjYW7u3ulHD8pKQlJSUkYOnQoBg8eDHd393c2sAgKCirTPtu2bXstPU2xsbEICwtDTk7OKz+LjIwMBAYG4s8//0SjRo2gr69f4fUhIiIiehl7LN4iubm5MDExgZ6eHoyMjCqtHunp6QAAc3PzCi1XEAQolUpUq1atQsv9J/P29gaAV/YmeHp6YsSIEahatSqOHDmCy5cvF5u3Zs2aOHDgAGrXrg0A+PDDDyuuwkRERETFYGBRQSIiIjBv3jwEBATg4sWLiIiIQHp6OmxtbeHl5YWePXtK8vft2xdWVlaYNm0aVq5ciStXrsDc3Bz79u3D2bNnMX78eI2hLoIgYO/evdi7dy/i4+MBANbW1ujatSvGjx8v5svPz8fmzZsRFRWF+/fvw9DQEG3atMG4cePQpEmTEs/D29sb58+fBwDMmzcP8+bNAwDs27cP1tbWUCqVWLduHQ4fPoy0tDSYmZnB2dkZPj4+sLKyEsspeg5KpRJhYWG4f/8+Ro0aJQ4tOnToELZv347bt2+joKAADg4OGD58ONzc3DTqdfbsWWzatAlXr16FUqmEQqFAu3btMHnyZFhYWAAAwsLCcPz4ccTHx+PJkycwNzdHhw4d4OPjA2tra0l5J0+eREhICO7cuYNnz57BwsICTZs2xcSJE2FraytpBycnJ3G/4oYfFc2XnJws2UfddrqwtLQsdV5DQ0MxqCAiIiJ6UxhYVLAVK1ZAqVTC09MTwIuA49tvv0V+fr7GDWlqaip8fHzg5uaGbt264enTpyWWPXv2bERGRqJ58+YYPXo05HI5EhIScPToUTGwUKlUmDRpEi5fvgx3d3cMGjQIOTk52LNnD8aMGYOgoCA0bdq02GOMHj0arVq1wvr16zFgwAC0adMGAFC9enWoVCpMnDgRly5dgqurK4YNG4Z79+5h165dOH36NEJCQjRuaLdt24bMzEz0798flpaW4vZffvkFwcHB6NSpE8aPHw89PT1ER0fjq6++wsyZMzFo0CCxjF27dsHPzw+1atXCwIEDYWVlhZSUFPz2229ITU0VA4vNmzejefPmGDx4MMzNzXHnzh3s3bsXcXFxCA0NFfOdO3cO06ZNg729Pby8vGBqaopHjx7hzJkzSExMhK2tLUaPHg1BEHDhwgXMnz9frEvLli2Lbbv58+dj6dKlsLCwwOjRo8X06tWrl/i5EhEREf0bMLCoYBkZGQgNDYWpqSmAF0NYhgwZgp9//hndu3eHsbGxmDcpKQmzZs1C//79X1nu4cOHERkZid69e2PevHnQ0/u/6TGFhYXiz9u3b8e5c+ewYsUKvP/++2K6p6cnBg8ejGXLlpU47KZjx44wMDDA+vXr0bJlS8k8jz179uDSpUsYPnw4pkyZIqY7OzvD19cXK1euxIIFCyTlpaSkYOfOnahRo4aYduPGDQQHB8PLywtffPGFmD5kyBBMnz4dAQEB8PDwgImJCVJTU7FkyRLY2dkhODgYcrlczO/j4yM599DQUFStWlVyfBcXF0yYMAHh4eEYOXIkACAmJgaFhYUICAiQ1Ovzzz+XtENUVBQuXLhQ6rku7u7uWLVqFWrUqFFp82OIiIiIKgsnb1cwT09PMagAAFNTUwwcOBBZWVk4d+6cJK+5uXmpVw+KjIwEAPj6+kqCCgCS3yMjI2FnZ4f33nsPGRkZ4j+VSgVnZ2dcunQJz549K9e5RUdHQ09PD15eXpL0zp07w9HRESdOnJDc6AOAh4eH5OZdXUeZTAYPDw9JHTMyMuDi4oLc3FxcuXIFAHDkyBE8f/4cY8eOlQQV2s5dHVQUFhYiJycHGRkZcHR0hKmpKa5evSrmU38+x44dg0qlKldblMfTp081zlelUkGlUmmkv6r3ioiIiOhtwx6LCmZnZ6eR1qBBAwAveiiKqlu3bqlX7ElMTETNmjVfOdb+7t27yMvL0zpPQS0jIwN16tQp1XGLevDgARQKBczMzDS22dvb49atW8jIyJAEEjY2NlrrKAiCOFxMG/UE8sTERABA48aNX1m/uLg4BAUF4dq1a8jLy5Nsy87OFn8eNGgQYmJi4OfnhxUrVqBVq1bo1KkTevbs+VqHLS1evBj79+/Xuu3lz6tPnz6YO3fua6sLERERUUVjYFGJig6LqkgODg6YOnVqsdvf5Jj/4s5RJpNh+fLlGr0vavb29mU6zrVr1zBx4kTUq1cPEydOhLW1NYyMjCCTyfDNN99IelIsLCwQEhKCCxcu4PTp07hw4QKWLl2KNWvWwN/fv8R5FLoYMWIEevfuLUlbtmwZgBc9UUUpFIrXUgciIiKi14WBRQVLSEjQSLt79y6AFz0U5WVjY4OYmBikp6eX2GtRv359PHnyBO3bty/2pr286tati1OnTiE7O1tjWFJ8fDxMTEzECdIlqV+/Pn7//XfUqVNH7M0pjrrH49atW7C1tS02X1RUFAoKCrB8+XJJOyuVSklvhZq+vj6cnJzE1Ztu376NYcOGYd26dfD39wfwIvgpq5L2adiwIRo2bChJU7ejs7NzmY9FRERE9DbhHIsKtnPnTuTk5Ii/5+TkYNeuXZDL5WjXrl25y1U/6V6+fLnGPAZBEMSfPTw8kJ6eji1btmgtRz3EqDy6dOmCwsJCbNiwQZIeGxuLmzdvwsXFpVTBjHpic0BAAAoKCkqso6urK6pUqYKgoCBJu6qpz109pKxoWwBAcHCwRntlZGRolGNnZwdjY2NkZWWJaeo5G5mZma88p6L7FC2DiIiI6F3BHosKZmFhgZEjR4qTsiMiIpCSkoJZs2bpNPTJzc0N3bt3x4EDB5CYmAgXFxfI5XLcu3cPp06dwo4dOwAAQ4cOxenTp+Hv74+4uDi0b98eJiYmSElJQVxcHAwNDbFmzZpy1aFv377Yv38/Nm7ciAcPHqBt27ZITEzEzp07YWlpKVnhqSTNmjWDt7c3AgMD8emnn8LNzQ0KhQKPHj3C9evXERsbiz/++AMAULt2bUyfPh2LFi3CkCFD4OHhASsrK6SlpSEmJgazZ89G48aN0aVLF2zduhVTpkzBgAEDUKVKFZw+fRp//fWXRi/KwoULkZaWBmdnZ1hZWSEvLw+HDx9Gbm4uPDw8xHwtWrTAjh074Ofnh86dO8PAwADNmzcvseepRYsWCA8Px6pVq9CgQQPIZDK4uLhorFZVVsnJyThw4AAAiO8wOXHiBFJTUwFAbBe17du3iz01KpUKKSkpWLt2LQDA0dERLi4uOtWHiIiI6GUMLCrYpEmTcPHiRYSFheHx48ewsbHBwoUL0atXL53L/u6779CmTRuEh4cjKCgI+vr6sLa2lkz8NTAwwLJly7Bz504cPHhQDCIUCgWaNWuGPn36lPv4BgYGWLlypfiCvOjoaMjlcri6umLChAllmhDu7e2Npk2bIjQ0FNu2bYNSqUSNGjVgb2+PGTNmSPJ6enqiXr16CAkJQWhoKJ4/fw6FQoH27duL78Vo3bo1Fi9ejLVr12L16tUwMjJChw4dEBgYiLFjx0rKc3d3R0REBA4cOIAnT57AxMQEDRs2xKJFi+Dq6irm69mzJ27evIlDhw7h6NGjKCwsxJw5c0oMLCZMmIDMzEyEhYUhOzsbgiBg3759OgcWSUlJWL16tSQtOjoa0dHR4vkXDSw2b96M5ORk8fcHDx6I+/fp04eBBREREVU4mfDy2BEqF/Wbt1evXi156zLRP51syZtbkpeI6J9EmMHns0RFcY4FERERERHpjIEFERERERHpjIEFERERERHpjHMsiKhEnGNBRKQd51gQSbHHgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbBgURUojVmwfDy8kKVKlUquypERET0FmOPBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6YyBBRERERER6UwmCIJQ2ZUgoreXbImqsqtARFRmwgyDyq4C0TuHPRZERERERKQzBhZERERERKQzBhZERERERKQzBhZERERERKQzBhZERERERKQzBhZERERERKQzBhZERERERKQzBhZvobNnz8LJyQkRERGVVoebN2/Cx8cHXbt2hZOTE9asWVNpdSEiIiKitx/fHkMaVCoVZs6cCZVKhfHjx0Mul6NRo0aVXa037vjx47h58ybGjRtX6n22bt0KuVyOvn37Vmhdrl69isjISFy/fh23b9+GUqnEnDlzij1Ofn4+goODcfDgQTx8+BC1atVC3759MWrUKBgY8M+eiIiIKh7vMN5Cbdu2RWxsbKXdACYlJSEpKQm+vr4YPHhwpdThbXD8+HHs37+/TIHFtm3bYGVlVeGBRWxsLMLCwmBnZ4dGjRrh8uXLJeb/+uuvERMTg379+qFly5a4fPkyVq9ejfv372Pu3LkVWjciIiIigIHFWyU3NxcmJibQ09ODkZFRpdUjPT0dAGBubl6h5QqCAKVSiWrVqlVouf9k3t7eAIDAwMAS83l6emLEiBGoWrUqjhw5UmJgcfLkScTExOCzzz7D1KlTAQD9+/eHXC7Hli1bMGDAALRq1ariToKIiIgIDCwqTEREBObNm4eAgABcvHgRERERSE9Ph62tLby8vNCzZ09J/r59+8LKygrTpk3DypUrceXKFZibm2Pfvn04e/Ysxo8frzHURRAE7N27F3v37kV8fDwAwNraGl27dsX48ePFfPn5+di8eTOioqJw//59GBoaok2bNhg3bhyaNGlS4nl4e3vj/PnzAIB58+Zh3rx5AIB9+/bB2toaSqUS69atw+HDh5GWlgYzMzM4OzvDx8cHVlZWYjlFz0GpVCIsLAz379/HqFGjxB6AQ4cOYfv27bh9+zYKCgrg4OCA4cOHw83NTaNeZ8+exaZNm3D16lUolUooFAq0a9cOkydPhoWFBQAgLCwMx48fR3x8PJ48eQJzc3N06NABPj4+sLa2lpR38uRJhISE4M6dO3j27BksLCzQtGlTTJw4Eba2tpJ2cHJyEvcrafiROl9ycrJkH3Xb6cLS0rLUeX/99VcAwNChQyXpQ4cOxZYtWxAZGcnAgoiIiCocA4sKtmLFCiiVSnh6egJ4EXB8++23yM/P17ghTU1NhY+PD9zc3NCtWzc8ffq0xLJnz56NyMhING/eHKNHj4ZcLkdCQgKOHj0qBhYqlQqTJk3C5cuX4e7ujkGDBiEnJwd79uzBmDFjEBQUhKZNmxZ7jNGjR6NVq1ZYv349BgwYgDZt2gAAqlevDpVKhYkTJ+LSpUtwdXXFsGHDcO/ePezatQunT59GSEgIateuLSlv27ZtyMzMRP/+/WFpaSlu/+WXXxAcHIxOnTph/Pjx0NPTQ3R0NL766ivMnDkTgwYNEsvYtWsX/Pz8UKtWLQwcOBBWVlZISUnBb7/9htTUVDGw2Lx5M5o3b47BgwfD3Nwcd+7cwd69exEXF4fQ0FAx37lz5zBt2jTY29vDy8sLpqamePToEc6cOYPExETY2tpi9OjREAQBFy5cwPz588W6tGzZsti2mz9/PpYuXQoLCwuMHj1aTK9evXqJn2tFu3btGmrVqoU6depI0uvUqQOFQoE///zzjdaHiIiI3g0MLCpYRkYGQkNDYWpqCuDFEJYhQ4bg559/Rvfu3WFsbCzmTUpKwqxZs9C/f/9Xlnv48GFERkaid+/emDdvHvT0/m9Br8LCQvHn7du349y5c1ixYgXef/99Md3T0xODBw/GsmXLShx207FjRxgYGGD9+vVo2bIl3N3dxW179uzBpUuXMHz4cEyZMkVMd3Z2hq+vL1auXIkFCxZIyktJScHOnTtRo0YNMe3GjRsIDg6Gl5cXvvjiCzF9yJAhmD59OgICAuDh4QETExOkpqZiyZIlsLOzQ3BwMORyuZjfx8dHcu6hoaGoWrWq5PguLi6YMGECwsPDMXLkSABATEwMCgsLERAQIKnX559/LmmHqKgoXLhwQdIGJXF3d8eqVatQo0aNUu/zOjx69AgNGjTQuk2hUCAtLe0N14iIiIjeBVxutoJ5enqKQQUAmJqaYuDAgcjKysK5c+ckec3NzUs9yTcyMhIA4OvrKwkqAEh+j4yMhJ2dHd577z1kZGSI/1QqFZydnXHp0iU8e/asXOcWHR0NPT09eHl5SdI7d+4MR0dHnDhxQnKjDwAeHh6Sm3d1HWUyGTw8PCR1zMjIgIuLC3Jzc3HlyhUAwJEjR/D8+XOMHTtWElRoO3d1UFFYWIicnBxkZGTA0dERpqamuHr1qphP/fkcO3YMKpWqXG1RHk+fPtU4X5VKBZVKpZH+qt6rkjx79gyGhoZatxkZGZX78yciIiIqCXssKpidnZ1GmvrpcVJSkiS9bt260NfXL1W5iYmJqFmz5ivH2t+9exd5eXla5ymoZWRkaAyTKY0HDx5AoVDAzMxMY5u9vT1u3bqFjIwMSSBhY2OjtY6CIIjDxbRRTyBPTEwEADRu3PiV9YuLi0NQUBCuXbuGvLw8ybbs7Gzx50GDBiEmJgZ+fn5YsWIFWrVqhU6dOqFnz56vddjS4sWLsX//fq3bXv68+vTpU+7Vm4yNjZGfn691W15enqTXjIiIiKiiMLCoRK/rBs/BwUFcDUibNznmv7hzlMlkWL58uUbvi5q9vX2ZjnPt2jVMnDgR9erVw8SJE2FtbQ0jIyPIZDJ88803kp4UCwsLhISE4MKFCzh9+jQuXLiApUuXYs2aNfD39y9xHoUuRowYgd69e0vSli1bBuBFT1RRCoWi3MepWbMmHj58qHWb+p0WRERERBWNgUUFS0hI0Ei7e/cugBc9FOVlY2ODmJgYpKenl9hrUb9+fTx58gTt27cv9qa9vOrWrYtTp04hOztbY1hSfHw8TExMxAnSJalfvz5+//131KlTp9i5AGrqHo9bt27B1ta22HxRUVEoKCjA8uXLJe2sVColvRVq+vr6cHJyEldvun37NoYNG4Z169bB398fwIvgp6xK2qdhw4Zo2LChJE3djs7OzmU+VnGaNWuGyMhIpKSkSHqmUlJS8PDhQ7i4uFTYsYiIiIjUOMeigu3cuRM5OTni7zk5Odi1axfkcjnatWtX7nLVT7qXL1+uMY9BEATxZw8PD6Snp2PLli1ay1EPMSqPLl26oLCwEBs2bJCkx8bG4ubNm3BxcSlVMKOe2BwQEICCgoIS6+jq6ooqVaogKChI0q5q6nNXDykr2hYAEBwcrNFeGRkZGuXY2dnB2NgYWVlZYpp6zkZmZuYrz6noPkXLqAzqpY23bdsmSVf//nKvCREREVFFYI9FBbOwsMDIkSPFSdkRERFISUnBrFmzdBr65Obmhu7du+PAgQNITEyEi4sL5HI57t27h1OnTmHHjh0AXryr4PTp0/D390dcXBzat28PExMTpKSkIC4uDoaGhlizZk256tC3b1/s378fGzduxIMHD9C2bVskJiZi586dsLS0lKzwVJJmzZrB29sbgYGB+PTTT+Hm5gaFQoFHjx7h+vXriI2NxR9//AEAqF27NqZPn45FixZhyJAh8PDwgJWVFdLS0hATE4PZs2ejcePG6NKlC7Zu3YopU6ZgwIABqFKlCk6fPo2//vpLoxdl4cKFSEtLg7OzM6ysrJCXl4fDhw8jNzcXHh4eYr4WLVpgx44d8PPzQ+fOnWFgYIDmzZuX2PPUokULhIeHY9WqVWjQoAFkMhlcXFw0Vqsqq+TkZBw4cAAAxHeYnDhxAqmpqQAgtgvwYjL9hx9+iC1btiAnJwctWrTAlStXEB4ejt69e6N169Y61YWIiIhIGwYWFWzSpEm4ePEiwsLC8PjxY9jY2GDhwoXo1auXzmV/9913aNOmDcLDwxEUFAR9fX1YW1tLJv4aGBhg2bJl2LlzJw4ePCgGEQqFAs2aNUOfPn3KfXwDAwOsXLlSfEFedHQ05HI5XF1dMWHChDJNCPf29kbTpk0RGhqKbdu2QalUokaNGrC3t8eMGTMkeT09PVGvXj2EhIQgNDQUz58/h0KhQPv27cX3YrRu3RqLFy/G2rVrsXr1ahgZGaFDhw4IDAzE2LFjJeW5u7sjIiICBw4cwJMnT2BiYoKGDRti0aJFcHV1FfP17NkTN2/exKFDh3D06FEUFhZizpw5JQYWEyZMQGZmJsLCwpCdnQ1BELBv3z6dA4ukpCSsXr1akhYdHY3o6Gjx/Iu+oNDPzw/r1q1DZGQkDh48iFq1amH8+PEYNWqUTvUgIiIiKo5MeHnsCJWL+s3bq1evlrx1meifTrbkzS3JS0RUUYQZfHZK9KZxjgUREREREemMgQUREREREemMgQUREREREemMcyyIqEScY0FE/0ScY0H05rHHgoiIiIiIdMbAgoiIiIiIdMZ+QiIq0RqzYHh5eaFKlSqVXRUiIiJ6i7HHgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdMbAgoiIiIiIdCYTBEGo7EoQ0dtLtkRV2VUgIioTYYZBZVeB6J3EHgsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZAwsiIiIiItIZA4u30NmzZ+Hk5ISIiIhKq8PNmzfh4+ODrl27wsnJCWvWrKm0uhARERHR248LPZMGlUqFmTNnQqVSYfz48ZDL5WjUqFFlV+uNO378OG7evIlx48aVep+tW7dCLpejb9++FVqXq1evIjIyEtevX8ft27ehVCoxZ86cEo+TmpqKtWvX4vfff8fjx49hZmaGxo0bw9fXFw0bNqzQ+hERERExsHgLtW3bFrGxsTAwqJyPJykpCUlJSfD19cXgwYMrpQ5vg+PHj2P//v1lCiy2bdsGKyurCg8sYmNjERYWBjs7OzRq1AiXL18uMf+NGzfwxRdfoFq1aujXrx/q1KmDrKws/Pnnn3jy5EmF1o2IiIgIYGDxVsnNzYWJiQn09PRgZGRUafVIT08HAJibm1douYIgQKlUolq1ahVa7j+Zt7c3ACAwMLDEfJ6enhgxYgSqVq2KI0eOlBhY5OXl4euvv0bt2rURGBgIU1PTCq0zERERkTYMLCpIREQE5s2bh4CAAFy8eBERERFIT0+Hra0tvLy80LNnT0n+vn37wsrKCtOmTcPKlStx5coVmJubY9++fTh79izGjx+vMdRFEATs3bsXe/fuRXx8PADA2toaXbt2xfjx48V8+fn52Lx5M6KionD//n0YGhqiTZs2GDduHJo0aVLieXh7e+P8+fMAgHnz5mHevHkAgH379sHa2hpKpRLr1q3D4cOHkZaWBjMzMzg7O8PHxwdWVlZiOUXPQalUIiwsDPfv38eoUaPEHoBDhw5h+/btuH37NgoKCuDg4IDhw4fDzc1No15nz57Fpk2bcPXqVSiVSigUCrRr1w6TJ0+GhYUFACAsLAzHjx9HfHw8njx5AnNzc3To0AE+Pj6wtraWlHfy5EmEhITgzp07ePbsGSwsLNC0aVNMnDgRtra2knZwcnIS9ytp+JE6X3JysmQfddvpwtLSstR5Dx8+jMTERCxduhSmpqbIz88HABgaGupUByIiIqKSMLCoYCtWrIBSqYSnpyeAFwHHt99+i/z8fI0b0tTUVPj4+MDNzQ3dunXD06dPSyx79uzZiIyMRPPmzTF69GjI5XIkJCTg6NGjYmChUqkwadIkXL58Ge7u7hg0aBBycnKwZ88ejBkzBkFBQWjatGmxxxg9ejRatWqF9evXY8CAAWjTpg0AoHr16lCpVJg4cSIuXboEV1dXDBs2DPfu3cOuXbtw+vRphISEoHbt2pLytm3bhszMTPTv3x+Wlpbi9l9++QXBwcHo1KkTxo8fDz09PURHR+Orr77CzJkzMWjQILGMXbt2wc/PD7Vq1cLAgQNhZWWFlJQU/Pbbb0hNTRUDi82bN6N58+YYPHgwzM3NcefOHezduxdxcXEIDQ0V8507dw7Tpk2Dvb09vLy8YGpqikePHuHMmTNITEyEra0tRo8eDUEQcOHCBcyfP1+sS8uWLYttu/nz52Pp0qWwsLDA6NGjxfTq1auX+LlWtNjYWACAXC7H2LFjcfHiRQiCAEdHR0yaNAnvv//+G60PERERvRsYWFSwjIwMhIaGisNPPD09MWTIEPz888/o3r07jI2NxbxJSUmYNWsW+vfv/8pyDx8+jMjISPTu3Rvz5s2Dnt7/LehVWFgo/rx9+3acO3cOK1askNxAenp6YvDgwVi2bFmJw246duwIAwMDrF+/Hi1btoS7u7u4bc+ePbh06RKGDx+OKVOmiOnOzs7w9fXFypUrsWDBAkl5KSkp2LlzJ2rUqCGm3bhxA8HBwfDy8sIXX3whpg8ZMgTTp09HQEAAPDw8YGJigtTUVCxZsgR2dnYIDg6GXC4X8/v4+EjOPTQ0FFWrVpUc38XFBRMmTEB4eDhGjhwJAIiJiUFhYSECAgIk9fr8888l7RAVFYULFy5I2qAk7u7uWLVqFWrUqFHqfV6Hv//+GwAwc+ZMNG/eHN9//z0yMzOxfv16TJkyBStWrICzs3Ol1Y+IiIj+nbjcbAXz9PSUjGk3NTXFwIEDkZWVhXPnzknympubl3qSb2RkJADA19dXElQAkPweGRkJOzs7vPfee8jIyBD/qVQqODs749KlS3j27Fm5zi06Ohp6enrw8vKSpHfu3BmOjo44ceKE5EYfADw8PCQ37+o6ymQyeHh4SOqYkZEBFxcX5Obm4sqVKwCAI0eO4Pnz5xg7dqwkqNB27uqgorCwEDk5OcjIyICjoyNMTU1x9epVMZ/68zl27BhUKlW52qI8nj59qnG+KpUKKpVKI/1VvVevOg4A2NnZYenSpejevTs8PT2xatUqyGQy/PLLLxV1SkREREQi9lhUMDs7O420Bg0aAHjRQ1FU3bp1oa+vX6pyExMTUbNmzVeOtb979y7y8vK0zlNQy8jIQJ06dUp13KIePHgAhUIBMzMzjW329va4desWMjIyJIGEjY2N1joKgiAOF9NGPYE8MTERANC4ceNX1i8uLg5BQUG4du0a8vLyJNuys7PFnwcNGoSYmBj4+flhxYoVaNWqFTp16oSePXu+1mFLixcvxv79+7Vue/nz6tOnD+bOnVuu46gn/nt4eEAmk4npNjY2aNWqFS5cuAClUqnRu0NERESkCwYWlajosKiK5ODggKlTpxa7/U2O+S/uHGUyGZYvX67R+6Jmb29fpuNcu3YNEydORL169TBx4kRYW1vDyMgIMpkM33zzjaQnxcLCAiEhIbhw4QJOnz6NCxcuYOnSpVizZg38/f1LnEehixEjRqB3796StGXLlgF40RNVlEKhKPdxateujTt37mgNQi0tLSEIAnJychhYEBERUYViYFHBEhISNNLu3r0L4EUPRXnZ2NggJiYG6enpJfZa1K9fH0+ePEH79u2LvWkvr7p16+LUqVPIzs7WGJYUHx8PExMTcYJ0SerXr4/ff/8dderUEXtziqPu8bh16xZsbW2LzRcVFYWCggIsX75c0s5KpVLSW6Gmr68PJycncfWm27dvY9iwYVi3bh38/f0BQPK0v7RK2qdhw4YaL6ZTt2NFznlo1qwZfv/9d6SmpmpsS0tLg76+vtZeJyIiIiJdcI5FBdu5cydycnLE33NycrBr1y7I5XK0a9eu3OWqn3QvX75cYx6DIAjizx4eHkhPT8eWLVu0lqMeYlQeXbp0QWFhITZs2CBJj42Nxc2bN+Hi4lKqYEY9sTkgIAAFBQUl1tHV1RVVqlRBUFCQpF3V1OeuHlJWtC0AIDg4WKO9MjIyNMqxs7ODsbExsrKyxDT1E/3MzMxXnlPRfYqWURl69uwJfX19hIeHS+aQ3Lp1C1euXIGTk1OlvieFiIiI/p3YY1HBLCwsMHLkSHFSdkREBFJSUjBr1iydhj65ubmhe/fuOHDgABITE+Hi4gK5XI579+7h1KlT2LFjBwBg6NChOH36NPz9/REXF4f27dvDxMQEKSkpiIuLg6GhIdasWVOuOvTt2xf79+/Hxo0b8eDBA7Rt2xaJiYnYuXMnLC0tJSs8laRZs2bw9vZGYGAgPv30U7i5uUGhUODRo0e4fv06YmNj8ccffwB4Maxn+vTpWLRoEYYMGQIPDw9YWVkhLS0NMTExmD17Nho3bowuXbpg69atmDJlCgYMGIAqVarg9OnT+OuvvzR6URYuXIi0tDQ4OzvDysoKeXl5OHz4MHJzc+Hh4SHma9GiBXbs2AE/Pz907twZBgYGaN68eYk9Ty1atEB4eDhWrVqFBg0aQCaTwcXFRedhR8nJyThw4AAAiO8wOXHihNgroW4X4EWQNGLECKxfvx7e3t7o0aMHsrKysH37dhgbG2sMuyIiIiKqCAwsKtikSZNw8eJFhIWF4fHjx7CxscHChQvRq1cvncv+7rvv0KZNG4SHhyMoKAj6+vqwtraWTPw1MDDAsmXLsHPnThw8eFAMIhQKBZo1a4Y+ffqU+/gGBgZYuXKl+IK86OhoyOVyuLq6YsKECWWaEO7t7Y2mTZsiNDQU27Ztg1KpRI0aNWBvb48ZM2ZI8np6eqJevXoICQlBaGgonj9/DoVCgfbt24vvxWjdujUWL16MtWvXYvXq1TAyMkKHDh0QGBiIsWPHSspzd3dHREQEDhw4gCdPnsDExAQNGzbEokWL4OrqKubr2bMnbt68iUOHDuHo0aMoLCzEnDlzSgwsJkyYgMzMTISFhSE7OxuCIGDfvn06BxZJSUlYvXq1JC06OhrR0dHi+Rd9QeEXX3wBKysrhIWFYfny5TAyMoKTkxPGjx9f5vkrRERERKUhE14eO0Llon7z9urVqyVvXSb6p5MteXNL8hIRVQRhBp+bElUGzrEgIiIiIiKdMbAgIiIiIiKdMbAgIiIiIiKdcY4FEZWIcyyI6J+GcyyIKgd7LIiIiIiISGcMLIiIiIiISGcMLIiIiIiISGcchEhEJVpjFgwvLy9UqVKlsqtCREREbzH2WBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4MKrsCRPT2EgQBSqUSWVlZqFKlSmVXh4iIiCqJXC6HTCYrMY9MEAThDdWHiP5hHj16BIVCUdnVICIiokqWmZkJMzOzEvOwx4KIimVkZITWrVvjwIEDMDU1rezqvFVycnLg4eHBttGCbaMd26V4bJvisW2Kx7bR7nW1i1wuf2UeBhZEVCyZTAZ9fX2YmZnxS/slenp6bJtisG20Y7sUj21TPLZN8dg22lVmu3DyNhERERER6YyBBRERERER6YyBBREVy9DQEGPHjoWhoWFlV+Wtw7YpHttGO7ZL8dg2xWPbFI9to11ltgtXhSIiIiIiIp2xx4KIiIiIiHTGwIKIiIiIiHTG5WaJ3lEJCQlYvHgxLl++DBMTE7i7u2PChAmvfMO2IAjYuHEjwsLCkJGRAUdHR0ybNg0tWrR4QzV//crbNn379kVycrJGemxsLIyMjF5Xdd+YxMREbNq0CVevXsWdO3dga2uLHTt2vHK/d+GaKW/b/NuvmSNHjuDgwYO4ceMGsrKyYGNjg8GDB6Nfv34lvsH3Xbhmyts2//ZrBgBOnjyJkJAQxMfHIzc3F7Vq1cJHH30Eb2/vVy6funfvXoSEhCAlJQW2traYMGECPvzwwzdU89ervO3i7e2N8+fPa6Tv3LkTdnZ2FVpHBhZE76CsrCyMHz8eNjY2+PHHH5GWloaff/4Zz549w3//+98S9924cSPWrFmDiRMnolGjRggLC8PEiROxZcsW1KtX7w2dweujS9sAgKurK4YNGyZJ+7dMLLxz5w5iY2PRrFkzFBYWorCwsFT7/duvGaD8bQP8u6+ZLVu2wMrKCr6+vqhevTpOnz6N7777DqmpqfD29i52v3fhmilv2wD/7msGePE93KxZMwwePBjm5ua4c+cOAgMDcefOHQQEBBS736+//orvvvsOo0ePRvv27XHo0CHMmDEDa9eu/VcEpeVtFwBo1aoVfH19JWlWVlYVX0mBiN45wcHBQufOnYWMjAwxbdeuXUKHDh2EtLS0Yvd79uyZ4OLiIqxcuVJMy8/PF/r06SP88MMPr7XOb0p520YQBKFPnz6Cn5/f665ipSkoKBB/njNnjvDJJ5+8cp934ZoRhPK1jSD8+6+ZJ0+eaKQtXLhQcHFxkbRZUe/KNVOethGEf/81U5zdu3cL7dq1K/F7eMCAAcI333wjSfPy8hImTZr0uqtXaUrTLmPHjhWmTJnyRurDORZE76Dff/8dHTp0gLm5uZjWvXt3FBYW4o8//ih2v8uXLyM3Nxdubm5iWpUqVdC1a1fExsa+1jq/KeVtm3eBnl7Z/5fxLlwzQPna5l1gYWGhkda4cWPk5uZCqVRq3edduWbK0zbvMvV38vPnz7Vuv3//Pu7du4fu3btL0nv06IG4uDjk5+e/9jpWhle1y5vGb0Kid1BCQoLGuEq5XI6aNWsiISGhxP0AaOzboEEDpKSk4NmzZxVb0UpQ3rZRi4qKwvvvv48PP/wQkydPxl9//fV6KvoP8S5cM7p6166ZixcvolatWjAxMdG6/V2+Zl7VNmrvyjVTUFCAvLw83LhxA2vXroWLiwusra215i3uurGzs8Pz58/x4MGD11zbN6cs7aJ2/vx5dO7cGZ06dSp2zkVF4BwLondQVlYW5HK5RrpcLkdWVlaJ+xkaGmpMEJTL5RAEAdnZ2TA2Nq7w+r5J5W0bAHBxcUHz5s1Rp04dJCUlITg4GGPGjPlXjQsvq3fhmtHFu3bNXLx4EYcOHdIY613Uu3rNlKZtgHfrmunbty/S0tIAAJ06dcJ3331XbN7s7GwA0JjEbGZmBgDIzMx8TbV888rSLgDQrl07eHh4wMbGBg8fPsTmzZsxYcIEBAYGomXLlhVaNwYWREQV5MsvvxR/btOmDTp27IiBAwdi8+bN+OqrryqxZvS2epeumdTUVHz99ddwcnLCkCFDKrs6b5WytM27dM34+/tDqVQiPj4e69atw9SpUxEQEAB9ff3KrlqlKmu7jBs3TvL7hx9+iEGDBmHt2rVYvnx5hdaNgQXRO8jMzAw5OTka6dnZ2eLTneL2y8/PR15enuRpYnZ2NmQymdYn/f805W0bbWrWrInWrVvj+vXrFVW9f5x34ZqpSP/WayY7OxuTJ0+Gubk5Fi9eXOKclHftmilL22jzb71mAKBRo0YAgJYtW6Jp06b49NNPER0dLZl/o6a+LnJyclCzZk0xXd3TXHTe3D9dWdpFm6pVq6Jz5844evRohdeNcyyI3kF2dnYa8wVycnLw6NGjEte0Vm/7+++/JekJCQmoU6fOv2J4QnnbhrR7F64ZKtmzZ8/g6+uLnJwcLF++/JXvIXiXrpmyts27rFGjRjAwMMD9+/e1bldfNy9/fyckJKBKlSqoW7fua65h5XhVu7xpDCyI3kGdOnXCmTNnxDGpwIuXNenp6aFjx47F7teyZUuYmJjgyJEjYppKpUJ0dDQ++OCD11rnN6W8baPNw4cPcfHiRTRt2rSiq/mP8S5cMxXp33bNqFQqfP3110hISMCKFStQq1atV+7zrlwz5Wkbbf5t10xxrl69CpVKVWyAUK9ePdjY2Gg8hT98+DDat2//yhec/lO9ql20USqV+O23317LNcOhUETvoIEDB2L79u2YPn06Ro8ejbS0NPj7++Pjjz+GQqEQ8/n4+CA5ORl79+4FABgZGcHLywuBgYGoXr06HBwcEBYWhszMTI2XNf1TlbdtoqKicPLkSXzwwQdQKBS4f/8+NmzYAH19/X9N2zx79gwnT54EACQnJyM3N1e8+WvXrh2qV6/+Tl4zQPna5l24ZhYtWoTffvsNvr6+yM3NxZUrV8RtjRs3hqGh4Tt7zZSnbd6FawZ4MY/kvffeQ6NGjWBkZIRbt25h06ZNaNSoEbp06QIAmD9/Pg4cOIDTp0+L+3l7e+N///sf6tWrh3bt2uHw4cO4evUqgoKCKulMKlZ52uXChQsICQlB165dYW1tLU7eTk9Ph5+fX4XXkYEF0TvIzMwMq1atwo8//ojp06fDxMQE/fv3x4QJEyT5CgoKUFBQIEkbOXIkBEHA5s2b8eTJEzg6OmLFihX/mtVIyts2devWxcOHD/HTTz8hOzsbcrkc7du3x7hx4/41XfCPHz/WmByq/n316tVwcnJ6J68ZoHxt8y5cM+p3vyxbtkxj2759+2Btbf3OXjPlaZt34ZoBgGbNmuHQoUPYuHEjCgsLYWVlhQEDBmDYsGFiz0NhYaHGddOrVy88e/YMGzduxIYNG2Bra4slS5ZU+MpHlaU87VKzZk2oVCoEBAQgMzMTVatWRcuWLfH111+jefPmFV5HmSAIQoWXSkRERERE7xTOsSAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCAiIiIiIp0xsCCiCpWWlgZzc3MEBQVJ0keNGgU7O7vKqdS/xNy5cyGTyZCQkPBGjrdhwwaN4ymVSlhbW2PevHllLq+4a4PKT/0ZHT9+vLKrQpVM1+8HXktvl/Pnz2Pq1Kno1asXnJycXuvnkpCQAGtrazg5OUn+DRw4sMxlMbAgogo1a9YsKBQKeHl5lSp/SkoKZsyYgebNm0Mul8PMzAyNGjXCkCFDsHv3bkneLl26wNTUtNiy1P9jPXv2rNbtT548QdWqVSGTybBp06Ziy7Gzs4NMJhP/GRoaws7ODp9//jkSExNLdV7/VlWrVsVXX32FH3/8EcnJyWXat6zXBr3bLl68iLlz576xQJoqX0JCAubOnYuLFy++0eO+jdeaUqlEo0aN8N///veNHVMulyMqKgpRUVHYsWMHGjduXOaAhoEFEVWY+/fvIzg4GJMmTYKBgcEr8//9999o1aoVAgIC0LFjR/j5+eGHH35Anz59cOPGDaxfv75C67dlyxbk5eWhQYMGCA4OLjFvvXr1sGnTJmzatAn+/v5wdnZGcHAwnJ2d8ejRowqt1z/NmDFjIJPJsHTp0lLvU9Zrg0pn+PDhUCqVcHFxqeyqVLiLFy9i3rx5b9XNHr1eCQkJmDdvXqUEFm/btfbBBx9gwoQJ6Nq1q9bt+fn5WLZsGXr37o3OnTtj5MiRxT5UexVbW1t8++23qFOnDmrWrImaNWtCT08PP/zwQ5kDC367E1GFWbNmDWQyGYYOHVqq/EuWLEFaWhr27t2L//znPxrbU1JSKrR+69atQ9euXfGf//wHvr6+iI+PR8OGDbXmNTc3x7Bhw8TffXx8UKtWLaxcuRLr16/Hl19+WaF1+ycxMTHBxx9/jA0bNmDhwoUwMjJ65T5lvTYqW0FBAfLy8lCtWrXKrkqJ9PX1oa+vX9nVIKI3bPHixYiPj8f3338PhUKB6OhoTJ48GaGhobCxsSlTWTKZDAYGBkhMTESvXr1gZGSEBg0aoEqVKmWuF3ssiCqRekzr0aNHMX/+fNja2qJq1apwdnbGH3/8AQCIiYlB586dYWJiAisrKyxYsEBrWWfPnsWAAQNQs2ZNGBkZoXHjxvjuu++gUqkk+c6cOYNRo0bB0dER1apVg1wuxwcffIA9e/ZolDlq1CjIZDJkZmaKN9bGxsb44IMPcPr0aY38YWFhcHJyQq1atUp1/rdv3wYAuLq6at1ep06dUpVTGufPn8fFixcxcuRIfPrppzAwMHhlr8XLevbsCQD466+/is0TGRkJmUyG5cuXa93+/vvvQ6FQ4Pnz5wDK9nloo/6MtJHJZBg1apRG+vbt29G5c2fI5XJUq1YNzs7O2LlzZ6mOp9a7d288evQI0dHRpcpf3LVRWFiI7777Di4uLqhTpw4MDQ1hY2MDHx8fpKeni/kyMjJgbGyMjz/+WGv5X3/9NWQymeRJZ2ZmJv773//CwcEBRkZGUCgUGDp0KOLj4yX7qv8Ojxw5ggULFsDe3h7GxsbYsWMHAODQoUMYPHgwGjZsiKpVq8LCwgI9evRATEyM1rrs2rULrVq1grGxMWxsbDBv3jwcOXIEMpkMGzZskOTNy8vD999/j2bNmsHY2BgWFhbo27cvLly4UKp21TYuvqK+V+zs7NClSxecP38e3bp1g6mpKWrUqIGRI0ciLS1Nkjc7OxuzZs2Cs7Oz+B3k4OCAr776Ck+fPtUoWxAEBAUFwdnZGaampjA1NUWLFi0we/ZsAC+GNaqHzHXt2lUclqjten7Z5cuXMWDAAFhaWsLY2BhNmzbF4sWLUVBQIMlX1u83bdTDL//880/4+vrCysoK1apVg6urK27evAkA2L17N9q2bYuqVavCzs4OgYGBWstau3atmM/c3Bw9evTAyZMnNfIVFhbihx9+QIMGDWBsbIzmzZtjy5YtxdYxOTkZPj4+sLGxgaGhIaytreHt7a3xGZZVadu5S5cuWufXJSQkQCaTYe7cuQBeXLfqp/NeXl7iZ96lSxcAwPHjx8W/oRUrVsDR0RHGxsZwdHTEihUrNMpXX78vK1oOUP5rTX39pKenY9SoUahZsybkcjn69+8vPhQLDAzEe++9B2NjYzRp0gTh4eEa5fzyyy/o0aMH6tatC0NDQ1hZWWHYsGFae08KCgqwYMECNGjQAHv27MHZs2dx69YtrF27FiNGjEDjxo0REREhqV9pru+EhATMnDkTTZs2xYoVK+Du7o6oqCg0btwYCxYsENtE/Tm+3IZFsceC6C3w1VdfoaCgAFOmTEF+fj5++ukn9OjRAyEhIRgzZgy8vb3x2WefYceOHZg9ezYaNGggeZp+4MABfPzxx3BwcMD06dNRo0YNnDp1CrNnz8bFixcRFhYm5t2zZw9u3LiBQYMGwdbWFunp6di4cSM+/vhjbNmyBZ9++qlG/Xr27AmFQoHZs2cjPT0dS5cuhYeHB+7evQu5XA4ASE1Nxc2bNzF58uRSn7e9vT0AICgoCL6+vsXeIL+suKFI2m5g1NatWwdTU1MMHDgQJiYm6NOnDzZu3Ij58+dDT690z1jUgVDNmjWLzdOjRw/UqVMHISEhGm1x+/Zt/PHHH5g8ebL4JKg8n4cuZs2ahe+++w69evXCggULoKenhz179uCTTz7BypUr8cUXX5SqnPfffx/Ai//B9OrVq8S8JV0b+fn5+PHHHzFw4ED85z//gYmJCeLi4rBu3TqcPHkS586dg6GhISwsLNCvXz+Eh4fj8ePHqFGjhlhGYWEhtmzZgpYtW6J169YAXgQVnTp1wr179zB69Gg0a9YMycnJ+OWXX+Ds7IyzZ8/C1tZWUpcZM2bg+fPnGDt2LMzMzNC4cWMAL254Hj9+jBEjRqBevXpISkrC2rVr4erqiujoaHz44YdiGdu3b8fQoUNhb2+POXPmwMDAABs3bhT/Z1/U8+fP0atXL/z+++8YPnw4Jk6ciMzMTAQFBeGDDz7AiRMn4OTkVKrPQxtdv1eAF0PYXF1dMXDgQHh6euL8+fMIDg7G2bNnERcXJ/boqNtk4MCBYuAeExODxYsX48KFC/j1118l5Q4fPhxbtmyBs7Mzvv32W1hYWODGjRvYuXMn5s+fj48//hjJyckIDAzEN998g/feew/A/31nFOfs2bP46KOPUKVKFXzxxReoU6cOIiIi8N///heXLl3SegNemu+3Vxk5ciRMTU3xzTff4OHDh/jpp5/Qs2dPLFiwADNnzoSPjw9Gjx6NdevWYdy4cWjatCk6d+4s7v/f//4XixcvRocOHfD9998jOzsbgYGB6Nq1K8LDw+Hu7i7mnTZtGvz9/eHi4oKpU6ciLS0NX3zxhdbe13v37uH9999Hfn4+xowZA3t7e/z1119YtWoVoqOjcfbsWZibm5fqHHVt51dxcXHBN998g++//x7e3t7i31Xt2rUl+VasWIGUlBSMGzcOcrkc27Ztw+TJk/H48WPMmTOnzMct77Wm1qtXL9SrVw/z58/HX3/9heXLl2PAgAH4+OOPERgYiDFjxsDY2BjLly+Hp6cnbt26hQYNGoj7L1myBB07dsTkyZNRo0YNXL16FWvXrsWxY8dw5coVWFpainknTpyI1atXo3PnzlAqlahatSoWLVoEPT09tG7dGn/++af4QC4vLw/t2rUTH9ypezHy8vLE7/mRI0di0qRJAICsrCxYW1ujUaNGMDMzQ2ZmJrZt2wZXV1eMGDECAEqc4ygSiKjSrF+/XgAgtGnTRsjLyxPTw8PDBQCCgYGBEBcXJ6bn5eUJderUETp27CimKZVKoXbt2sKHH34oPH/+XFL+0qVLBQBCdHS0mJaTk6NRj9zcXMHR0VF47733JOkjR44UAAg+Pj6S9B07dggAhNWrV4tpx44dEwAI/v7+Ws915MiRgq2trSTtzp07gpmZmQBAqF+/vvDpp58KP//8s3D27FmtZXz00UcCgFf+K9pm6jaysLAQRo4cKabt3btXACAcPHhQ4zi2trZCkyZNhIcPHwoPHz4U4uPjheDgYMHc3FwwMDAQrly5orV+ajNmzBAACNeuXZOkz5o1SwAgnDt3Tkwry+cxZ84cAYBw9+5dMU39GWkDQHLO586dEwAIX3/9tUbe//znP4JcLheysrLENPX1WfR4RRkYGAh9+vTRuq2okq6NwsJC4enTpxrpa9euFQAI27dvF9P2798vABACAgIkeY8cOSIAEH766ScxbfLkyYKxsbFw8eJFSd6EhARBLpdL2kV9no6OjkJubq5GXbR9RikpKYKlpaXQu3dvMe358+eCtbW1UKtWLeHx48dienZ2ttCgQQMBgLB+/XoxXf33GRUVJSk7MzNTqF+/vvDRRx9pHPdl6roX/RuviO8VQXjxdwBA+PnnnyXp6nr/8MMPkjLy8/M16qe+5k+fPi2mbd++XQAgDBs2TCgoKJDkL/q7tnN7lU6dOgn6+vrCpUuXxLTCwkLhk08+EQAIR44cEdPL8v1WHPXfZJ8+fYTCwkIx3d/fXwAgyOVy4d69e2J6WlqaYGRkJAwZMkRMu3HjhiCTyYQPPvhA8nklJSUJ5ubmgq2traBSqSR5u3XrJqYJwou/bZlMpvH32q9fP0GhUAiJiYmSesfFxQn6+vrCnDlzxLSytHdZ2vmjjz7S+O4XBEG4e/euAEBSh+joaI2/k5e3mZqaSs4nLy9PaN++vWBgYCBJt7W11fo3pO0Y5bnW1NfPhAkTJOlTp04V/5+WmZkppl+6dEkAIHz11VeS/Nq+X9TfaYsWLRIEQRDatWsnbNy4UQAg9OzZU4iKihI6dOgg3L17Vzh8+LBgbGwsGBkZCb///rvw8OFDQRAEYfjw4YKRkZEwatQo4e7du+K/VatWCUZGRoKfn5/4PaXts7h7967QpEkTYdCgQaVqQzUOhSJ6C/j4+MDQ0FD8Xf2kxtnZWfLE0tDQEB06dBCfnAPA4cOHkZqaCi8vL2RkZODRo0fiP/VTrkOHDon5TUxMxJ+fPn2K9PR0PH36FN26dcP169eRlZWlUb+pU6dKfu/WrRsASOrx8OFDAJA8SX6Vhg0b4tKlS+LTk61bt2Lq1KlwcnJCy5Ytce7cOY19jI2NcfjwYa3/hg8frvU4u3fvRkZGBkaOHCmmubu7Q6FQFDsc6saNG1AoFFAoFGjYsCFGjx6NmjVrIjw8HM2bNy/xvNTHCQkJEdMEQcDmzZvRvHlztG3bVkwvz+dRXlu2bIFMJsPIkSMl18mjR4/Qr18/ZGdn49SpU6Uur0aNGqUaTlHStSGTyVC1alUAL7r51dew+hor2mXfs2dP1K5dW9KuwIt2NjAwwGeffQbgRVtv2bIFLi4uqFu3ruQ8TUxM0LFjR8nfhJqPj4/WORVFP6OcnBykp6dDX18fzs7OkvqdO3cODx48wKhRo1C9enUx3dTUFOPHj9cod/PmzWjSpAnatWsnqWN+fj66d++OkydPQqlUamnR0tHle0XNzMwMEyZMkKRNmDABZmZmkuF6hoaGYi+cSqXCkydP8OjRI7i5uQGQfo7qp9lLlizR6C0sbe+hNmlpafj999/Rr18/tGzZUkyXyWT49ttvAUDrEMPSfL+9yuTJkyU9ruq27tevH+rXry+mKxQKNG7cWFJ2eHg4BEHAzJkzJZ+XtbU1vLy88Pfff4tD49R5p02bJplb07ZtW3Tv3l1Sp8zMTOzfvx/9+vWDsbGx5Bqzs7ODg4OD1r+DVylvO1eUzz77DPXq1RN/NzQ0xNSpU6FSqbT2DL5uvr6+kt/Vn/2IESNgZmYmprds2RJmZmYa15X6+6WwsBCZmZl49OgRWrVqBXNzc8nfjXpi9pQpU9CkSRMUFBTgyZMncHNzQ9euXZGXlwcrKyuxR11PTw95eXn45ptvYGdnJ/775JNPkJeXh4cPH0q+p16mVCphZGQEY2PjMrUHh0IRvQVe7sJW/7EX7S4tuq3o2PPr168DAEaPHl1s+ampqeLPaWlpmDVrFsLDw7XeFGZkZEi+DLXVT901W7Qe6v+pCoJQbD20sbOzw8qVK7Fy5UokJyfj5MmT2LRpEyIiItCnTx9cu3ZNckOqr68v3qy8TNt4ZODFMCiFQoF69epJ5kf06NEDYWFhePTokcbwJjs7O/F9C+pxyQ4ODqU6J3XwsGXLFnz//ffQ09PDiRMnkJCQgMWLF0vylufzKK/r169DEAQ0adKk2DxFr5VXEQShVMPXXnVt7NixAz/99BMuXLggzj1Re/LkifizOnhYunQpbt26BUdHR+Tm5mL37t3o0aOHOGTi4cOHSE9Px6FDh6BQKLQeU9sNrKOjo9a8d+7cwbfffotff/0VGRkZWs8NAO7evQsA4hCqorSlXb9+HUqlstg6Ai+G/RW9MS0LXb5XipZR9GYXAIyMjNCwYUONuSq//PILVq9ejWvXrqGwsFCyrejnePv2bVhZWWkMcdGVuv2bNWumse29996Dnp6eRp2B0n2/vUpZ2/rvv/8uVb3VafHx8XBychLrr+1vuGnTppJA4ebNmygsLMS6deuwbt26UtW7NMrbzhVFPVSpqKZNmwLAaz1ucXT9Ozt27Bjmz5+P06dP49mzZ2K6np4eHj16JM7VuXfvHqpWrQpLS0vY2tqid+/emDNnDnx9fWFra4tq1aph9+7d6NChg2SYXWmv77p16yI9PR0PHjzAw4cP4e/vD0EQYG1tXab2YGBB9BYoblWX0qz2or5Z+/HHH8Xx5S9TfzEIgoAePXrg+vXrmDJlCpycnGBubg59fX2sX78eW7du1bghKKkeRW8U1TdHjx8/fmWdi2NlZYVPPvkEn3zyCT777DNs3boVBw8e1Bj3XRZ3795FdHQ0BEEo9sZx8+bNGk+dTExMig1gSmPEiBHw9fXFsWPH4ObmhpCQEOjr60vOpbyfR1HF3di/PGlffTyZTIbIyMhiP1NtNwvFefLkSYk3xWolXRu7d+/G4MGD0aFDB/j7+6N+/fowNjZGQUEBevXqpXH+I0aMwNKlSxESEoKFCxdi9+7dyMnJkfRGqa9LNze3Mq0Br623IicnBy4uLsjNzYWvry9atGgBuVwuLsV47NixUpf/MkEQ0KJFixKX7S1N+xZHl++Vslq6dCmmT5+OHj16YPLkybC2toahoSGSkpIwatSoV17Hlak032/lLaMiyi4v9TGGDRsm+fsoSt1b+DqV5Tvqn3hcXT77uLg49OjRAw4ODvDz80ODBg3Edy2NGjUKubm5Yk/s/fv30bRpU2zfvh0dOnTAnDlzsG7dOixbtgzJycni/Jl+/fqVuR7Aiwdo58+fx8CBA1G9enU4ODjgxo0bGDBggMa+JT1QYmBB9A/XqFEjAKW7Eb58+TIuXbqE2bNna7w5ee3atTrVQ31DWpbhAyXp2LEjtm7diqSkJJ3KWb9+vbgCjYWFhcb2WbNmITg4WCOw0NWnn36KL7/8EiEhIfjggw+wc+dOdO/eHVZWVmKeivg81L05L09o1vbkrlGjRoiKioKNjY3Wp35lkZCQAJVK9cphYUDJ18amTZtgbGyM6OhoyY39jRs3tJbVqlUrtGrVCps3b8aCBQsQEhIiTuxWUygUsLCwQFZWlk7BIQAcPXoUDx48QHBwsMaL/WbNmiX5Xb1iivoJY1Ha0ho1aoSHDx+iW7duOg0Bep3i4+ORn58v6bXIy8tDfHy85Kn5pk2bYGdnh8jISMm5REVFaZTp6OiI8PBwpKamlthrUdrFHNTUT4ivXbumse3GjRsoLCws1xP6101dp2vXrmlMGP7zzz8ledT/vXHjRrF51RwcHCCTyZCfn6/z30FRZW3nGjVqaB3Wqu07qjSfubqXvqiX20l9XG0PM8p73Ndh69atKCgoQGRkpKSHIzc3F8nJyXBwcBBXfPPz88PXX38truBmYGCAcePGYdy4cXB3d0dkZCT27dundQWu0rh79y5GjBghrtL1999/a11tC5D+f+dlb+c3GRGVWs+ePVGrVi34+flp/SNXKpXIzs4G8H9PLl5+UnH16lWdx8QqFAo0a9ZMXM6yNI4fP651DHlhYaE4VlbdxV0ehYWF2LBhA1q0aIHPP/8cnp6eGv+GDh2KK1euIC4urtzH0UahUKB3797YvXs3tmzZgqysLI2nhhXxeah7YY4cOSJJ/+mnnzTyquegfPPNNxpLQgJlGwal/pw/+uijV+Yt6drQ19eHTCaTPNEWBAELFy4stryRI0fi77//xtatW3Hs2DEMHjxYMg5YT08Pn332Gc6cOVPsMrqlXWqzuM/o0KFDGks2Ojk5wcrKChs2bJAM/cnJycHq1as1yh4xYgRSUlKK7bEoy+fxumRlZeGXX36RpP3yyy/IyspC//79xTT151i0nVQqFfz8/DTKVD+BnTlzpkZPRtH91SvQlLYXtFatWujUqRMiIiJw9epVSZk//PADAGh9+lrZ+vXrB5lMhh9//FEyFDA5ORnr16+Hra0t2rRpI8m7dOlSyd/w+fPnNb4DLC0t4e7ujt27d2v92xMEQZz/VBZlbWdHR0dkZ2fjzJkzYlphYSF+/vlnjbJL85lv2bIF9+/fF3/Pz8/Hzz//DH19ffTp00dy3Bs3bkgeTuXl5SEgIKBcx30divt++f777zX+Nvr27QsA8Pf3l2y7cuWKxqprFaGkNmnQoAEMDAw0rrnff/+dPRZE/3QmJiYICQlB//790bhxY4wePRoODg7IyMjAjRs3sHv3buzZswddunTBe++9h2bNmmHx4sV4+vQpGjdujFu3bmHNmjVo0aKF1qdKZfHJJ59gwYIFSE5OljyZL86SJUsQGxuLvn37om3btjA3N0dKSgp27dqFc+fOoWvXrvDw8Ch3fQ4dOoTExESMGTOm2DwDBw7E3LlzsW7dOrRv377cx9Jm5MiR2LdvH6ZPnw5zc3PJjRiACvk8hg4dim+++Qbe3t64ceMGatSogaioKK1L8rZv3x5z587F3Llz0bp1a3zyySewtrZGcnIyzp07h4MHDyI/P79U53bw4EHUrFmz2LfCvqy4a8PT0xO7du1Ct27dMGLECDx//hx79+4tcengzz77DDNnzsSECRNQWFiodZjHd999h9jYWAwaNAiDBg1Cx44dYWhoiL///hsHDx5Eu3bttK7B/rLOnTujTp06mD59OhISElCvXj1cvHgRmzZtQosWLXDlyhUxr4GBAZYsWYLPPvsMHTp0wJgxY2BgYIANGzbA0tISd+/elTwZnTJlCg4fPowvv/wSx44dQ7du3WBmZoZ79+7h6NGjYk9OZbK3t8e8efNw9epVtGvXDufOnUNwcDCaNGkiWT7Y09MTX3/9NXr37o2PP/4YWVlZ2Lp1q9YXbH3yyScYPHgwQkJCcPv2bfTr1w/Vq1fHrVu38Ouvv4o3q+3bt4eenh6+++47PHnyBCYmJmjQoAGcnZ2Lra+/vz8++ugjfPjhh+IyqPv378evv/6KTz/9tNh35lSmxo0b48svv8TixYvh4uKCwYMHi8vN5uTkYMuWLeINaJMmTfDFF19g5cqV6NatGwYOHIi0tDSsXLkSrVq10nj/yapVq9C5c2e4uLhgxIgRaNOmDQoLCxEfH4/w8HDJE+qyKEs7e3t746effsKAAQMwZcoUGBoaYufOnVqHJDVt2hRyuRy//PILqlWrBgsLC9SqVUucUA+8CBicnZ0xfvx4yOVybN26FXFxcfjf//4nmY80ceJEhIaGws3NDePHj0d+fj42bdqkdchjea61ijBgwAD8/PPPcHd3h7e3NwwNDXH48GFcvnxZY95fs2bN4O3tjcDAQLi5uWHAgAF4+PAhAgIC0KZNG5w7d65Ce14sLS3h4OCA0NBQ2Nvbo3bt2jAxMUHfvn1hamqKUaNGYe3atRg6dCi6dOmC27dvY/369VxulqgylbTEHV5aKlStuOVFr1y5Inz22WeCtbW1UKVKFaFWrVrC+++/L8yfP19IT08X8yUkJAienp5CzZo1hapVqwrt27cXdu/erfNSpoLwYnlEAwMDYcmSJVrr/fKSg6dOnRKmTZsmODk5CbVq1RIMDAwEc3NzoWPHjsJPP/0kPHv2TJL/o48+EkxMTLTWRxD+b+lH9VKanp6eAgDh8uXLxe4jCILg6OgomJubi8ue2traCs2aNStxn9LIy8sTatSoIQAQPv/8c615yvJ5aEsTBEH4448/hE6dOglGRkaCpaWlMHbsWOHJkyfFXkP79+8XevToIVSvXl0wNDQU6tWrJ/Tq1UtYtWqVJF9xy83m5OQIJiYmwowZM0rdFiVdG4GBgcJ7770nGBkZCXXq1BHGjh0rpKenF1t/QRCEPn36CACERo0aFXvM3NxcYf78+ULz5s0FY2NjwdTUVGjSpInw+eefC3/88YfGeRa31OSlS5eEnj17ChYWFoKpqanw0UcfCSdOnCj272PHjh1CixYtBENDQ6F+/frC3Llzhd27d2ssnysIL5ao9ff3F5ycnIRq1aoJ1apVExwcHIRPP/1U+PXXX4s9t5LqXlHfK+rlOs+dOyd07dpVqFatmmBhYSEMGzZMSElJkeRVqVTC999/L9jb2wuGhoaCjY2N8OWXXwp//vmnxjKWgvBiWdmVK1cKbdq0EapWrSqYmpoKLVq0EObOnSvJt2HDBuG9994TqlSpUuL1UNTFixeF//znP+L13aRJE2HRokWS5VmLO+dXtdPLivub1LZ8p1pxy68GBgYKrVu3FoyMjAS5XC64ubkJJ06c0MhXUFAgLFy4ULCxsREMDQ2FZs2aCZs3by62Lg8fPhRmzJghNGrUSDAyMhLMzc2F5s2bC5MnT5YsiV3WJVdL286CIAgHDhwQWrVqJRgaGgpWVlbCzJkzhRs3bmhtowMHDght2rQRjIyMBADikrFFlzj19/cXHBwcBENDQ8HBwUFYtmyZ1jpu2LBBcHR0FKpUqSLY2dkJixYtEo4ePap1qdSyXmvFXT8lLcWqbQncPXv2CG3bthWqVasmWFpaCoMHDxb+/vtvrXlVKpUwd+5coX79+oKhoaHQokULYfv27cL06dMFAEJqauor6ycImtd3cdfr6dOnhU6dOgnVqlUTAEiu2+zsbGHMmDFCjRo1hKpVqwqdO3cWYmNjBdn/PwARUYUYP348Dh06hJs3b0qeVo4aNQrHjx/X+jZRejtt2LABXl5euHv3rmTcrr+/P7799ltxdZ/SKu7aeBf89NNPmDFjBk6dOoWOHTtWdnVKRb08ZdG3ehNVluPHj6Nr165Yv359qd7A/i7p27cvjh07hqysrNeyOENZcI4FEVWo+fPnIz09/UWXKP3rKJVK+Pn54csvvyxTUAG8G9dGfn6+xvyVnJwcBAQEwNLSUvIOEyKistA2J/Hy5cuIjIxEt27dKj2oALgqFBFVsFq1aiEzM7Oyq0GvSdWqVZGcnFyufd+FayM+Ph69e/fGkCFD0KBBAyQnJ2Pjxo24e/cuVq1apfFOCCKi0tq4cSNCQkLg4eEBhUKBGzduIDAwEIaGhpg/f35lVw8AAwsiIqIKo1Ao0LFjR2zZsgVpaWkwMDBAixYt4Ofnh0GDBlV29YjoH6xt27bYs2cPli9fjsePH0Mul6Nbt26YM2eOuHJYZeMcCyIiIiIi0hnnWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc4YWBARERERkc7+H3MdOpKgfkhiAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 800x950 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "# Summary plot for the first output dimension\n",
     "shap.summary_plot(shap_values[0], X_test, feature_names=feature_names, show=False)\n",

--- a/examples/notebooks/09_example_Sim_and_xRL.ipynb
+++ b/examples/notebooks/09_example_Sim_and_xRL.ipynb
@@ -195,8 +195,6 @@
    },
    "outputs": [],
    "source": [
-    "import importlib.util\n",
-    "\n",
     "import pandas as pd\n",
     "\n",
     "# import plotly for visualization\n",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Description
Fixed bugs in RL example notebooks
- example_04:
    - inputs_path is declared differently for local and colab environment at beginning of notebook but not used 
    - learning_config uses "None" instead of None as trained_policies_save_path, creates folder called None
- example_09:
   - local inputs path was pointing one directory up while, for example 8 and 9, the inputs path is in the notebooks directory
- PROBLEM: The Rl notebook does not currently run in collab but locally. We suspect the reason is a change in Colab since we get a PyDrive2 error, which is Colab's API. Yet, the release note of collab (https://cloud.google.com/colab/docs/release-notes) does not indicate any change since the dach energy Informatics that should have led to that. **This was fixed in** #489 

## Changes Proposed
- example_04: 
   - used inputs_path in notebook cells that only usedhard coded relative path
   - changed"None" to None in learning config dict
- example_09:
   - changed the inputs path

## Testing
Ran each notebook after implementing the changes 

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [x] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [x] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [x] New dependencies added to `pyproject.toml`
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

