### PR TITLE
Remove duplicate `Powerplant.set_dispatch_plan()`

### DIFF
--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -9,8 +9,6 @@ from functools import lru_cache
 import pandas as pd
 
 from assume.common.base import SupportsMinMax
-from assume.common.market_objects import MarketConfig, Orderbook
-from assume.common.utils import get_products_index
 
 logger = logging.getLogger(__name__)
 
@@ -163,61 +161,6 @@ class PowerPlant(SupportsMinMax):
             self.outputs["energy"][t] = current_power
 
         return self.outputs["energy"].loc[start:end]
-
-    def set_dispatch_plan(
-        self,
-        marketconfig: MarketConfig,
-        orderbook: Orderbook,
-    ) -> None:
-        """
-        Adds the dispatch plan from the current market result to the total dispatch plan and calculates the cashflow.
-
-        Args:
-            marketconfig (MarketConfig): The market configuration.
-            orderbook (Orderbook): The orderbook.
-        """
-        products_index = get_products_index(orderbook)
-
-        max_power = (
-            self.forecaster.get_availability(self.id)[products_index] * self.max_power
-        )
-
-        product_type = marketconfig.product_type
-        for order in orderbook:
-            start = order["start_time"]
-            end = order["end_time"]
-            end_excl = end - self.index.freq
-            if isinstance(order["accepted_volume"], dict):
-                self.outputs[product_type].loc[start:end_excl] += [
-                    order["accepted_volume"][key]
-                    for key in order["accepted_volume"].keys()
-                ]
-            else:
-                self.outputs[product_type].loc[start:end_excl] += order[
-                    "accepted_volume"
-                ]
-
-        self.calculate_cashflow(product_type, orderbook)
-
-        for start in products_index:
-            current_power = self.outputs[product_type][start]
-
-            previous_power = self.get_output_before(start)
-            op_time = self.get_operation_time(start)
-
-            current_power = self.calculate_ramp(op_time, previous_power, current_power)
-
-            if current_power > 0:
-                current_power = min(current_power, max_power[start])
-                current_power = max(current_power, self.min_power)
-
-            self.outputs[product_type][start] = current_power
-
-        self.bidding_strategies[marketconfig.market_id].calculate_reward(
-            unit=self,
-            marketconfig=marketconfig,
-            orderbook=orderbook,
-        )
 
     def calc_simple_marginal_cost(
         self,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,7 @@ Upcoming Release
 **Bugfixes:**
   - **Tutorials**: General fixes of the tutorials, to align with updated functionalitites of Assume
   - **Tutorial 07**: Aligned Amiris loader with changes in format in Amiris compare (https://gitlab.com/fame-framework/fame-io/-/issues/203 and https://gitlab.com/fame-framework/fame-io/-/issues/208)
+  - **Powerplant**: Remove duplicate `Powerplant.set_dispatch_plan()` which broke multi-market bidding
 
 v0.4.3 - (11th November 2024)
 ===========================================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #493 

## Description
As detailed in the issue, the dispatch correction should not happen for every market.

The dispatch correction code is copied from [`Powerplant.execute_dispatch()`](https://github.com/RobbeSneyders/assume/blob/caa46f771c591eb26ccdcfd8a16188eb204a0e5f/assume/units/powerplant.py#L127). What remains after removing this is equivalent to [`BaseUnit.set_dispatch_plan()`](https://github.com/RobbeSneyders/assume/blob/caa46f771c591eb26ccdcfd8a16188eb204a0e5f/assume/common/base.py#L145), so the whole method can be removed.

## Changes Proposed
Remove duplicate `Powerplant.set_dispatch_plan()` method.

## Testing
See minimal reproducible example in issue.

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [x] New dependencies added to `pyproject.toml`
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0