### PR TITLE
pin xarray version to before v2025.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "pyyaml >=6.0",
     "pyyaml-include >=2.2a",
     "pyomo >=6.8.0",
+    "xarray <2025.7.0", # https://github.com/PyPSA/linopy/issues/470
     "highspy",
 ]
 


### PR DESCRIPTION

# Pull Request

This pins xarray to before v2025.7.0 to fix the issue in pypsa.


## Related Issue
Closes #602 

https://github.com/PyPSA/linopy/issues/470
https://github.com/PyPSA/PyPSA/pull/1274

## Description
Pin the xarray version for now as the new xarray release seems to include breaking changes.
