### PR TITLE
fix flaky learning integration test by excluding explore episodes

### DIFF
--- a/tests/test_integration_cli.py
+++ b/tests/test_integration_cli.py
@@ -65,4 +65,5 @@ def test_cli_learning():
             conn,
         )
     assert len(got) == 10
-    assert got["total_reward"][4] < got["total_reward"][9]  # its somehow converging
+    # check improvement during training (excluding initial exploration)
+    assert got["total_reward"][3] < got["total_reward"][9]


### PR DESCRIPTION
<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
## Description
Exclude initial three exploring episodes from learning convergence assumption in the learning integration test

## Checklist
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
