### PR TITLE
docker: fix build by pinning pip-tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,8 @@ RUN useradd -m -s /bin/bash admin
 RUN mkdir /src
 WORKDIR /src
 COPY README.md pyproject.toml .
-#RUN python -m pip install --upgrade pip
-# that's needed to use create the requirements.txt only
-RUN pip install pip-tools
+# https://github.com/jazzband/pip-tools/pull/2221
+RUN pip install "pip-tools<7.5.0"
 RUN mkdir assume assume_cli
 RUN touch assume/__init__.py
 RUN pip-compile --resolver=backtracking -o requirements.txt ./pyproject.toml


### PR DESCRIPTION
# Pull Request

There is an issue with self-referential packages in a pyproject.toml with the latest pip-tools release.
The self-referential [all] package, which is not written to the requirements.txt as it is not selected still throws a pip-compile error.

More information for this can be found in the ticket: https://github.com/jazzband/pip-tools/issues/2215

The pin should be removed when https://github.com/jazzband/pip-tools/pull/2221 gets merged.
