### PR TITLE
Add single bid DRL strategy

### DIFF
--- a/assume/strategies/__init__.py
+++ b/assume/strategies/__init__.py
@@ -50,10 +50,12 @@ bidding_strategies: dict[str, BaseStrategy] = {
 try:
     from assume.strategies.learning_strategies import (
         RLStrategy,
+        RLStrategySingleBid,
         StorageRLStrategy,
     )
 
     bidding_strategies["pp_learning"] = RLStrategy
+    bidding_strategies["pp_learning_single_bid"] = RLStrategySingleBid
     bidding_strategies["storage_learning"] = StorageRLStrategy
 
 except ImportError:

--- a/docs/source/learning_algorithm.rst
+++ b/docs/source/learning_algorithm.rst
@@ -60,7 +60,7 @@ The continue learning function allows you to load pre-trained strategies (actor 
 
 To use this feature, you need to set the ``continue_learning`` config item to ``True`` and specify the path where the pre-trained strategies are stored in the ``trained_policies_load_path`` config item. The path you specify here is relative to the folder in which the rest of your input data is stored.
 
-The learning process will then start from these pre-trained networks instead of initializing new ones. As described in :doc:`learning_implementation`, the critics are used to evaluate the actions of the actor based on global information. The dimensions of this global observation depend on the number of agents in the simulation.
+The learning process will then start from these pre-trained networks instead of initializing new ones. As described in :ref:`learning_implementation`, the critics are used to evaluate the actions of the actor based on global information. The dimensions of this global observation depend on the number of agents in the simulation.
 
 In other words, the input layer of the critics will vary depending on the number of agents. To enable the use of continue learning between simulations with varying agent sizes, a mapping is implemented that ensures the loaded critics are adapted to match the new number of agents.
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,11 @@ Upcoming Release
   The features in this section are not released yet, but will be part of the next release! To use the features already you have to install the main branch,
   e.g. ``pip install git+https://github.com/assume-framework/assume``
 
+**New Features:**
+
+- **Add single bid RL strategy:** Added a new reinforcement learning strategy that allows agents to submit bids based on one action value only that determines the price at which the full capacity is offered.
+
+
 **Improvements:**
 
 - **Flexible Agent Count in `continue_learning` Mode:** You can now change the number of learning agents between training runs while reusing previously trained critics.

--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -9,7 +9,7 @@ import pytest
 
 try:
     from assume.reinforcement_learning.learning_role import LearningConfig
-    from assume.strategies.learning_strategies import RLStrategy
+    from assume.strategies.learning_strategies import RLStrategy, RLStrategySingleBid
 except ImportError:
     pass
 
@@ -21,7 +21,7 @@ end = datetime(2023, 7, 2)
 
 
 @pytest.fixture
-def power_plant_mcp() -> PowerPlant:
+def power_plant() -> PowerPlant:
     # Create a PowerPlant instance with some example parameters
     index = pd.date_range("2023-06-30 22:00:00", periods=48, freq="h")
     ff = NaiveForecast(index, availability=1, fuel_price=10, co2_price=10)
@@ -50,96 +50,65 @@ def power_plant_mcp() -> PowerPlant:
     )
 
 
-@pytest.fixture
-def power_plant_lstm() -> PowerPlant:
-    # Create a PowerPlant instance with some example parameters
-    index = pd.date_range("2023-06-30 22:00:00", periods=48, freq="h")
-    ff = NaiveForecast(index, availability=1, fuel_price=10, co2_price=10)
+@pytest.mark.require_learning
+@pytest.mark.parametrize(
+    "strategy_class, obs_dim, act_dim, actor_architecture, expected_bid_count, expected_volumes",
+    [
+        (RLStrategy, 50, 2, "mlp", 2, [200, 800]),
+        (RLStrategy, 50, 2, "lstm", 2, [200, 800]),
+        (RLStrategySingleBid, 74, 1, "mlp", 1, [1000]),
+    ],
+)
+def test_learning_strategies_parametrized(
+    mock_market_config,
+    power_plant,
+    strategy_class,
+    obs_dim,
+    act_dim,
+    actor_architecture,
+    expected_bid_count,
+    expected_volumes,
+):
+    product_index = pd.date_range("2023-07-01", periods=1, freq="h")
+    mc = mock_market_config
+    mc.product_type = "energy_eom"
+    product_tuples = [
+        (start, start + pd.Timedelta(hours=1), None) for start in product_index
+    ]
+
+    # Build learning config dynamically
     learning_config: LearningConfig = {
-        "observation_dimension": 50,
-        "action_dimension": 2,
+        "observation_dimension": obs_dim,
+        "action_dimension": act_dim,
         "algorithm": "matd3",
-        "actor_architecture": "lstm",
         "learning_mode": True,
         "training_episodes": 3,
-        "unit_id": "test_pp",
+        "unit_id": power_plant.id,
     }
+    if actor_architecture != "mlp":
+        learning_config["actor_architecture"] = actor_architecture
 
-    return PowerPlant(
-        id="test_pp",
-        unit_operator="test_operator",
-        technology="coal",
-        index=ff.index,
-        max_power=1000,
-        min_power=200,
-        efficiency=0.5,
-        additional_cost=10,
-        bidding_strategies={"EOM": RLStrategy(**learning_config)},
-        fuel_type="lignite",
-        emission_factor=0.5,
-        forecaster=ff,
-    )
+    # Override the strategy
+    power_plant.bidding_strategies["EOM"] = strategy_class(**learning_config)
 
+    strategy = power_plant.bidding_strategies["EOM"]
+    bids = strategy.calculate_bids(power_plant, mc, product_tuples=product_tuples)
 
-@pytest.mark.require_learning
-def test_learning_strategies(mock_market_config, power_plant_mcp):
-    product_index = pd.date_range("2023-07-01", periods=1, freq="h")
-    mc = mock_market_config
-    mc.product_type = "energy_eom"
-    product_tuples = [
-        (start, start + pd.Timedelta(hours=1), None) for start in product_index
-    ]
-
-    strategy = power_plant_mcp.bidding_strategies["EOM"]
-    bids = strategy.calculate_bids(power_plant_mcp, mc, product_tuples=product_tuples)
-
-    assert len(bids) == 2
-    assert bids[0]["volume"] == 200
-    assert bids[1]["volume"] == 800
+    assert len(bids) == expected_bid_count
+    for bid, expected_volume in zip(bids, expected_volumes):
+        assert bid["volume"] == expected_volume
 
     for order in bids:
         order["accepted_price"] = 50
         order["accepted_volume"] = order["volume"]
 
-    strategy.calculate_reward(power_plant_mcp, mc, orderbook=bids)
-    reward = power_plant_mcp.outputs["reward"].loc[product_index]
-    profit = power_plant_mcp.outputs["profit"].loc[product_index]
-    regret = power_plant_mcp.outputs["regret"].loc[product_index]
-    costs = power_plant_mcp.outputs["total_costs"].loc[product_index]
+    strategy.calculate_reward(power_plant, mc, orderbook=bids)
+    reward = power_plant.outputs["reward"].loc[product_index]
+    profit = power_plant.outputs["profit"].loc[product_index]
+    regret = power_plant.outputs["regret"].loc[product_index]
+    costs = power_plant.outputs["total_costs"].loc[product_index]
 
     assert reward[0] == 0.01
     assert profit[0] == 1000.0
     assert regret[0] == 0.0
-    assert costs[0] == 40000.0
-
-
-@pytest.mark.require_learning
-def test_lstm_learning_strategies(mock_market_config, power_plant_lstm):
-    product_index = pd.date_range("2023-07-01", periods=1, freq="h")
-    mc = mock_market_config
-    mc.product_type = "energy_eom"
-    product_tuples = [
-        (start, start + pd.Timedelta(hours=1), None) for start in product_index
-    ]
-
-    strategy = power_plant_lstm.bidding_strategies["EOM"]
-    bids = strategy.calculate_bids(power_plant_lstm, mc, product_tuples=product_tuples)
-
-    assert len(bids) == 2
-    assert bids[0]["volume"] == 200
-    assert bids[1]["volume"] == 800
-
-    for order in bids:
-        order["accepted_price"] = 50
-        order["accepted_volume"] = order["volume"]
-
-    strategy.calculate_reward(power_plant_lstm, mc, orderbook=bids)
-    reward = power_plant_lstm.outputs["reward"].loc[product_index]
-    profit = power_plant_lstm.outputs["profit"].loc[product_index]
-    regret = power_plant_lstm.outputs["regret"].loc[product_index]
-    costs = power_plant_lstm.outputs["total_costs"].loc[product_index]
-
-    assert reward[0] == 0.01
-    assert profit[0] == 1000.0
-    assert regret[0] == 0.0
-    assert costs[0] == 40000.0
+    assert costs[0] == 40000.0  # Assumes hot_start_cost = 20000 by default

--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -11,9 +11,9 @@ try:
     from assume.reinforcement_learning.learning_role import LearningConfig
     from assume.strategies.learning_strategies import RLStrategy, RLStrategySingleBid
 
-    HAS_RL = True
 except ImportError:
-    HAS_RL = False
+    RLStrategy = None
+    RLStrategySingleBid = None
 
 from assume.common.forecasts import NaiveForecast
 from assume.units import PowerPlant
@@ -52,7 +52,7 @@ def power_plant() -> PowerPlant:
     )
 
 
