### PR TITLE
Fix storage strategies

### DIFF
--- a/assume/strategies/dmas_storage.py
+++ b/assume/strategies/dmas_storage.py
@@ -144,7 +144,7 @@ class DmasStorageStrategy(BaseStrategy):
         ]
 
         self.model.vol_con = pyo.ConstraintList()
-        v0 = unit.get_soc_before(start)
+        v0 = unit.outputs["soc"].at[start - unit.index.freq]
 
         for t in time_range:
             if t == 0:

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -61,17 +61,17 @@ class flexableEOMStorage(BaseStrategy):
         # Calculate bids
         # =============================================================================
         # save a theoretic SOC to calculate the ramping
-        theoretic_SOC = unit.outputs["soc"].at[product_tuples[0][0]]
+        start = product_tuples[0][0]
+        theoretic_SOC = unit.outputs["soc"].at[start]
+        previous_power = unit.get_output_before(start)
+
+        current_power = unit.outputs["energy"].at[start]
+        current_power_discharge = max(current_power, 0)
+        current_power_charge = min(current_power, 0)
 
         bids = []
         for product in product_tuples:
             start, end = product[0], product[1]
-
-            previous_power = unit.get_output_before(start)
-
-            current_power = unit.outputs["energy"].at[start]
-            current_power_discharge = max(current_power, 0)
-            current_power_charge = min(current_power, 0)
 
             # calculate min and max power for charging and discharging
             min_power_charge, max_power_charge = unit.calculate_min_max_charge(

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -58,47 +58,28 @@ class flexableEOMStorage(BaseStrategy):
         """
 
         # =============================================================================
-        # Storage Unit is either charging, discharging, or off
-        # =============================================================================
-        start = product_tuples[0][0]
-        end_all = product_tuples[-1][1]
-
-        previous_power = unit.get_output_before(start)
-
-        # save a theoretic SOC to calculate the ramping
-        theoretic_SOC = unit.get_soc_before(start)
-
-        # calculate min and max power for charging and discharging
-        min_power_charge_values, max_power_charge_values = (
-            unit.calculate_min_max_charge(start, end_all)
-        )
-        min_power_discharge_values, max_power_discharge_values = (
-            unit.calculate_min_max_discharge(start, end_all, soc=theoretic_SOC)
-        )
-
-        # =============================================================================
         # Calculate bids
         # =============================================================================
-        bids = []
+        # save a theoretic SOC to calculate the ramping
+        theoretic_SOC = unit.outputs["soc"].at[product_tuples[0][0]]
 
-        for (
-            product,
-            max_power_discharge,
-            min_power_discharge,
-            max_power_charge,
-            min_power_charge,
-        ) in zip(
-            product_tuples,
-            max_power_discharge_values,
-            min_power_discharge_values,
-            max_power_charge_values,
-            min_power_charge_values,
-        ):
+        bids = []
+        for product in product_tuples:
             start, end = product[0], product[1]
+
+            previous_power = unit.get_output_before(start)
 
             current_power = unit.outputs["energy"].at[start]
             current_power_discharge = max(current_power, 0)
             current_power_charge = min(current_power, 0)
+
+            # calculate min and max power for charging and discharging
+            min_power_charge, max_power_charge = unit.calculate_min_max_charge(
+                start, end, soc=theoretic_SOC
+            )
+            min_power_discharge, max_power_discharge = unit.calculate_min_max_discharge(
+                start, end, soc=theoretic_SOC
+            )
 
             # Calculate ramping constraints using helper function
             max_power_discharge = unit.calculate_ramp_discharge(
@@ -176,8 +157,6 @@ class flexableEOMStorage(BaseStrategy):
 
             theoretic_SOC += delta_soc
             previous_power = bid_quantity + current_power
-
-        bids = self.remove_empty_bids(bids)
 
         return bids
 
@@ -267,7 +246,7 @@ class flexablePosCRMStorage(BaseStrategy):
         end = product_tuples[-1][1]
 
         previous_power = unit.get_output_before(start)
-        theoretic_SOC = unit.get_soc_before(start)
+        theoretic_SOC = unit.outputs["soc"].at[start]
 
         _, max_power_discharge_values = unit.calculate_min_max_discharge(
             start, end, soc=theoretic_SOC
@@ -400,7 +379,7 @@ class flexableNegCRMStorage(BaseStrategy):
 
         previous_power = unit.get_output_before(start)
 
-        theoretic_SOC = unit.get_soc_before(start)
+        theoretic_SOC = unit.outputs["soc"].at[start]
 
         _, max_power_charge_values = unit.calculate_min_max_charge(start, end)
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -816,11 +816,8 @@ class StorageRLStrategy(AbstractLearningStrategy):
         else:
             bid_direction = "ignore"
 
-        _, max_discharge = unit.calculate_min_max_discharge(start, end_all)
-        _, max_charge = unit.calculate_min_max_charge(start, end_all)
-
-        bid_quantity_supply = max_discharge[0]
-        bid_quantity_demand = max_charge[0]
+        _, bid_quantity_supply = unit.calculate_min_max_discharge(start, end_all)
+        _, bid_quantity_demand = unit.calculate_min_max_charge(start, end_all)
 
         bids = []
 

--- a/examples/inputs/example_01c/config.yaml
+++ b/examples/inputs/example_01c/config.yaml
@@ -108,7 +108,7 @@ dam_with_complex_opt_clearing:
       products:
         - duration: 1h
           count: 24
-          first_delivery: 1h
+          first_delivery: 24h
       opening_frequency: 24h
       opening_duration: 24h
       volume_unit: MWh

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -83,21 +83,21 @@ def test_calculate_operational_window(storage_unit):
     start = datetime(2022, 1, 1, 0)
     end = datetime(2022, 1, 1, 1)
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
-        start, end, product_type="energy"
+        start, end
     )
-    cost_discharge = storage_unit.calculate_marginal_cost(start, max_power_discharge[0])
+    cost_discharge = storage_unit.calculate_marginal_cost(start, max_power_discharge)
 
-    assert min_power_discharge[0] == 0
-    assert max_power_discharge[0] == 100
+    assert min_power_discharge == 0
+    assert max_power_discharge == 100
     assert cost_discharge == 4 / 0.95
 
     min_power_charge, max_power_charge = storage_unit.calculate_min_max_charge(
-        start, end, product_type="energy"
+        start, end
     )
-    cost_charge = storage_unit.calculate_marginal_cost(start, max_power_charge[0])
+    cost_charge = storage_unit.calculate_marginal_cost(start, max_power_charge)
 
-    assert min_power_charge[0] == 0
-    assert max_power_charge[0] == -100
+    assert min_power_charge == 0
+    assert max_power_charge == -100
     assert math.isclose(cost_charge, 3 / 0.9)
 
     assert storage_unit.outputs["energy"].at[start] == 0
@@ -109,14 +109,14 @@ def test_calculate_operational_window(storage_unit):
     min_power_charge, max_power_charge = storage_unit.calculate_min_max_charge(
         start, end
     )
-    assert min_power_charge[0] == -40
-    assert max_power_charge[0] == -60
+    assert min_power_charge == -40
+    assert max_power_charge == -60
 
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
         start, end
     )
-    assert min_power_discharge[0] == 40
-    assert max_power_discharge[0] == 60
+    assert min_power_discharge == 40
+    assert max_power_discharge == 60
 
     start = start + timedelta(hours=1)
 
@@ -133,20 +133,19 @@ def test_soc_constraint(storage_unit):
     storage_unit.outputs["soc"][start - timedelta(hours=1)] = (
         0.05 * storage_unit.max_soc
     )
-    assert storage_unit.get_soc_before(start) == 0.05 * storage_unit.max_soc
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
         start, end
     )
-    assert min_power_discharge[0] == 40
-    assert max_power_discharge[0] == 60
+    assert min_power_discharge == 40
+    assert max_power_discharge == 60
 
     storage_unit.outputs["soc"][start] = 0.95 * storage_unit.max_soc
     min_power_charge, max_power_charge = storage_unit.calculate_min_max_charge(
         start, end
     )
-    assert min_power_charge[0] == -40
+    assert min_power_charge == -40
     assert math.isclose(
-        max_power_charge[0], -50 / storage_unit.efficiency_charge, abs_tol=0.1
+        max_power_charge, -50 / storage_unit.efficiency_charge, abs_tol=0.1
     )
 
 
@@ -154,19 +153,19 @@ def test_storage_feedback(storage_unit, mock_market_config):
     start = datetime(2022, 1, 1, 0)
     end = datetime(2022, 1, 1, 1)
     min_power_charge, max_power_charge = storage_unit.calculate_min_max_charge(
-        start, end, product_type="energy"
+        start, end
     )
 
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
-        start, end, product_type="energy"
+        start, end
     )
-    cost_discharge = storage_unit.calculate_marginal_cost(start, max_power_discharge[0])
+    cost_discharge = storage_unit.calculate_marginal_cost(start, max_power_discharge)
 
-    assert min_power_charge[0] == 0
-    assert max_power_charge[0] == -100
+    assert min_power_charge == 0
+    assert max_power_charge == -100
 
-    assert min_power_discharge[0] == 0
-    assert max_power_discharge[0] == 100
+    assert min_power_discharge == 0
+    assert max_power_discharge == 100
     assert storage_unit.outputs["energy"][start] == 0
 
     orderbook = [
@@ -176,7 +175,7 @@ def test_storage_feedback(storage_unit, mock_market_config):
             "only_hours": None,
             "price": cost_discharge,
             "accepted_price": cost_discharge,
-            "accepted_volume": max_power_discharge[0] / 2,
+            "accepted_volume": max_power_discharge / 2,
         }
     ]
     # max_power_charge gets accepted
@@ -185,25 +184,25 @@ def test_storage_feedback(storage_unit, mock_market_config):
 
     # second market request for same interval
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
-        start, end, product_type="energy"
+        start, end
     )
 
     # we do not need additional min_power, as our runtime requirement is fulfilled
-    assert min_power_discharge[0] == 0
+    assert min_power_discharge == 0
     # we can not bid the maximum anymore, because we already provide energy on the other market
-    assert max_power_discharge[0] == 50
+    assert max_power_discharge == 50
 
     storage_unit.execute_current_dispatch(start, end)
     # second market request for next interval
     start = datetime(2022, 1, 1, 1)
     end = datetime(2022, 1, 1, 2)
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
-        start, end, product_type="energy"
+        start, end
     )
 
     # now we can bid max_power and need min_power again
-    assert min_power_discharge[0] == 0
-    assert max_power_discharge[0] == 100
+    assert min_power_discharge == 0
+    assert max_power_discharge == 100
 
 
 def test_storage_ramping(storage_unit):
@@ -211,23 +210,23 @@ def test_storage_ramping(storage_unit):
     end = datetime(2022, 1, 1, 1)
 
     min_power_charge, max_power_charge = storage_unit.calculate_min_max_charge(
-        start, end, product_type="energy"
+        start, end
     )
 
     min_power_discharge, max_power_discharge = storage_unit.calculate_min_max_discharge(
-        start, end, product_type="energy"
+        start, end
     )
 
-    assert min_power_charge[0] == 0
-    assert max_power_charge[0] == -100
+    assert min_power_charge == 0
+    assert max_power_charge == -100
 
-    assert min_power_discharge[0] == 0
-    assert max_power_discharge[0] == 100
+    assert min_power_discharge == 0
+    assert max_power_discharge == 100
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        500, 0, max_power_discharge[0]
+        500, 0, max_power_discharge
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(500, 0, max_power_charge[0])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(500, 0, max_power_charge)
 
     assert max_ramp_discharge == 60
     assert max_ramp_charge == -60
@@ -240,9 +239,9 @@ def test_storage_ramping(storage_unit):
     end = datetime(2022, 1, 1, 2)
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        500, 60, max_power_discharge[0]
+        500, 60, max_power_discharge
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(500, 60, max_power_charge[0])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(500, 60, max_power_charge)
 
     assert max_ramp_discharge == 100
     assert max_ramp_charge == -60
@@ -255,9 +254,9 @@ def test_storage_ramping(storage_unit):
     end = datetime(2022, 1, 1, 3)
 
     max_ramp_discharge = storage_unit.calculate_ramp_discharge(
-        500, -60, max_power_discharge[0]
+        500, -60, max_power_discharge
     )
-    max_ramp_charge = storage_unit.calculate_ramp_charge(500, -60, max_power_charge[0])
+    max_ramp_charge = storage_unit.calculate_ramp_charge(500, -60, max_power_charge)
 
     assert max_ramp_discharge == 60
     assert max_ramp_charge == -100
@@ -329,7 +328,10 @@ def test_set_dispatch_plan(mock_market_config, storage_unit):
     storage_unit.outputs["soc"][start] = 0.5 * storage_unit.max_soc
 
     bids = strategy.calculate_bids(storage_unit, mc, product_tuples=product_tuples)
-    assert len(bids) == 0
+    assert len(bids) == 1
+
+    bids[0]["accepted_volume"] = bids[0]["volume"]
+    bids[0]["accepted_price"] = bids[0]["price"]
 
     # dispatch full discharge
     storage_unit.set_dispatch_plan(mc, bids)


### PR DESCRIPTION
FlexABLE storage strategies were acting weird when used with a day ahead bidding. The problem was that the SOC was updated only later during execute_current_dispatch and was not reflected for the next bidding period, where the storage units assumed again an initial soc of 0. This PR adds an soc update part to the set_dispatch function when used by storage units. This also refactors the flexable storage strategy to make viable bids on the day ahead market compared to before.