### PR TITLE
Improve pandas mapper

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -127,7 +127,7 @@ class BaseUnit:
 
         return bids
 
-    def calculate_marginal_cost(self, start: pd.Timestamp, power: float) -> float:
+    def calculate_marginal_cost(self, start: datetime, power: float) -> float:
         """
         Calculates the marginal cost for the given power.
 
@@ -200,15 +200,14 @@ class BaseUnit:
             self.calculate_marginal_cost(t, product_data[idx])
             for idx, t in enumerate(self.index[start:end])
         ]
-
         new_values = np.abs(marginal_costs * product_data)
         self.outputs[product_type_mc].loc[start:end] = new_values
 
     def execute_current_dispatch(
         self,
-        start: pd.Timestamp,
-        end: pd.Timestamp,
-    ) -> pd.Series:
+        start: datetime,
+        end: datetime,
+    ) -> np.array:
         """
         Checks if the total dispatch plan is feasible.
 
@@ -326,8 +325,8 @@ class SupportsMinMax(BaseUnit):
     min_down_time: int = 0
 
     def calculate_min_max_power(
-        self, start: pd.Timestamp, end: pd.Timestamp, product_type: str = "energy"
-    ) -> tuple[pd.Series, pd.Series]:
+        self, start: datetime, end: datetime, product_type: str = "energy"
+    ) -> tuple[np.array, np.array]:
         """
         Calculates the min and max power for the given time period.
 
@@ -548,8 +547,8 @@ class SupportsMinMaxCharge(BaseUnit):
     efficiency_discharge: float
 
     def calculate_min_max_charge(
-        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
-    ) -> tuple[pd.Series, pd.Series]:
+        self, start: datetime, end: datetime, product_type="energy"
+    ) -> tuple[np.array, np.array]:
         """
         Calculates the min and max charging power for the given time period.
 
@@ -563,8 +562,8 @@ class SupportsMinMaxCharge(BaseUnit):
         """
 
     def calculate_min_max_discharge(
-        self, start: pd.Timestamp, end: pd.Timestamp, product_type="energy"
-    ) -> tuple[pd.Series, pd.Series]:
+        self, start: datetime, end: datetime, product_type="energy"
+    ) -> tuple[FastSeries, FastSeries]:
         """
         Calculates the min and max discharging power for the given time period.
 

--- a/assume/common/fast_pandas.py
+++ b/assume/common/fast_pandas.py
@@ -580,6 +580,11 @@ class FastSeries:
         result.data = -self.data
         return result
 
+    def __abs__(self):
+        result = self.copy()
+        result.data = abs(self.data)
+        return result
+
     # Reverse Arithmetic Operations
     def __radd__(self, other: int | float | np.ndarray):
         return self.__add__(other)

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -311,25 +311,27 @@ class UnitsOperator(Role):
             groupby=["market_id", "unit_id"],
         )
 
-        unit_dispatch_dfs = []
+        unit_dispatch = []
         for unit_id, unit in self.units.items():
             current_dispatch = unit.execute_current_dispatch(start, now)
             end = now
-            data = {"power": current_dispatch}
-
-            # TODO: this needs to be fixed. For now it is consuming too much time and is deactivated
-            # unit.calculate_generation_cost(start, now, "energy")
-            valid_outputs = ["soc", "cashflow", "marginal_costs", "total_costs"]
+            dispatch = {"power": current_dispatch}
+            unit.calculate_generation_cost(start, now, "energy")
+            valid_outputs = [
+                "soc",
+                "cashflow",
+                "marginal_costs",
+                "total_costs",
+            ]
 
             for key in unit.outputs.keys():
                 for output in valid_outputs:
                     if output in key:
-                        data[key] = unit.outputs[key][start:end]
-            data["time"] = unit.index.get_date_list(start, end)
-            data["unit"] = unit_id
-            unit_dispatch_dfs.append(data)
-
-        return market_dispatch, unit_dispatch_dfs
+                        dispatch[key] = unit.outputs[key][start:end]
+            dispatch["time"] = unit.index.get_date_list(start, end)
+            dispatch["unit"] = unit_id
+            unit_dispatch.append(dispatch)
+        return market_dispatch, unit_dispatch
 
     def write_actual_dispatch(self, product_type: str) -> None:
         """

--- a/assume/scenario/loader_pypsa.py
+++ b/assume/scenario/loader_pypsa.py
@@ -38,7 +38,7 @@ def load_pypsa(
         marketdesign (list[MarketConfig]): description of the market design which will be used with the scenario
     """
     index = network.snapshots
-    index.freq = "h"
+    index.freq = index.inferred_freq
     start = index[0]
     end = index[-1]
     sim_id = f"{scenario}_{study_case}"

--- a/assume/units/demand.py
+++ b/assume/units/demand.py
@@ -64,7 +64,7 @@ class Demand(SupportsMinMax):
         self.ramp_down = max(abs(min_power), abs(max_power))
         self.ramp_up = max(abs(min_power), abs(max_power))
         volume = self.forecaster[self.id]
-        self.volume = -volume  # demand is negative
+        self.volume = -abs(volume)  # demand is negative
         if isinstance(price, numbers.Real):
             price = FastSeries(index=self.index, value=price)
         self.price = price

--- a/assume_cli/cli.py
+++ b/assume_cli/cli.py
@@ -156,6 +156,8 @@ def cli(args=None):
             study_case=args.case_study,
         )
 
+        logging.info(f"loaded {args.scenario} - {args.case_study}")
+
         if world.learning_config.get("learning_mode", False):
             run_learning(
                 world,
@@ -163,7 +165,6 @@ def cli(args=None):
                 scenario=args.scenario,
                 study_case=args.case_study,
             )
-
         world.run()
 
     except KeyboardInterrupt:

--- a/examples/world_script.py
+++ b/examples/world_script.py
@@ -5,10 +5,10 @@
 import logging
 from datetime import datetime, timedelta
 
-import pandas as pd
 from dateutil import rrule as rr
 
 from assume import World
+from assume.common.fast_pandas import FastIndex
 from assume.common.forecasts import NaiveForecast
 from assume.common.market_objects import MarketConfig, MarketProduct
 
@@ -18,11 +18,8 @@ log = logging.getLogger(__name__)
 def init(world, n=1):
     start = datetime(2019, 1, 1)
     end = datetime(2019, 3, 1)
-    index = pd.date_range(
-        start=start,
-        end=end + timedelta(hours=24),
-        freq="h",
-    )
+
+    index = FastIndex(start, end, freq="h")
     sim_id = "world_script_simulation"
 
     world.setup(
@@ -35,7 +32,9 @@ def init(world, n=1):
     marketdesign = [
         MarketConfig(
             market_id="EOM",
-            opening_hours=rr.rrule(rr.HOURLY, interval=24, dtstart=start, until=end),
+            opening_hours=rr.rrule(
+                rr.HOURLY, interval=24, dtstart=start, until=end, cache=True
+            ),
             opening_duration=timedelta(hours=1),
             market_mechanism="pay_as_clear",
             market_products=[MarketProduct(timedelta(hours=1), 24, timedelta(hours=1))],


### PR DESCRIPTION
This PR is created by rebasing my previous changes onto the pandas_mapper branch and check lost differences, taking the unit tests and comparing performance to the prior implementation.

All in all this looks very good, the __set_item__ method was quite slower, so I cleaned it a little, don't know which use cases of that were missing.

We also do run `calculate_generation_cost` again, as it costs far less performance and is required for economic metrics.