### PR TITLE
fix missing database check when doing RL without a given database

### DIFF
--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -568,9 +568,9 @@ class WriteOutput(Role):
         query = text(
             f"select unit, SUM(reward) FROM rl_params where simulation='{self.simulation_id}' GROUP BY unit"
         )
-
-        with self.db.begin() as db:
-            rewards_by_unit = db.execute(query).fetchall()
+        if self.db is not None:
+            with self.db.begin() as db:
+                rewards_by_unit = db.execute(query).fetchall()
 
         # convert into a numpy array
         rewards_by_unit = [r[1] for r in rewards_by_unit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers=[
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">=3.10"
 dependencies = [


### PR DESCRIPTION
This fixes commands like:

`assume -s example_02a -c tiny` which did throw: `AttributeError: 'NoneType' object has no attribute 'begin'` before