-@pytest.mark.skipif(not HAS_RL, reason="Reinforcement learning module not available")
+@pytest.mark.require_learning
 @pytest.mark.parametrize(
     "strategy_class, obs_dim, act_dim, actor_architecture, expected_bid_count, expected_volumes",
     [

--- a/tests/test_rl_strategies.py
+++ b/tests/test_rl_strategies.py
@@ -10,8 +10,10 @@ import pytest
 try:
     from assume.reinforcement_learning.learning_role import LearningConfig
     from assume.strategies.learning_strategies import RLStrategy, RLStrategySingleBid
+
+    HAS_RL = True
 except ImportError:
-    pass
+    HAS_RL = False
 
 from assume.common.forecasts import NaiveForecast
 from assume.units import PowerPlant
@@ -50,7 +52,7 @@ def power_plant() -> PowerPlant:
     )
 
 
-@pytest.mark.require_learning
+@pytest.mark.skipif(not HAS_RL, reason="Reinforcement learning module not available")
 @pytest.mark.parametrize(
     "strategy_class, obs_dim, act_dim, actor_architecture, expected_bid_count, expected_volumes",
     [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Description  
Adds a single-bid DRL strategy. To be merged after #574.

## Proposed Changes  
- Add a new single-bid DRL strategy for power plants to enable compatible simulations with storage units as well as the simulation of renewable energy generators  
- Make the DRL bidding strategies' initialization more flexible by allowing changes to the default observation and action dimensions  
- Refactor DRL strategy tests to use parametrization for improved modularity

## Testing
Added a new test for the bidding strategy.

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [x] New unit tests added for new features or bug fixes
- [x] Existing tests pass with the changes
- [x] Reinforcement learning examples are operational (for DRL-related changes)
- [x] Code tested with both local and Docker databases
- [x] Code follows project style guidelines and best practices
- [x] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [x] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

