### PR TITLE
Fix storage behavior

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -522,7 +522,7 @@ class SupportsMinMaxCharge(BaseUnit):
         Returns:
             float: The SoC before the given datetime.
         """
-        if dt - self.index.freq <= self.index[0]:
+        if dt - self.index.freq < self.index[0]:
             return self.initial_soc
         else:
             return self.outputs["soc"].at[dt - self.index.freq]

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -98,6 +98,8 @@ class Storage(SupportsMinMaxCharge):
 
         self.max_soc = max_soc
         self.min_soc = min_soc
+        if initial_soc is None:
+            initial_soc = max_soc / 2
         self.initial_soc = initial_soc
 
         self.max_power_charge = -abs(max_power_charge)
@@ -325,7 +327,11 @@ class Storage(SupportsMinMaxCharge):
         return min_power_charge, max_power_charge
 
     def calculate_min_max_discharge(
-        self, start: datetime, end: datetime, product_type="energy"
+        self,
+        start: datetime,
+        end: datetime,
+        product_type = "energy",
+        soc = None,
     ) -> tuple[np.array, np.array]:
         """
         Calculates the min and max discharging power for the given time period.
@@ -362,10 +368,11 @@ class Storage(SupportsMinMaxCharge):
             min_power_discharge < max_power_discharge, min_power_discharge, 0
         )
 
+        if soc is None:
+            soc = self.get_soc_before(start)
+
         # restrict according to min_soc
-        max_soc_discharge = self.calculate_soc_max_discharge(
-            self.outputs["soc"].at[start]
-        )
+        max_soc_discharge = self.calculate_soc_max_discharge(soc)
         max_power_discharge = max_power_discharge.clip(max=max_soc_discharge)
 
         return min_power_discharge, max_power_discharge

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -130,7 +130,8 @@ def test_soc_constraint(storage_unit):
     storage_unit.outputs["capacity_neg"][start] = -50
     storage_unit.outputs["capacity_pos"][start] = 30
 
-    storage_unit.outputs["soc"][start] = 0.05 * storage_unit.max_soc
+    storage_unit.outputs["soc"][start-timedelta(hours=1)] = 0.05 * storage_unit.max_soc
+    assert storage_unit.get_soc_before(start) == 0.05 * storage_unit.max_soc
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
         start, end
     )


### PR DESCRIPTION
running: `assume -s example_01c -c dam_with_complex_opt_clearing -db "postgresql+psycopg2://assume:assume@localhost:5432/assume"`

previous behavior:

![image](https://github.com/user-attachments/assets/c92a3891-ac84-4037-ac35-daa784538e60)

new behavior:

![image](https://github.com/user-attachments/assets/1e06e48d-fc5b-4a27-9e79-485929f69007)


Description:

Storages were using the current SoC before, which led to always using the initial value to calculate discharge possibility.
This is fixed, by using the get_soc_before function as intended.

Also fixes debug printing of FastSeries (... ellipses was at the wrong place) and cuts of data if a timeseries index was given in FastIndex