### PR TITLE
Enable changing number of learning agents in continue_learning mode

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -115,7 +115,7 @@ class UnitsOperator(Role):
             self.store_units(),
             1,  # register after time was updated for the first time
         )
-        
+
     async def store_units(self) -> None:
         db_addr = self.context.data.get("output_agent_addr")
         logger.debug("store units to %s", db_addr)

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,11 @@ Upcoming Release
   The features in this section are not released yet, but will be part of the next release! To use the features already you have to install the main branch,
   e.g. ``pip install git+https://github.com/assume-framework/assume``
 
+**Improvements:**
+
+- **Flexible Agent Count in `continue_learning` Mode:** You can now change the number of learning agents between training runs while reusing previously trained critics.
+  This enables flexible workflows like training power plants first and adding storage units later. When the core architectures match, critic weights are partially transferred when possible, ensuring smoother transitions.
+
 
 0.5.2 - (21th March 2025)
 =========================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Description
This PR allows us to change the number of learning agents between training runs while still reusing previously trained critics in `continue_learning` mode.

Useful for scenarios like training power plants first and later adding storage units or adjusting the number of agents.

## Changes Proposed
- Add weight transfer logic to adapt critic weights when agent count changes
- Perform architecture check before loading critics; if mismatched, safely transfer compatible weights
- Transfer logic copies:
  - Shared observation weights
  - Unique per-agent obs and action weights for overlapping agents only
- Add `strategy.loaded` flag to mark strategies loaded from file
- In `continue_learning`, disable initial exploration only for loaded strategies
- Move common attributes of learning strategies into base class


## Testing
Tested on RL cases by changing the number of units in the simulation

## Checklist
Please check all applicable items:

- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (if applicable)
[Any additional information, concerns, or areas you want reviewers to focus on]

## Screenshots (if applicable)
[Add screenshots to demonstrate visual changes]
