### PR TITLE
Added case for non accepted order in dispatch plan for base unit

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -164,7 +164,9 @@ class BaseUnit:
             self.outputs[product_type].loc[start:end_excl] += added_volume
 
             # Get the accepted price and store it in the outputs
-            if isinstance(order["accepted_price"], dict):
+            if "accepted_price" not in order:
+                accepted_price = 0
+            elif isinstance(order["accepted_price"], dict):
                 accepted_price = list(order["accepted_price"].values())
             else:
                 accepted_price = order["accepted_price"]


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request

## Description
Adds new case for not accepted orders preventing errors in set_dispatch_plan method of baseUnit

## Changes Proposed
- Currently, not accepted orders returned to unit lead to error in dispatch plan, as "accepted_price" key is not set in order object
- New case prevents this error and sets accepted price to 0.

## Testing
No testing

## Checklist
Please check all applicable items:

- [x] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0
