### PR TITLE
Fixes the bug in 'aggregate_step_amount' method

### DIFF
--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -293,7 +293,7 @@ def aggregate_step_amount(orderbook: Orderbook, begin=None, end=None, groupby=No
         elif isinstance(bid["accepted_volume"], dict):
             start_hour = bid["start_time"]
             end_hour = bid["end_time"]
-            duration = (start_hour - end_hour) / len(bid["accepted_volume"])
+            duration = (end_hour - start_hour) / len(bid["accepted_volume"])
             for key in bid["accepted_volume"].keys():
                 deltas.append((key, bid["accepted_volume"][key]) + add)
                 deltas.append((key + duration, -bid["accepted_volume"][key]) + add)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -274,6 +274,78 @@ def test_aggregate_step_amount_long():
     # this returns the bids in a minimal representation
 
 
+def test_aggregate_step_amount_block_bid():
+    # create a 3-hour block bid from 00:00 to 03:00 with accepted volumes 1, 2, 3
+    index = pd.date_range(start=datetime(2020, 1, 1, 0), periods=3, freq="1h")
+    accepted = {dt: i + 1 for i, dt in enumerate(index)}  # {00:00→1, 01:00→2, 02:00→3}
+    orderbook = [
+        {
+            "start_time": index[0],
+            "end_time": index[-1] + timedelta(hours=1),  # 00:00→03:00
+            "only_hours": None,
+            "accepted_volume": accepted,
+        },
+    ]
+
+    # aggregate over the full interval
+    result = aggregate_step_amount(
+        orderbook,
+        begin=datetime(2020, 1, 1, 0),
+        end=datetime(2020, 1, 1, 4),
+    )
+
+    # we expect:
+    # at 00:00 →  1
+    # at 01:00 →  2 (1 removed, 2 added ⇒ 2)
+    # at 02:00 →  3 (2 removed, 3 added ⇒ 3)
+    # at 03:00 →  0 (3 removed ⇒ 0)
+    expected = [
+        [pd.Timestamp(2020, 1, 1, 0), 1.0],
+        [pd.Timestamp(2020, 1, 1, 1), 2.0],
+        [pd.Timestamp(2020, 1, 1, 2), 3.0],
+        [pd.Timestamp(2020, 1, 1, 3), 0.0],
+    ]
+
+    assert result == expected
+
+
+def test_mixed_block_and_simple_bid():
+    # Block bid 00→02h, volumes 5, 5
+    idx = pd.date_range("2020-01-01 00:00", periods=2, freq="1h")
+    accepted = {ts: 5.0 for ts in idx}
+    bb = {
+        "start_time": idx[0],
+        "end_time": idx[-1] + timedelta(hours=1),
+        "only_hours": None,
+        "accepted_volume": accepted,
+    }
+    # Simple bid 01→03h, volume 3
+    sb = {
+        "start_time": datetime(2020, 1, 1, 1),
+        "end_time": datetime(2020, 1, 1, 3),
+        "only_hours": None,
+        "accepted_volume": 3.0,
+    }
+
+    result = aggregate_step_amount(
+        [bb, sb], begin=datetime(2020, 1, 1, 0), end=datetime(2020, 1, 1, 4)
+    )
+
+    # Expected step-function:
+    # 00:00 →  5.0
+    # 01:00 →  5.0 + 3.0 = 8.0
+    # 02:00 →  0.0 + 3.0 = 3.0  (block bid ends)
+    # 03:00 →  0.0              (simple bid ends)
+    expected = [
+        [pd.Timestamp("2020-01-01 00:00"), 5.0],
+        [pd.Timestamp("2020-01-01 01:00"), 8.0],
+        [pd.Timestamp("2020-01-01 02:00"), 3.0],
+        [pd.Timestamp("2020-01-01 03:00"), 0.0],
+    ]
+
+    assert result == expected
+
+
 def test_initializer():
     class Test:
         @initializer


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Related Issue
Closes #580 

## Description
Fixes the bug where 'aggregate_step_amount' method returned a wrong value for block bids

## Changes Proposed
- fix the bug
- add test to catch such possible mistakes in the future

## Testing
Added additional tests for block and mixes bids to catch this wrong behavior


- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

