### PR TITLE
the fast pandas series did behave different than pandas series for uneven timestamps

### DIFF
--- a/assume/common/fast_pandas.py
+++ b/assume/common/fast_pandas.py
@@ -116,7 +116,7 @@ class FastIndex:
                 else item.start or 0
             )
             stop_idx = (
-                self._get_idx_from_date(item.stop) + 1
+                self._get_idx_from_date(item.stop, round_up=False) +1
                 if isinstance(item.stop, datetime)
                 else item.stop or len(self._date_list)
             )
@@ -201,7 +201,7 @@ class FastIndex:
             self._date_list = [self._start + timedelta(seconds=s) for s in total_dates]
 
         start_idx = self._get_idx_from_date(start or self.start)
-        end_idx = self._get_idx_from_date(end or self.end) + 1
+        end_idx = self._get_idx_from_date(end or self.end, round_up=False) +1
         return self._date_list[start_idx:end_idx]
 
     def as_datetimeindex(self) -> pd.DatetimeIndex:
@@ -217,7 +217,7 @@ class FastIndex:
         return pd.DatetimeIndex(pd.to_datetime(datetimes), name="FastIndex")
 
     @lru_cache(maxsize=1000)
-    def _get_idx_from_date(self, date: datetime) -> int:
+    def _get_idx_from_date(self, date: datetime, round_up:bool = True) -> int:
         """
         Convert a datetime to its corresponding index in the range.
 
@@ -237,13 +237,9 @@ class FastIndex:
         delta_seconds = (date - self.start).total_seconds()
         remainder = delta_seconds % self.freq_seconds
 
-        if remainder > self.tolerance_seconds and remainder < (
-            self.freq_seconds - self.tolerance_seconds
-        ):
-            raise ValueError(
-                f"Date {date} is not aligned with frequency {self.freq_seconds} seconds. "
-                f"Allowed tolerance: {self.tolerance_seconds} seconds."
-            )
+        if round_up and remainder > 0:
+            # if there is a large remainder, we need to add to return the value of the next date as begin
+            delta_seconds += self.freq_seconds
 
         return round(delta_seconds / self.freq_seconds)
 
@@ -448,7 +444,7 @@ class FastSeries:
                 else 0
             )
             stop_idx = (
-                self.index._get_idx_from_date(item.stop) + 1
+                self.index._get_idx_from_date(item.stop, round_up=False)+1
                 if item.stop is not None
                 else len(self.data)
             )
@@ -515,7 +511,7 @@ class FastSeries:
                 )
             )
             stop_idx = (
-                self.index._get_idx_from_date(item.stop) + 1
+                self.index._get_idx_from_date(item.stop, round_up=False) +1
                 if isinstance(item.stop, datetime)
                 else (
                     len(self.data) + item.stop

--- a/assume/common/fast_pandas.py
+++ b/assume/common/fast_pandas.py
@@ -116,7 +116,7 @@ class FastIndex:
                 else item.start or 0
             )
             stop_idx = (
-                self._get_idx_from_date(item.stop, round_up=False) +1
+                self._get_idx_from_date(item.stop, round_up=False) + 1
                 if isinstance(item.stop, datetime)
                 else item.stop or len(self._date_list)
             )
@@ -201,7 +201,7 @@ class FastIndex:
             self._date_list = [self._start + timedelta(seconds=s) for s in total_dates]
 
         start_idx = self._get_idx_from_date(start or self.start)
-        end_idx = self._get_idx_from_date(end or self.end, round_up=False) +1
+        end_idx = self._get_idx_from_date(end or self.end, round_up=False) + 1
         return self._date_list[start_idx:end_idx]
 
     def as_datetimeindex(self) -> pd.DatetimeIndex:
@@ -217,7 +217,7 @@ class FastIndex:
         return pd.DatetimeIndex(pd.to_datetime(datetimes), name="FastIndex")
 
     @lru_cache(maxsize=1000)
-    def _get_idx_from_date(self, date: datetime, round_up:bool = True) -> int:
+    def _get_idx_from_date(self, date: datetime, round_up: bool = True) -> int:
         """
         Convert a datetime to its corresponding index in the range.
 
@@ -444,7 +444,7 @@ class FastSeries:
                 else 0
             )
             stop_idx = (
-                self.index._get_idx_from_date(item.stop, round_up=False)+1
+                self.index._get_idx_from_date(item.stop, round_up=False) + 1
                 if item.stop is not None
                 else len(self.data)
             )
