### PR TITLE
Fixes missing scaled observations during evaluation

### DIFF
--- a/assume/reinforcement_learning/learning_unit_operator.py
+++ b/assume/reinforcement_learning/learning_unit_operator.py
@@ -76,11 +76,6 @@ class RLUnitsOperator(UnitsOperator):
                 )
 
                 self.rl_units.append(unit)
-
-                # prepare scaled foecasts for the RL staretgy as observations
-                unit.bidding_strategies[market.market_id].prepare_observations(
-                    unit, market.market_id
-                )
                 break
 
     def handle_market_feedback(self, content: ClearingMessage, meta: MetaDict) -> None:

--- a/assume/strategies/learning_advanced_orders.py
+++ b/assume/strategies/learning_advanced_orders.py
@@ -255,6 +255,13 @@ class RLAdvancedOrderStrategy(RLStrategy):
             The scaling factors are defined by the maximum residual load, the maximum bid price
             and the maximum capacity of the unit.
         """
+
+        # check if scaled observations are already available and if not prepare them
+        if not hasattr(self, "scaled_res_load_obs") or not hasattr(
+            self, "scaled_prices_obs"
+        ):
+            self.prepare_observations(unit, market_id)
+
         # end includes the end of the last product, to get the last products' start time we deduct the frequency once
         end_excl = end - unit.index.freq
 
@@ -284,19 +291,19 @@ class RLAdvancedOrderStrategy(RLStrategy):
                 start : end_excl + forecast_len
             ]
 
-        if end_excl + forecast_len > self.scaled_pices_obs.index[-1]:
-            scaled_price_forecast = self.scaled_pices_obs.loc[start:]
+        if end_excl + forecast_len > self.scaled_prices_obs.index[-1]:
+            scaled_price_forecast = self.scaled_prices_obs.loc[start:]
             scaled_price_forecast = np.concatenate(
                 [
                     scaled_price_forecast,
-                    self.scaled_pices_obs.iloc[
+                    self.scaled_prices_obs.iloc[
                         : self.foresight - len(scaled_price_forecast)
                     ],
                 ]
             )
 
         else:
-            scaled_price_forecast = self.scaled_pices_obs.loc[
+            scaled_price_forecast = self.scaled_prices_obs.loc[
                 start : end_excl + forecast_len
             ]
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -55,8 +55,12 @@ class AbstractLearningStrategy(LearningStrategy):
         # scaling factors for the observations
         upper_scaling_factor_price = max(unit.forecaster[f"price_{market_id}"])
         lower_scaling_factor_price = min(unit.forecaster[f"price_{market_id}"])
-        upper_scaling_factor_res_load = max(unit.forecaster[f"residual_load_{market_id}"])
-        lower_scaling_factor_res_load = min(unit.forecaster[f"residual_load_{market_id}"])
+        upper_scaling_factor_res_load = max(
+            unit.forecaster[f"residual_load_{market_id}"]
+        )
+        lower_scaling_factor_res_load = min(
+            unit.forecaster[f"residual_load_{market_id}"]
+        )
 
         self.scaled_res_load_obs = min_max_scale(
             unit.forecaster[f"residual_load_{market_id}"],
@@ -64,7 +68,7 @@ class AbstractLearningStrategy(LearningStrategy):
             upper_scaling_factor_res_load,
         )
 
-        self.scaled_pices_obs = min_max_scale(
+        self.scaled_prices_obs = min_max_scale(
             unit.forecaster[f"price_{market_id}"],
             lower_scaling_factor_price,
             upper_scaling_factor_price,
@@ -407,6 +411,12 @@ class RLStrategy(AbstractLearningStrategy):
         the total capacity and marginal cost, scaled by maximum power and bid price, respectively.
         """
 
+        # check if scaled observations are already available and if not prepare them
+        if not hasattr(self, "scaled_res_load_obs") or not hasattr(
+            self, "scaled_prices_obs"
+        ):
+            self.prepare_observations(unit, market_id)
+
         # end includes the end of the last product, to get the last products' start time we deduct the frequency once
         end_excl = end - unit.index.freq
 
@@ -436,19 +446,19 @@ class RLStrategy(AbstractLearningStrategy):
                 start : end_excl + forecast_len
             ]
 
