### PR TITLE
Fix writing generation costs to the database

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -368,7 +368,7 @@ class UnitsOperator(Role):
             valid_outputs = [
                 "soc",
                 "cashflow",
-                "marginal_costs",
+                "generation_costs",
                 "total_costs",
                 "heat",
             ]

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -314,6 +314,7 @@ def test_participate():
 
     assert units_role.participate(marketconfig)
 
+
 def test_participate_lambda():
     """
     Tests that one of the selected lambda functions works correctly in the participation


### PR DESCRIPTION
After latest update in #553 the generation costs are no longer written to the database. This is fixed here