### PR TITLE
outputs: sort dataframe columns before writing CSV

### DIFF
--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -508,6 +508,8 @@ class WriteOutput(Role):
 
             # check for tensors and convert them to floats
             df = df.apply(convert_tensors)
+            # sort dataframes by column names for consistent CSVs
+            df = df.reindex(sorted(df.columns), axis=1)
 
             # check for any float64 columns and convert them to floats
             df = df.map(lambda x: float(x) if isinstance(x, np.float64) else x)


### PR DESCRIPTION
For whatever reason, the order of columns in the dataframe unit_dispatch is not consistent in `example_03d`.

It seems that we can't rely on having the same initialization order of the dataframes here, so sorting the columns by name in the dataframe is a good solution to get a consistent column order of the pandas DataFrame - and therefore also of the written CSVs.

This does only affect the CSV files, which are appended to the same file, while the database writer matches the columns of the existing table with the previous one by name and is therefore not affected.

Thanks @dlr-cjs for reporting this.

Fixes #600