### PR TITLE
Fix loading sequence after DRL training

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -115,7 +115,7 @@ class UnitsOperator(Role):
             self.store_units(),
             1,  # register after time was updated for the first time
         )
-        
+
     async def store_units(self) -> None:
         db_addr = self.context.data.get("output_agent_addr")
         logger.debug("store units to %s", db_addr)

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -142,12 +142,6 @@ class Learning(Role):
         self.db_addr = None
         self.freq_timedelta = None
         self.time_steps = None
-        
-        # test if the training episodes are higher than the eval runs + intial_expereicen
-        if self.training_episodes < (self.episodes_collecting_initial_experience + learning_config.get("validation_episodes_interval", 5)):
-            raise ValueError(
-                f"Training episodes {self.training_episodes} need to be higher than the episodes collecting initial experience {self.episodes_collecting_initial_experience} and one evaluation interval {learning_config.get('validation_episodes_interval', 5)}."
-                )
 
     def load_inter_episodic_data(self, inter_episodic_data):
         """

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -142,6 +142,12 @@ class Learning(Role):
         self.db_addr = None
         self.freq_timedelta = None
         self.time_steps = None
+        
+        # test if the training episodes are higher than the eval runs + intial_expereicen
+        if self.training_episodes < (self.episodes_collecting_initial_experience + learning_config.get("validation_episodes_interval", 5)):
+            raise ValueError(
+                f"Training episodes {self.training_episodes} need to be higher than the episodes collecting initial experience {self.episodes_collecting_initial_experience} and one evaluation interval {learning_config.get('validation_episodes_interval', 5)}."
+                )
 
     def load_inter_episodic_data(self, inter_episodic_data):
         """

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -1076,8 +1076,6 @@ def run_learning(
         terminate_learning=True,
     )
 
-    world.learning_role.load_inter_episodic_data(inter_episodic_data)
-
 
 if __name__ == "__main__":
     data = read_grid(Path("examples/inputs/example_01d"))

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -976,6 +976,16 @@ def run_learning(
         world.learning_config.get("validation_episodes_interval", 5),
     )
 
+    # Ensure training episodes exceed the sum of initial experience and one evaluation interval
+    min_required_episodes = (
+        world.learning_role.episodes_collecting_initial_experience + validation_interval
+    )
+
+    if world.learning_role.training_episodes < min_required_episodes:
+        raise ValueError(
+            f"Training episodes ({world.learning_role.training_episodes}) must be greater than the sum of initial experience episodes ({world.learning_role.episodes_collecting_initial_experience}) and evaluation interval ({validation_interval})."
+        )
+
     eval_episode = 1
 
     for episode in tqdm(

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -39,18 +39,6 @@ class AbstractLearningStrategy(LearningStrategy):
         ).to(self.device)
         self.actor.load_state_dict(params["actor"])
 
-        if self.learning_mode:
-            self.actor_target = self.actor_architecture_class(
-                obs_dim=self.obs_dim,
-                act_dim=self.act_dim,
-                float_type=self.float_type,
-                unique_obs_dim=self.unique_obs_dim,
-                num_timeseries_obs_dim=self.num_timeseries_obs_dim,
-            ).to(self.device)
-            self.actor_target.load_state_dict(params["actor_target"])
-            self.actor_target.eval()
-            self.actor.optimizer.load_state_dict(params["actor_optimizer"])
-
     def prepare_observations(self, unit, market_id):
         # scaling factors for the observations
         upper_scaling_factor_price = max(unit.forecaster[f"price_{market_id}"])

--- a/assume/world.py
+++ b/assume/world.py
@@ -321,6 +321,10 @@ class World:
                 freq=self.forecaster.index.freq,
             )
 
+        else:
+            self.learning_role = None
+            self.learning_agent_addr = None
+
     def setup_output_agent(
         self,
         save_frequency_hours: int,

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,8 +12,11 @@ Upcoming Release
   The features in this section are not released yet, but will be part of the next release! To use the features already you have to install the main branch,
   e.g. ``pip install git+https://github.com/assume-framework/assume``
 
+**Bug Fixes:**
 
-0.5.2 - (21th March 2025)
+- **Last policy loading**: Fixed a bug where the last policy loaded after a training run was not the best policy, but rather the last policy.
+
+0.5.2 - (21st March 2025)
 =========================
 
 **New Features:**


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #571 

## Description
This PR fixes the incorrect policy loading sequence after learning. Previously, the best policies were mistakenly overwritten by the policies from the last episode. This was initially mentioned in #572 

## Changes Proposed
- Do not create the learning role and set it to `None` when not in learning or evaluation mode.
- Remove the loading of inter-episodic data after learning is completed, as it is redundant.
- Remove the loading of target networks from strategies, since this is unused and is instead handled directly by the learning role during training.

## Testing
[Describe the testing you've done, including any specific test cases or scenarios]

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [x] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
[Add screenshots to demonstrate visual changes]
