### PR TITLE
Add action + noise clamping based on NN architecture 

### DIFF
--- a/assume/reinforcement_learning/neural_network_architecture.py
+++ b/assume/reinforcement_learning/neural_network_architecture.py
@@ -130,6 +130,10 @@ class MLPActor(Actor):
         # Initialize weights
         self._init_weights()
 
+        # call forward pass with high obs value array to get max value of output layer
+        self.max_output = self.forward(th.ones(obs_dim, dtype=float_type) * 1000)
+        self.min_output = self.forward(th.ones(obs_dim, dtype=float_type) * -1000)
+
     def _init_weights(self):
         """Apply Xavier initialization to all layers."""
 
@@ -192,6 +196,10 @@ class LSTMActor(Actor):
         # input size defined by forecast horizon and concatenated with capacity and marginal cost values
         self.FC1 = nn.Linear(self.timeseries_len * 16 + 2, 128, dtype=float_type)
         self.FC2 = nn.Linear(128, act_dim, dtype=float_type)
+
+        # call forward pass with high obs value array to get max value of output layer
+        self.max_output = self.forward(th.ones(obs_dim, dtype=float_type) * 1000)
+        self.min_output = self.forward(th.ones(obs_dim, dtype=float_type) * -1000)
 
     def forward(self, obs):
         if obs.dim() not in (1, 2):

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -275,6 +275,11 @@ class BaseLearningStrategy(LearningStrategy):
                     device=self.device, dtype=self.float_type
                 )
                 curr_action += noise
+
+                # make sure that noise adding does not exceed the actual output of the NN as it pushes results in a direction that actor can't even reach
+                curr_action = th.clamp(
+                    curr_action, self.actor.min_output, self.actor.max_output
+                )
         else:
             # if we are not in learning mode we just use the actor neural net to get the action without adding noise
             curr_action = self.actor(next_observation).detach()
@@ -758,7 +763,7 @@ class RLStrategySingleBid(RLStrategy):
         # =============================================================================
         # 3. Transform Actions into bids
         # =============================================================================
-        # actions are in the range [-1,1], we need to transform them into actual bids
+        # actions are in the range [-1,1] + noise, we need to transform them into actual bids
         # we can use our domain knowledge to guide the bid formulation
         bid_price = actions[0] * self.max_bid_price
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

# Pull Request


## Description
This PR introduces changes to ensure that the action outputs of the actor network are always clamped to the valid output range, which is now dynamically determined based on the actor architecture. This prevents exploration noise from pushing actions outside the actor's achievable output space, ensuring more robust and consistent bidding behavior.

## Changes Proposed
- Added logic to clamp actions to the actor's output range after noise is applied.
- Output range ([min_output], [max_output]) is now determined by the actor architecture, allowing for automatic adaptation if the architecture or activation function changes.
- Updated [BaseLearningStrategy.get_actions] to use these dynamic output bounds.

## Testing
Manual tests performed by running training and evaluation with different actor architectures and verifying that actions remain within the expected output range.
Checked that bids generated from actions do not exceed the defined maximum bid price, even with high exploration noise.
No errors or unexpected behaviors observed during simulation runs.

## Checklist
Please check all applicable items:

- [ ] Code changes are sufficiently documented (docstrings, inline comments, `doc` folder updates)
- [ ] New unit tests added for new features or bug fixes
- [ ] Existing tests pass with the changes
- [ ] Reinforcement learning examples are operational (for DRL-related changes)
- [ ] Code tested with both local and Docker databases
- [ ] Code follows project style guidelines and best practices
- [ ] Changes are backwards compatible, or deprecation notices added
- [ ] New dependencies added to `pyproject.toml`
- [ ] A note for the release notes `doc/release_notes.rst` of the upcoming release is included
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

