### PR TITLE
improve error message when learning without given database

### DIFF
--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -1083,6 +1083,9 @@ def run_learning(
 
             world.learning_role.tensor_board_logger.update_tensorboard()
 
+            if not world.db_uri:
+                raise AssumeException("No learning rewards as no database was given")
+
             total_rewards = world.output_role.get_sum_reward(episode=eval_episode)
 
             if len(total_rewards) == 0:


### PR DESCRIPTION
Learning without a connected database fails with `No rewards were collected during evaluation run` when no database is configured.

Example: `assume -s example_02c`

This should provide a better warning.

A potential fix is to simply add the database `assume -s example_02c -db "postgresql://assume:assume@localhost:5432/assume"`

With this PR a more helpful hint is given in these cases