### PR TITLE
register agents later in output

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -110,7 +110,15 @@ class UnitsOperator(Role):
                     self.register_market(market),
                     1,  # register after time was updated for the first time
                 )
+
+        self.context.schedule_timestamp_task(
+            self.store_units(),
+            1,  # register after time was updated for the first time
+        )
+        
+    async def store_units(self) -> None:
         db_addr = self.context.data.get("output_agent_addr")
+        logger.debug("store units to %s", db_addr)
         if db_addr:
             # send unit data to db agent to store it
             for unit in self.units.values():
@@ -119,7 +127,7 @@ class UnitsOperator(Role):
                     "type": "store_units",
                     "data": unit.as_dict(),
                 }
-                self.context.schedule_instant_message(
+                await self.context.send_message(
                     content=message,
                     receiver_addr=db_addr,
                 )

--- a/compose.yml
+++ b/compose.yml
@@ -4,7 +4,7 @@
 
 services:
   assume_db:
-    image: timescaledev/timescaledb-ha:pg17-oss
+    image: timescale/timescaledb-ha:pg17-oss
     # smaller without postgis support:
     # image: timescale/timescaledb:latest-pg17
     container_name: assume_db

--- a/examples/distributed_simulation/config.py
+++ b/examples/distributed_simulation/config.py
@@ -69,7 +69,6 @@ async def worker(
         end=end,
         save_frequency_hours=48,
         simulation_id=simulation_id,
-        index=index,
         manager_address=manager_protocol_addr,
         broker_addr=broker_addr,
     )


### PR DESCRIPTION

# Pull Request

this is  required for distributed simulations, in which the output agent might not yet be available if the clock manager is running somewhere else

also fix the distributed simulation example
and switch to timescale official repository for docker image

This fixes reconnects and waiting for other containers in distributed simulations, while not affecting anything else.

## Checklist
Please check all applicable items:

- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
[Add screenshots to demonstrate visual changes]