-        if end_excl + forecast_len > self.scaled_pices_obs.index[-1]:
-            scaled_price_forecast = self.scaled_pices_obs.loc[start:]
+        if end_excl + forecast_len > self.scaled_prices_obs.index[-1]:
+            scaled_price_forecast = self.scaled_prices_obs.loc[start:]
             scaled_price_forecast = np.concatenate(
                 [
                     scaled_price_forecast,
-                    self.scaled_pices_obs.iloc[
+                    self.scaled_prices_obs.iloc[
                         : self.foresight - len(scaled_price_forecast)
                     ],
                 ]
             )
 
         else:
-            scaled_price_forecast = self.scaled_pices_obs.loc[
+            scaled_price_forecast = self.scaled_prices_obs.loc[
                 start : end_excl + forecast_len
             ]
 
@@ -995,6 +1005,12 @@ class StorageRLStrategy(AbstractLearningStrategy):
         the agent's action selection.
         """
 
+        # check if scaled observations are already available and if not prepare them
+        if not hasattr(self, "scaled_res_load_obs") or not hasattr(
+            self, "scaled_prices_obs"
+        ):
+            self.prepare_observations(unit, market_id)
+
         # end includes the end of the last product, to get the last products' start time we deduct the frequency once
         end_excl = end - unit.index.freq
 
@@ -1024,19 +1040,19 @@ class StorageRLStrategy(AbstractLearningStrategy):
                 start : end_excl + forecast_len
             ]
 
-        if end_excl + forecast_len > self.scaled_pices_obs.index[-1]:
-            scaled_price_forecast = self.scaled_pices_obs.loc[start:]
+        if end_excl + forecast_len > self.scaled_prices_obs.index[-1]:
+            scaled_price_forecast = self.scaled_prices_obs.loc[start:]
             scaled_price_forecast = np.concatenate(
                 [
                     scaled_price_forecast,
-                    self.scaled_pices_obs.iloc[
+                    self.scaled_prices_obs.iloc[
                         : self.foresight - len(scaled_price_forecast)
                     ],
                 ]
             )
 
         else:
-            scaled_price_forecast = self.scaled_pices_obs.loc[
+            scaled_price_forecast = self.scaled_prices_obs.loc[
                 start : end_excl + forecast_len
             ]
 

--- a/examples/notebooks/04_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04_reinforcement_learning_example.ipynb
@@ -695,7 +695,7 @@
     "\n",
     "\n",
     "Following up on these concepts the following tasks will:\n",
-    "1. obtain the action values from the neurnal net in the bidding staretgy and\n",
+    "1. obtain the action values from the neurnal net in the bidding strategy and\n",
     "2. then transform theses values into the actual bids of an order. "
    ]
   },
@@ -2524,7 +2524,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "assume",
+   "display_name": "assume-framework",
    "language": "python",
    "name": "python3"
   },

--- a/tests/test_drl_storage_strategy.py
+++ b/tests/test_drl_storage_strategy.py
@@ -86,7 +86,6 @@ def test_storage_rl_strategy_sell_bid(mock_market_config, storage_unit):
 
     # get the strategy
     strategy = storage_unit.bidding_strategies["EOM"]
-    strategy.prepare_observations(storage_unit, mc.market_id)
 
     # Define the 'sell' action: [0.2, 0.5] -> price=20, direction='sell'
     sell_action = [0.2, 0.5]
@@ -182,7 +181,6 @@ def test_storage_rl_strategy_buy_bid(mock_market_config, storage_unit):
 
     # Instantiate the StorageRLStrategy
     strategy = storage_unit.bidding_strategies["EOM"]
-    strategy.prepare_observations(storage_unit, mc.market_id)
 
     # Define the 'buy' action: [0.3, -0.5] -> price=30, direction='buy'
     buy_action = [0.3, -0.5]
@@ -276,7 +274,6 @@ def test_storage_rl_strategy_ignore_bid(mock_market_config, storage_unit):
 
     # Instantiate the StorageRLStrategy
     strategy = storage_unit.bidding_strategies["EOM"]
-    strategy.prepare_observations(storage_unit, mc.market_id)
 
     # Define the 'ignore' action: [0.0, 0.0] -> price=0, direction='ignore'
     ignore_action = [0.0, 0.0]

--- a/tests/test_rl_advanced_order_strategy.py
+++ b/tests/test_rl_advanced_order_strategy.py
@@ -59,7 +59,6 @@ def test_learning_advanced_orders(mock_market_config, power_plant):
     ]
 
     strategy = power_plant.bidding_strategies["EOM"]
-    strategy.prepare_observations(power_plant, mc.market_id)
 
     strategy.order_types = ["SB"]
     bids = strategy.calculate_bids(power_plant, mc, product_tuples=product_tuples)

--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -91,7 +91,6 @@ def test_learning_strategies(mock_market_config, power_plant_mcp):
     ]
 
     strategy = power_plant_mcp.bidding_strategies["EOM"]
-    strategy.prepare_observations(power_plant_mcp, mc.market_id)
     bids = strategy.calculate_bids(power_plant_mcp, mc, product_tuples=product_tuples)
 
     assert len(bids) == 2
@@ -124,7 +123,6 @@ def test_lstm_learning_strategies(mock_market_config, power_plant_lstm):
     ]
 
     strategy = power_plant_lstm.bidding_strategies["EOM"]
-    strategy.prepare_observations(power_plant_lstm, mc.market_id)
     bids = strategy.calculate_bids(power_plant_lstm, mc, product_tuples=product_tuples)
 
     assert len(bids) == 2


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #526

## Description
See issue #526

## Changes Proposed
-remove the creation of the scaled observations from the unit operator to the bidding strategy itself
-check if these properties exist and create if not 
-replace unit operator with RL-Operator only in learning mode, so we can preserve actual names of the unit Operators 
-fix tests to reflect the change
-fixes some namings

## Testing
[Describe the testing you've done, including any specific test cases or scenarios]

## Checklist
Please check all applicable items:

- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
[Add screenshots to demonstrate visual changes]
