### PR TITLE
setup improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cd assume
 2. Start the database and Grafana using the following command:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
 This will launch a container for TimescaleDB and Grafana with preconfigured dashboards for analysis.

--- a/docker_configs/datasources/datasource.yml
+++ b/docker_configs/datasources/datasource.yml
@@ -21,6 +21,7 @@ datasources:
   secureJsonData:
     password: assume
   jsonData:
+    database: assume
     sslmode: "disable"
     postgresVersion: 1600
     timescaledb: true


### PR DESCRIPTION
1. Specify the default database in the datasource.yml to prevent a manual setup
2. Use the new `docker compose` semantics instead of `docker-compose`