@@ -511,7 +511,7 @@ class FastSeries:
                 )
             )
             stop_idx = (
-                self.index._get_idx_from_date(item.stop, round_up=False) +1
+                self.index._get_idx_from_date(item.stop, round_up=False) + 1
                 if isinstance(item.stop, datetime)
                 else (
                     len(self.data) + item.stop

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -244,10 +244,8 @@ async def test_get_actual_dispatch(units_operator: UnitsOperator):
     market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
     # THEN resulting unit dispatch dataframe contains one row
     # which is for the current time - as we must know our current dispatch
-    assert datetime2timestamp(unit_dfs[0]["time"][0]) == last
-    assert datetime2timestamp(unit_dfs[0]["time"][1]) == clock.time
-    # only 1 start and stop contained
-    assert len(unit_dfs[0]["time"]) == 2
+    assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
+    assert len(unit_dfs[0]["time"]) == 1
     assert len(market_dispatch) == 0
 
     # WHEN another hour passes
@@ -256,16 +254,14 @@ async def test_get_actual_dispatch(units_operator: UnitsOperator):
 
     # THEN resulting unit dispatch dataframe contains only one row with current dispatch
     market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
-    assert datetime2timestamp(unit_dfs[0]["time"][0]) == last
-    assert datetime2timestamp(unit_dfs[0]["time"][1]) == clock.time
-    assert len(unit_dfs[0]["time"]) == 2
+    assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
+    assert len(unit_dfs[0]["time"]) == 1
     assert len(market_dispatch) == 0
 
     last = clock.time
     clock.set_time(clock.time + 3600)
 
     market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
-    assert datetime2timestamp(unit_dfs[0]["time"][0]) == last
-    assert datetime2timestamp(unit_dfs[0]["time"][1]) == clock.time
-    assert len(unit_dfs[0]["time"]) == 2
+    assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
+    assert len(unit_dfs[0]["time"]) == 1
     assert len(market_dispatch) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -620,6 +620,35 @@ def test_set_list():
     print(res_pd)
     assert res_fds < res_pd
 
+def test_slicing_fastseries_even():
+    start = datetime(2020, 1, 1, 0)
+    end = datetime(2020, 1, 1, 5)
+    index = FastIndex(start, end, freq="1h")
+    fs = FastSeries(index)
+    b = start+timedelta(hours=1)
+    e = start+timedelta(hours=4)
+    result = fs[b:e]
+    
+    datelist = fs.index.get_date_list(b, e)
+    series = pd.Series(0, index=pd.date_range(start,end, freq="h"))
+    assert list(series[b:e].index) == datelist
+    assert len(series[b:e]) == len(fs[b:e])
+
+
+def test_slicing_fastseries_uneven():
+    start = datetime(2020, 1, 1, 0)
+    end = datetime(2020, 1, 1, 5)
+    index = FastIndex(start, end, freq="1h")
+    fs = FastSeries(index)
+    b = start+timedelta(seconds= 1)
+    e = start+timedelta(hours=4, seconds= 1)
+    result = fs[b:e]
+    
+    datelist = fs.index.get_date_list(b, e)
+    series = pd.Series(0, index=pd.date_range(start,end, freq="h"))
+    assert list(series[b:e].index) == datelist
+    assert len(series[b:e]) == len(fs[b:e])
+
 
 def test_parse_duration():
     assert parse_duration("24h") == timedelta(days=1)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -620,17 +620,18 @@ def test_set_list():
     print(res_pd)
     assert res_fds < res_pd
 
+
 def test_slicing_fastseries_even():
     start = datetime(2020, 1, 1, 0)
     end = datetime(2020, 1, 1, 5)
     index = FastIndex(start, end, freq="1h")
     fs = FastSeries(index)
-    b = start+timedelta(hours=1)
-    e = start+timedelta(hours=4)
+    b = start + timedelta(hours=1)
+    e = start + timedelta(hours=4)
     result = fs[b:e]
-    
+
     datelist = fs.index.get_date_list(b, e)
-    series = pd.Series(0, index=pd.date_range(start,end, freq="h"))
+    series = pd.Series(0, index=pd.date_range(start, end, freq="h"))
     assert list(series[b:e].index) == datelist
     assert len(series[b:e]) == len(fs[b:e])
 
@@ -640,12 +641,12 @@ def test_slicing_fastseries_uneven():
     end = datetime(2020, 1, 1, 5)
     index = FastIndex(start, end, freq="1h")
     fs = FastSeries(index)
-    b = start+timedelta(seconds= 1)
-    e = start+timedelta(hours=4, seconds= 1)
+    b = start + timedelta(seconds=1)
+    e = start + timedelta(hours=4, seconds=1)
     result = fs[b:e]
-    
+
     datelist = fs.index.get_date_list(b, e)
-    series = pd.Series(0, index=pd.date_range(start,end, freq="h"))
+    series = pd.Series(0, index=pd.date_range(start, end, freq="h"))
     assert list(series[b:e].index) == datelist
     assert len(series[b:e]) == len(fs[b:e])
 


### PR DESCRIPTION
This is an issue in get_actual_dispatch, where we add one second to the start time to not include the start time, which was sent before

`start = timestamp2datetime(last + 1)`

closes #539