### PR TITLE
move flexable calculation into bidding_strategies

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -58,8 +58,6 @@ class BaseUnit:
         self.outputs = defaultdict(lambda: FastSeries(value=0.0, index=self.index))
         # series does not like to convert from tensor to float otherwise
 
-        self.avg_op_time = 0
-
         # some data is stored as series to allow to store it in the outputs
         # check if any bidding strategy is using the RL strategy
         if any(
@@ -142,51 +140,25 @@ class BaseUnit:
         Iterates through the orderbook, adding the accepted volumes to the corresponding time slots
         in the dispatch plan. It then calculates the cashflow and the reward for the bidding strategies.
 
-        Additionally, updates the average operation and downtime dynamically.
-
         Args:
             marketconfig (MarketConfig): The market configuration.
             orderbook (Orderbook): The orderbook.
+
         """
+
         product_type = marketconfig.product_type
-
-        # Initialize counters for operation and downtime updates
-        total_op_time = self.avg_op_time * len(self.outputs[product_type])
-        total_periods = len(self.outputs[product_type])
-
         for order in orderbook:
             start = order["start_time"]
             end = order["end_time"]
             # end includes the end of the last product, to get the last products' start time we deduct the frequency once
             end_excl = end - self.index.freq
-
-            # Determine the added volume
             if isinstance(order["accepted_volume"], dict):
                 added_volume = list(order["accepted_volume"].values())
             else:
                 added_volume = order["accepted_volume"]
-
-            # Update outputs and track changes
-            current_slice = self.outputs[product_type].loc[start:end_excl]
             self.outputs[product_type].loc[start:end_excl] += added_volume
-
-            # Detect changes in operation/downtime
-            for idx, volume in enumerate(
-                self.outputs[product_type].loc[start:end_excl]
-            ):
-                was_operating = current_slice[idx] > 0
-                now_operating = volume > 0
-
-                if was_operating and not now_operating:  # Transition to downtime
-                    total_op_time -= 1
-                elif not was_operating and now_operating:  # Transition to operating
-                    total_op_time += 1
-
-        # Recalculate averages
-        self.avg_op_time = total_op_time / total_periods
-
-        # Calculate cashflow and reward
         self.calculate_cashflow(product_type, orderbook)
+
         self.bidding_strategies[marketconfig.market_id].calculate_reward(
             unit=self,
             marketconfig=marketconfig,

--- a/assume/strategies/advanced_orders.py
+++ b/assume/strategies/advanced_orders.py
@@ -69,6 +69,7 @@ class flexableEOMBlock(flexableEOM):
         bid_quantity_block = {}
         bid_price_block = []
         op_time = unit.get_operation_time(start)
+        avg_op_time = self.update_avg_op_time(op_time)
 
         for product, min_power, max_power in zip(
             product_tuples, min_power_values, max_power_values
@@ -126,6 +127,7 @@ class flexableEOMBlock(flexableEOM):
                     marginal_cost_inflex=marginal_cost_inflex,
                     bid_quantity_inflex=bid_quantity_inflex,
                     op_time=op_time,
+                    avg_op_time=avg_op_time,
                 )
 
             if unit.outputs["heat"].at[start] > 0:
@@ -236,6 +238,7 @@ class flexableEOMLinked(flexableEOM):
         bid_quantity_block = {}
         bid_price_block = []
         op_time = unit.get_operation_time(start)
+        avg_op_time = self.update_avg_op_time(op_time)
 
         block_id = unit.id + "_block"
 
@@ -295,6 +298,7 @@ class flexableEOMLinked(flexableEOM):
                     marginal_cost_inflex=marginal_cost_inflex,
                     bid_quantity_inflex=bid_quantity_inflex,
                     op_time=op_time,
+                    avg_op_time=avg_op_time,
                 )
 
             if unit.outputs["heat"].at[start] > 0:


### PR DESCRIPTION
Isn't this the better way to calculate this?

This adds up the maximum runtimes.
If the new runtime is lower than the current one, we had a downtime in the meantime.

Though we cut off the `unit.get_operation_time(start)` by the `max_time = max(self.min_operating_time, self.min_down_time, 1)`

So the current approach is probably better.