### PR TITLE
tests: utcoffset of timestamp(0) did fail on windows

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -18,6 +18,7 @@ Upcoming Release
 - **Adjusted reward scaling**: Reward scaling now considers current available power instead of the unit’s max_power, reducing reward distortion when availability limits capacity. Available power is now derived from offered_order_volume instead of unit.calculate_min_max_power. Because dispatch is set before reward calculation, the previous method left available power at 0 whenever the unit was dispatched.
 - **Update pytest dependency**: Tests now run with Pytest 9
 - **Add new docs feature**: dependencies to build docs can now be installed with `pip install -e .[docs]`
+- **Fix tests on Windows**: One test was always failing on Windows, which is fixed so that all tests succeed on all archs
 
   **New Features:**
 - **Unit Operator Portfolio Strategy**: A new bidding strategy type that enables portfolio optimization, where the default is called `DirectUnitOperatorStrategy`. This strategy simply passes through bidding decisions of individual units within a portfolio, which was the default behavior beforehand as well. Further we added 'CournotPortfolioStrategy' which allows to model bidding behavior of a portfolio of units in a day-ahead market. The strategy calculates the optimal bid price and quantity for each unit in the portfolio, taking into account markup and the production costs of the units. This enables users to simulate and analyze the impact of strategic portfolio bidding on market outcomes and unit profitability.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -494,7 +494,8 @@ def test_broken_timestamps():
 
     unix_epoch_start = datetime.fromtimestamp(0)
     true_unix_epoch_start = unix_start
-    offset = tzlocal().utcoffset(datetime.fromtimestamp(0))
+    # offset = tzlocal().utcoffset(datetime.fromtimestamp(0))
+    offset = tzlocal().utcoffset(datetime(2020, 1, 1))
     # this should be 1970-01-01-00-00 but it isn't (when run in CET locale)
     # so we always have this offset
     assert true_unix_epoch_start + offset == unix_epoch_start


### PR DESCRIPTION
This is fixed by calculating the utcoffset in 2020 instead of beginning of time, so that all tests pass. It is still unclear, why the utcoffset fails on windows for that, but it isn't a problem anyway, as the date to calculate the offset from in the tests is arbitrary anyhow.

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
