### PR TITLE
see PR, suggested using terminate learning in initialize policy function

### DIFF
--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -1070,13 +1070,14 @@ def run_learning(
         f"{world.learning_role.trained_policies_save_path}/avg_reward_eval_policies"
     )
 
+
     # load scenario for evaluation
     setup_world(
         world=world,
         terminate_learning=True,
     )
 
-    world.learning_role.load_inter_episodic_data(inter_episodic_data)
+    world.learning_role.load_inter_episodic_data(inter_episodic_data, terminate_learning=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #571 

## Description
So, I am pretty sure that loading the strategies after the learning is finished does not work as intended. We currently overwrite everything we read from the specified path with the actors and critics stored in the inter episodic dict. In an attempt to fix that, I noticed that the terminate learning function is not properly executed.

The learning mode should be False while it is still True for the learning_role, which we call 'load_interepisodic_data()'. Now comes the thing, the terminate learning in the 'worl.setup()' call beforehand leads to the 'learning_role' not being initialized at all. Hence, the 'learning_role.learning_mode()' is also not false.

I suggested fixing the wrong reading of the policy in the last step. However, the 'terminate_learning' is not working as intended and should be locked. Let's discuss!

## Changes Proposed
- suggested using terminate learning in initialize policy function
-

## Testing
Briefly tested in 02c

## Checklist
Please check all applicable items:

- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0
