### PR TITLE
enable adding existing units directly to the world

### DIFF
--- a/assume/world.py
+++ b/assume/world.py
@@ -615,14 +615,24 @@ class World:
             unit_operator_id (str): The identifier of the unit operator.
         """
 
-        if unit_operator_id not in self.unit_operators:
-            raise ValueError(f"Invalid unit operator: {unit_operator_id}")
+        self._validate_unit_operator(unit_operator_id)
 
         if unit_type not in self.unit_types:
             raise ValueError(f"Invalid unit type: {unit_type}")
 
         if self.unit_operators[unit_operator_id].units.get(id):
             raise ValueError(f"Unit {id} already exists")
+
+    def _validate_unit_operator(self, unit_operator_id: str):
+        """
+        Validate the existence of a unit operator in the simulation.
+
+        Args:
+            unit_operator_id (str): The identifier for the unit operator.
+        """
+
+        if unit_operator_id not in self.unit_operators.keys():
+            raise ValueError(f"Invalid unit operator: {unit_operator_id}")
 
     def add_market_operator(self, id: str) -> None:
         """
@@ -795,7 +805,7 @@ class World:
         forecaster: Forecaster,
     ) -> None:
         """
-        Add a unit to the World instance.
+        Creates a unit and adds it to the World instance.
 
         This method checks if the unit operator exists, verifies the unit type, and ensures that the unit operator
         does not already have a unit with the same id. It then creates bidding strategies for the unit and creates
@@ -817,3 +827,16 @@ class World:
         )
 
         self.unit_operators[unit_operator_id].add_unit(unit)
+
+    def add_unit_instance(self, operator_id: str, unit: BaseUnit):
+        """
+        Add an existing unit to the World instance.
+
+        This method checks if the unit operator exists and then assigns the provided unit instance to it.
+
+        Args:
+            operator_id (str): The identifier of the unit operator.
+            unit (BaseUnit): The unit instance to be added.
+        """
+        self._validate_unit_operator(operator_id)
+        self.unit_operators[operator_id].add_unit(unit)

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -7,6 +7,7 @@ import asyncio
 from assume import World
 from assume.common.forecasts import NaiveForecast
 from assume.scenario.loader_csv import load_scenario_folder
+from assume.units.demand import Demand
 from tests.utils import index, setup_simple_world
 
 
@@ -39,6 +40,25 @@ def test_world_operators_default():
             "bidding_strategies": {},
         },
         forecaster=NaiveForecast(index, demand=100),
+    )
+    assert "test_operator" in world.unit_operators
+    assert len(world.unit_operators["test_operator"].units) == 1
+
+
+def test_world_operators_by_instance():
+    world = setup_simple_world()
+    world.add_unit_operator("test_operator")
+    world.add_unit_instance(
+        operator_id="test_operator",
+        unit=Demand(
+            id="test_unit",
+            unit_operator="test_operator",
+            min_power=0,
+            max_power=1000,
+            technology="demand",
+            bidding_strategies={},
+            forecaster=NaiveForecast(index, demand=100),
+        ),
     )
     assert "test_operator" in world.unit_operators
     assert len(world.unit_operators["test_operator"].units) == 1


### PR DESCRIPTION
Enable users to add existing units to a World. This might be more user-friendly, since users now don't have to lookup the config properties of the desired unit but instead see them when directly creating a concrete unit type. 