### PR TITLE
Fixup start costs

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -202,7 +202,7 @@ class BaseUnit:
             for idx, t in enumerate(self.index[start:end])
         ]
         generation_costs = np.abs(marginal_costs * product_data)
-        self.outputs[f"{product_type}_generation_costs"].loc[start:end] += (
+        self.outputs[f"{product_type}_generation_costs"].loc[start:end] = (
             generation_costs
         )
 
@@ -224,9 +224,6 @@ class BaseUnit:
         Returns:
             The volume of the unit within the given time range.
         """
-        # TODO for each time, check if start cost must be applied and calculate this
-        # self.outputs["energy"]["start"] +=
-        # cost = self.get_starting_costs(op_time)
         self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
 
@@ -323,7 +320,6 @@ class SupportsMinMax(BaseUnit):
     emission_factor: float
     min_operating_time: int = 1
     min_down_time: int = 1
-    cold_start_cost: float = 0
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -399,9 +395,22 @@ class SupportsMinMax(BaseUnit):
             )
         return power
 
+    def get_max_lookback_optime(self):
+        max_time = max(
+            self.min_operating_time,
+            self.min_down_time,
+            1,
+        )
+        return max_time
+
     def get_operation_time(self, start: datetime) -> int:
         """
         Returns the time the unit is operating (positive) or shut down (negative).
+
+        The lookback window covers the longest of the minimum operating time
+        and the minimum down time (or the warm-start downtime threshold if the
+        subclass defines one), so the value is meaningful both for ramping
+        decisions and for tiering start-up costs (hot / warm / cold).
 
         Args:
             start (datetime.datetime): The start time.
@@ -409,8 +418,8 @@ class SupportsMinMax(BaseUnit):
         Returns:
             int: The operation time as a positive integer if operating, or negative if shut down.
         """
-        # Set the time window based on max of min operating/down time
-        max_time = max(self.min_operating_time, self.min_down_time, 1)
+        max_time = self.get_max_lookback_optime()
+
         begin = max(start - self.index.freq * max_time, self.index[0])
         end = start - self.index.freq
 
@@ -436,24 +445,6 @@ class SupportsMinMax(BaseUnit):
 
         # Return positive time if operating, negative if shut down
         return -run if is_off else run
-
-    def get_starting_costs(self, op_time: int) -> float:
-        """
-        Returns the start-up cost for the given operation time.
-        If operation time is positive, the unit is running, so no start-up costs are returned.
-        If operation time is negative, the unit is not running, so start-up costs are returned
-
-        Args:
-            op_time (float): The time the unit was shut down in hours.
-
-        Returns:
-            float: The starting costs of the unit.
-        """
-        if op_time > 0:
-            # unit is running
-            return 0
-        else:
-            return self.cold_start_cost
 
 
 class SupportsMinMaxCharge(BaseUnit):
@@ -489,7 +480,8 @@ class SupportsMinMaxCharge(BaseUnit):
     capacity: float
     efficiency_charge: float
     efficiency_discharge: float
-    cold_start_cost: float = 0
+    min_operating_time: int = 1
+    min_down_time: int = 1
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -676,24 +668,6 @@ class SupportsMinMaxCharge(BaseUnit):
             # update the values of the state of charge and the energy
             self.outputs["soc"].at[next_t] = soc + delta_soc
             self.outputs["energy"].at[t] = current_power
-
-    def get_starting_costs(self, op_time: int) -> float:
-        """
-        Returns the start-up cost for the given operation time.
-        If operation time is positive, the unit is running, so no start-up costs are returned.
-        If operation time is negative, the unit is not running, so start-up costs are returned
-
-        Args:
-            op_time (float): The time the unit was shut down in hours.
-
-        Returns:
-            float: The starting costs of the unit.
-        """
-        if op_time > 0:
-            # unit is running
-            return 0
-        else:
-            return self.cold_start_cost
 
 
 class BaseStrategy:

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -415,7 +415,7 @@ class SupportsMinMax(BaseUnit):
         end = start - self.index.freq
 
         if start <= self.index[0]:
-            # before start of index
+            # this assumes that all powerplants are running at the start of the simulation
             return max_time
 
         # Check energy output in the defined time window, reversed for most recent state

--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -291,11 +291,11 @@ class BaseUnit:
                 cashflow * elapsed_intervals
             )
 
-    def get_starting_costs(self, op_time: int) -> float:
+    def get_starting_costs(self, op_time: float) -> float:
         """
         Returns the start-up cost for the given operation time.
         If operation time is positive, the unit is running, so no start-up costs are returned.
-        If operation time is negative, the unit is not running, so start-up costs are returned
+        If operation time is negative, the unit is not running, so start-up costs are returned.
 
         Args:
             op_time (float): The time the unit was shut down in hours.
@@ -318,8 +318,8 @@ class SupportsMinMax(BaseUnit):
     ramp_up: float = None
     efficiency: float
     emission_factor: float
-    min_operating_time: int = 1
-    min_down_time: int = 1
+    min_operating_time: float = 0.0
+    min_down_time: float = 0.0
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -345,7 +345,7 @@ class SupportsMinMax(BaseUnit):
 
     def calculate_ramp(
         self,
-        op_time: int,
+        op_time: float,
         previous_power: float,
         power: float,
         current_power: float = 0,
@@ -354,7 +354,7 @@ class SupportsMinMax(BaseUnit):
         Corrects the possible power to offer according to ramping restrictions.
 
         Args:
-            op_time (int): The operation time.
+            op_time (float): The operation time.
             previous_power (float): The previous power output of the unit.
             power (float): The planned power offer of the unit.
             current_power (float): The current power output of the unit.
@@ -395,17 +395,17 @@ class SupportsMinMax(BaseUnit):
             )
         return power
 
-    def get_max_lookback_optime(self):
+    def get_max_lookback_op_time(self):
         max_time = max(
             self.min_operating_time,
             self.min_down_time,
-            1,
+            1.0,
         )
         return max_time
 
-    def get_operation_time(self, start: datetime) -> int:
+    def get_operation_time(self, start: datetime) -> float:
         """
-        Returns the time the unit is operating (positive) or shut down (negative).
+        Returns the time in simulation frequency steps the unit is operating (positive) or shut down (negative).
 
         The lookback window covers the longest of the minimum operating time
         and the minimum down time (or the warm-start downtime threshold if the
@@ -416,15 +416,15 @@ class SupportsMinMax(BaseUnit):
             start (datetime.datetime): The start time.
 
         Returns:
-            int: The operation time as a positive integer if operating, or negative if shut down.
+            float: The operation time as a positive float if operating, or negative if shut down.
         """
-        max_time = self.get_max_lookback_optime()
+        max_time = self.get_max_lookback_op_time()
 
         begin = max(start - self.index.freq * max_time, self.index[0])
         end = start - self.index.freq
 
         if start <= self.index[0]:
-            # this assumes that all powerplants are running at the start of the simulation
+            # This assumes that all units are running at the start of the simulation.
             return max_time
 
         # Check energy output in the defined time window, reversed for most recent state
@@ -435,13 +435,13 @@ class SupportsMinMax(BaseUnit):
             is_off = not arr[0]
         else:
             is_off = False
-        run = 0
+        run = 0.0
 
         # Count consecutive periods with the same status, break on change
         for val in arr:
             if val != (not is_off):  # Stop if the state changes
                 break
-            run += 1
+            run += 1.0
 
         # Return positive time if operating, negative if shut down
         return -run if is_off else run
@@ -480,8 +480,8 @@ class SupportsMinMaxCharge(BaseUnit):
     capacity: float
     efficiency_charge: float
     efficiency_discharge: float
-    min_operating_time: int = 1
-    min_down_time: int = 1
+    min_operating_time: float = 0.0
+    min_down_time: float = 0.0
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -377,7 +377,6 @@ class UnitsOperator(Role):
             current_dispatch = unit.execute_current_dispatch(start, now)
             end = now
             dispatch = {"power": current_dispatch}
-            unit.calculate_generation_cost(start, now, "energy")
             valid_outputs = [
                 "soc",
                 "cashflow",

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -381,6 +381,7 @@ class UnitsOperator(Role):
                 "soc",
                 "cashflow",
                 "generation_costs",
+                "start_costs",
                 "total_costs",
                 "heat",
             ]

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -386,6 +386,7 @@ class UnitsOperator(Role):
                 "soc",
                 "cashflow",
                 "generation_costs",
+                "start_costs",
                 "total_costs",
                 "heat",
             ]

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -382,7 +382,6 @@ class UnitsOperator(Role):
             current_dispatch = unit.execute_current_dispatch(start, now)
             end = now
             dispatch = {"power": current_dispatch}
-            unit.calculate_generation_cost(start, now, "energy")
             valid_outputs = [
                 "soc",
                 "cashflow",

--- a/assume/strategies/dmas_powerplant.py
+++ b/assume/strategies/dmas_powerplant.py
@@ -171,14 +171,14 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
                         <= unit.ramp_down * self.model.z[t]
                     )
             # minimal run and stop time
-            if t > unit.min_down_time:
+            if t > int(unit.min_down_time):
                 self.model.stop_time.add(
                     1 - self.model.z[t]
                     >= quicksum(
                         self.model.w[k] for k in range(t - int(unit.min_down_time), t)
                     )
                 )
-            if t > unit.min_operating_time:
+            if t > int(unit.min_operating_time):
                 self.model.run_time.add(
                     self.model.z[t]
                     >= quicksum(
@@ -519,7 +519,7 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
         yesterday = start.date() - timedelta(days=1)
 
         index = 0
-        runtime = unit.get_operation_time(start)
+        runtime = int(unit.get_operation_time(start))
 
         # TODO add ramping constraints from
         # unit.calculate_ramp(runtime, last_power, unit.min_power)
@@ -535,7 +535,7 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
                 # pwp is on and must runtime is reached
                 if result["power"][0] > 0 and runtime > 0:
                     reduction = 0
-                    hours_needed_to_run = unit.min_operating_time - runtime
+                    hours_needed_to_run = int(unit.min_operating_time) - runtime
                     hours = (
                         list(range(hours_needed_to_run))
                         if hours_needed_to_run > 0

--- a/assume/strategies/dmas_powerplant.py
+++ b/assume/strategies/dmas_powerplant.py
@@ -26,6 +26,7 @@ from pyomo.opt import (
 )
 
 from assume.common.base import MinMaxStrategy, SupportsMinMax
+from assume.common.exceptions import ValidationError
 from assume.common.market_objects import MarketConfig, Orderbook, Product
 from assume.common.utils import get_supported_solver_pyomo
 
@@ -91,7 +92,18 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
         Returns:
             np.ndarray: Cashflow.
         """
-        runtime = runtime or unit.get_operation_time(start)
+        if (
+            unit.index.freq != timedelta(hours=1)
+            or not unit.min_down_time.is_integer()
+            or not unit.min_operating_time.is_integer()
+        ):
+            raise ValidationError(
+                message=f"The DMAS strategy for unit {unit.id} is only applicable with hourly resolution. Check the unit's minimum up/down times and the simulation frequency.",
+                id=self.id,
+                field="unit",
+            )
+
+        runtime = runtime or int(unit.get_operation_time(start))
         p0 = p0 or unit.get_output_before(start)
         self.model.clear()
         tr = np.arange(hour_count)
@@ -163,14 +175,15 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
                 self.model.stop_time.add(
                     1 - self.model.z[t]
                     >= quicksum(
-                        self.model.w[k] for k in range(t - unit.min_down_time, t)
+                        self.model.w[k] for k in range(t - int(unit.min_down_time), t)
                     )
                 )
             if t > unit.min_operating_time:
                 self.model.run_time.add(
                     self.model.z[t]
                     >= quicksum(
-                        self.model.v[k] for k in range(t - unit.min_operating_time, t)
+                        self.model.v[k]
+                        for k in range(t - int(unit.min_operating_time), t)
                     )
                 )
             if t > 0:
@@ -182,9 +195,9 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
                     == 0
                 )
 
-            if runtime > 0 and t < unit.min_operating_time - runtime:
+            if runtime > 0 and t < int(unit.min_operating_time) - runtime:
                 self.model.initial_on.add(self.model.z[t] == 1)
-            elif runtime < 0 and t < unit.min_down_time - (-runtime):
+            elif runtime < 0 and t < int(unit.min_down_time) - (-runtime):
                 self.model.initial_off.add(self.model.z[t] == 0)
 
         # -> fuel costs
@@ -480,7 +493,7 @@ class EnergyOptimizationDmasStrategy(MinMaxStrategy):
             This does search the most profitable hours, even if the first hour might be sufficient to match our marginal costs
             """
             max_profit, start_hour = 0, 0
-            run_time = unit.min_operating_time
+            run_time = int(unit.min_operating_time)
             for t in range(start, hour_count - run_time):
                 p = np.sum(unit.min_power * base_price[t : t + run_time])
 

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -175,20 +175,19 @@ class EnergyHeuristicFlexableStrategy(MinMaxStrategy):
             orderbook (Orderbook): An orderbook with accepted and rejected orders for the unit.
 
         Note:
-            The reward is calculated as the profit minus the opportunity cost,
-            which is the loss of income we have because we are not running at full power.
-            The regret is the opportunity cost.
-            Because the regret_scale is set to 0 the reward equals the profit.
-            The profit is the income we have from the accepted bids.
-            The total costs are the running costs and the start-up costs.
-
+            Generation and start-up costs are the ones booked by
+            :meth:`execute_current_dispatch` into
+            ``{product_type}_generation_costs`` and
+            ``{product_type}_start_costs``. Reading them here keeps
+            ``total_costs`` idempotent when several markets clear for the same
+            window, and avoids double-counting start-up cost (which used to be
+            added both here and in the dispatch executor).
         """
         product_type = marketconfig.product_type
         products_index = get_products_index(orderbook)
 
         # Initialize intermediate results as numpy arrays for better performance
         profit = np.zeros(len(products_index))
-        costs = np.zeros(len(products_index))
 
         # Map products_index to their positions for faster updates
         index_map = {time: i for i, time in enumerate(products_index)}
@@ -204,10 +203,6 @@ class EnergyHeuristicFlexableStrategy(MinMaxStrategy):
             for start in order_times:
                 idx = index_map.get(start)
 
-                marginal_cost = unit.calculate_marginal_cost(
-                    start, unit.outputs[product_type].at[start]
-                )
-
                 if isinstance(accepted_volume, dict):
                     accepted_volume = accepted_volume.get(start, 0)
                 else:
@@ -220,17 +215,14 @@ class EnergyHeuristicFlexableStrategy(MinMaxStrategy):
 
                 profit[idx] += accepted_price * accepted_volume
 
-        # consideration of start-up costs
-        for i, start in enumerate(products_index):
-            op_time = unit.get_operation_time(start)
-
-            output = unit.outputs[product_type].at[start]
-            marginal_cost = unit.calculate_marginal_cost(start, output)
-            costs[i] += marginal_cost * output
-
-            if output != 0 and op_time < 0:
-                start_up_cost = unit.get_starting_costs(op_time)
-                costs[i] += start_up_cost
+        #  TODO not available  yet as generation costs are calculated afterwards
+        generation_costs = unit.outputs[f"{product_type}_generation_costs"].loc[
+            products_index[0] : products_index[-1]
+        ]
+        start_costs = unit.outputs[f"{product_type}_start_costs"].loc[
+            products_index[0] : products_index[-1]
+        ]
+        costs = np.asarray(generation_costs) + np.asarray(start_costs)
 
         profit -= costs
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -1035,7 +1035,9 @@ class StorageEnergyLearningStrategy(TorchLearningStrategy, MinMaxChargeStrategy)
         marginal_cost = unit.calculate_marginal_cost(
             start, unit.outputs[product_type].at[start]
         )
-        marginal_cost += unit.get_starting_costs(int(duration_hours))
+        # Start-up cost is already booked idempotently into
+        # outputs[f"{product_type}_start_costs"] by _book_start_costs.
+        start_cost = unit.outputs[f"{product_type}_start_costs"].at[start]
 
         accepted_volume = order.get("accepted_volume", 0)
         # ignore very small volumes due to calculations
@@ -1044,7 +1046,7 @@ class StorageEnergyLearningStrategy(TorchLearningStrategy, MinMaxChargeStrategy)
 
         # Calculate profit and cost for the order
         order_profit = accepted_price * accepted_volume * duration_hours
-        order_cost = abs(marginal_cost * accepted_volume * duration_hours)
+        order_cost = abs(marginal_cost * accepted_volume * duration_hours) + start_cost
 
         current_soc = unit.outputs["soc"].at[start]
         next_soc = unit.outputs["soc"].at[next_time]
@@ -1263,7 +1265,7 @@ class RenewableEnergyLearningSingleBidStrategy(EnergyLearningSingleBidStrategy):
         # Start-up cost is already booked idempotently into
         # outputs[f"{product_type}_start_costs"] by _book_start_costs in
         # execute_current_dispatch. Read from there instead of recomputing.
-        start_cost = unit.outputs[f"{product_type}_start_costs"].at[start] /2
+        start_cost = unit.outputs[f"{product_type}_start_costs"].at[start] / 2
 
         profit = income - operational_cost - start_cost
 

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -594,6 +594,11 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
         # end includes the end of the last product, to get the last products' start time we deduct the frequency once
         end_excl = end - unit.index.freq
 
+        # profit_series = (
+        #     unit.outputs[f"{product_type}_cashflow"][start:end]
+        #     - unit.outputs[f"{product_type}_generation_costs"][start:end]
+        # )
+
         # Depending on how the unit calculates marginal costs, retrieve cost values.
         marginal_cost = unit.calculate_marginal_cost(
             start, unit.outputs[product_type].at[start]

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -628,17 +628,10 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
             income += order_income
             operational_cost += order_cost
 
-        # Consideration of start-up costs, divided evenly between upward and downward regulation events.
-        if (
-            unit.outputs[product_type].at[start] != 0
-            and unit.outputs[product_type].at[start - unit.index.freq] == 0
-        ):
-            operational_cost += unit.hot_start_cost / 2
-        elif (
-            unit.outputs[product_type].at[start] == 0
-            and unit.outputs[product_type].at[start - unit.index.freq] != 0
-        ):
-            operational_cost += unit.hot_start_cost / 2
+        # Start-up cost is already booked idempotently into
+        # outputs[f"{product_type}_start_costs"] by _book_start_costs in
+        # execute_current_dispatch. Read from there instead of recomputing.
+        operational_cost += unit.outputs[f"{product_type}_start_costs"].at[start]
 
         profit = income - operational_cost
 
@@ -1267,19 +1260,12 @@ class RenewableEnergyLearningSingleBidStrategy(EnergyLearningSingleBidStrategy):
             income += order_income
             operational_cost += order_cost
 
-        # Consideration of start-up costs, divided evenly between upward and downward regulation events.
-        if (
-            unit.outputs[product_type].at[start] != 0
-            and unit.outputs[product_type].at[start - unit.index.freq] == 0
-        ):
-            operational_cost += unit.hot_start_cost / 2
-        elif (
-            unit.outputs[product_type].at[start] == 0
-            and unit.outputs[product_type].at[start - unit.index.freq] != 0
-        ):
-            operational_cost += unit.hot_start_cost / 2
+        # Start-up cost is already booked idempotently into
+        # outputs[f"{product_type}_start_costs"] by _book_start_costs in
+        # execute_current_dispatch. Read from there instead of recomputing.
+        start_cost = unit.outputs[f"{product_type}_start_costs"].at[start] /2
 
-        profit = income - operational_cost
+        profit = income - operational_cost - start_cost
 
         # Stabilizing learning: Limit positive profit to 50% of its absolute value.
         # This reduces variance in rewards and prevents overfitting to extreme profit-seeking behavior.

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -144,26 +144,27 @@ class PowerPlant(SupportsMinMax):
         self.ramp_down = None if ramp_down == 0 else ramp_down
         self.ramp_up = None if ramp_up == 0 else ramp_up
 
+        # Convert time parameters from hours to index steps
+        hours_to_steps = timedelta(hours=1) / self.index.freq
+
         if min_operating_time < 0:
             raise ValidationError(
-                message=f"{min_operating_time=} must be > 0 for unit {self.id}",
+                message=f"{min_operating_time=} must be >= 0 for unit {self.id}",
                 id=self.id,
                 field="min_operating_time",
             )
-        self.min_operating_time = min_operating_time
+        self.min_operating_time = min_operating_time * hours_to_steps
+
         if min_down_time < 0:
             raise ValidationError(
-                message=f"{min_down_time=} must be > 0 for unit {self.id}",
+                message=f"{min_down_time=} must be >= 0 for unit {self.id}",
                 id=self.id,
                 field="min_down_time",
             )
-        self.min_down_time = min_down_time
-        self.downtime_hot_start = downtime_hot_start / (
-            self.index.freq / timedelta(hours=1)
-        )
-        self.downtime_warm_start = downtime_warm_start / (
-            self.index.freq / timedelta(hours=1)
-        )
+        self.min_down_time = min_down_time * hours_to_steps
+
+        self.downtime_hot_start = downtime_hot_start * hours_to_steps
+        self.downtime_warm_start = downtime_warm_start * hours_to_steps
 
         self.marginal_cost = self.calc_simple_marginal_cost()
 

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -193,7 +193,9 @@ class PowerPlant(SupportsMinMax):
             current_power = self.outputs["energy"].at[t]
             previous_power = self.get_output_before(t)
             op_time = self.get_operation_time(t)
-
+            self.outputs["energy_generation_costs"].at[t] += self.get_starting_costs(
+                op_time
+            )
             current_power = self.calculate_ramp(op_time, previous_power, current_power)
 
             if current_power > 0:
@@ -201,7 +203,7 @@ class PowerPlant(SupportsMinMax):
                 current_power = max(current_power, self.min_power)
 
             self.outputs["energy"].at[t] = current_power
-
+        self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
 
     def calc_simple_marginal_cost(
@@ -376,6 +378,35 @@ class PowerPlant(SupportsMinMax):
                 power_output=power,
                 timestep=start,
             )
+
+    def get_starting_costs(self, op_time: int) -> float:
+        """
+        Returns the start-up cost for the given operation time.
+        If operation time is positive, the unit is running, so no start-up costs are returned.
+        If operation time is negative, the unit is not running, so start-up costs are returned
+        according to the start-up costs of the unit and the hot/warm/cold start times.
+
+        Args:
+            op_time (int): The operation time.
+
+        Returns:
+            float: The start-up costs depending on the down time.
+        """
+        if op_time > 0:
+            # The unit is running, no start-up cost is needed
+            return 0
+
+        downtime = abs(op_time)
+
+        # Check and return the appropriate start-up cost
+        if downtime <= self.downtime_hot_start:
+            return self.hot_start_cost
+
+        if downtime <= self.downtime_warm_start:
+            return self.warm_start_cost
+
+        # If it exceeds warm start threshold, return cold start cost
+        return self.cold_start_cost
 
     def as_dict(self) -> dict:
         """

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -193,9 +193,6 @@ class PowerPlant(SupportsMinMax):
             current_power = self.outputs["energy"].at[t]
             previous_power = self.get_output_before(t)
             op_time = self.get_operation_time(t)
-            self.outputs["energy_generation_costs"].at[t] += self.get_starting_costs(
-                op_time
-            )
             current_power = self.calculate_ramp(op_time, previous_power, current_power)
 
             if current_power > 0:
@@ -203,8 +200,76 @@ class PowerPlant(SupportsMinMax):
                 current_power = max(current_power, self.min_power)
 
             self.outputs["energy"].at[t] = current_power
+
+        # Book start-up and variable generation costs from the finalized
+        # dispatch. Both helpers overwrite their output series, which keeps
+        # the computation idempotent when execute_current_dispatch is called
+        # multiple times per simulation tick (once per cleared market).
+        self._book_start_costs(start, end, "energy")
         self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
+
+    def get_starting_costs(self, op_time: int) -> float:
+        """
+        Returns the start-up cost for the given operation time.
+
+        If ``op_time`` is positive, the unit is running and no start-up cost is
+        returned. Otherwise the cost is selected from the hot / warm / cold
+        tiers based on how many index steps the unit has been shut down.
+
+        Args:
+            op_time: The operation time, in index steps. Positive if running,
+                negative (as produced by :meth:`get_operation_time`) if it was
+                shut down.
+
+        Returns:
+            The start-up cost applicable to the given operation time.
+        """
+        if op_time > 0:
+            return 0
+
+        downtime = abs(op_time)
+        if downtime <= self.downtime_hot_start:
+            return self.hot_start_cost
+        if downtime <= self.downtime_warm_start:
+            return self.warm_start_cost
+        return self.cold_start_cost
+
+    def _book_start_costs(
+        self, start: datetime, end: datetime, product_type: str = "energy"
+    ) -> None:
+        """
+        Recomputes and overwrites ``{product_type}_start_costs`` for the window.
+
+        A start-up cost is booked at step ``t`` iff the unit transitions from
+        non-operating to operating between ``t - freq`` and ``t`` in the final,
+        multi-market-aggregated ``outputs[product_type]`` series. The amount is
+        taken from :meth:`get_starting_costs` using the operation time observed
+        just before ``t``.
+
+        Idempotent: calling it repeatedly with the same
+        ``outputs[product_type]`` history produces the same series. Must be
+        called after :meth:`calculate_ramp` has finalized the dispatch, so
+        starts that are suppressed by ``min_down_time`` are not charged.
+        """
+        if start not in self.index:
+            start = self.index[0]
+
+        energy = self.outputs[product_type]
+        start_cost_key = f"{product_type}_start_costs"
+
+        for t in self.index[start:end]:
+            self.outputs[start_cost_key].at[t] = 0.0
+
+            if energy.at[t] <= 0:
+                continue
+
+            prev_energy = self.get_output_before(t, product_type)
+            if prev_energy > 0:
+                continue
+
+            op_time = self.get_operation_time(t)
+            self.outputs[start_cost_key].at[t] = self.get_starting_costs(op_time)
 
     def calc_simple_marginal_cost(
         self,
@@ -379,35 +444,6 @@ class PowerPlant(SupportsMinMax):
                 timestep=start,
             )
 
-    def get_starting_costs(self, op_time: int) -> float:
-        """
-        Returns the start-up cost for the given operation time.
-        If operation time is positive, the unit is running, so no start-up costs are returned.
-        If operation time is negative, the unit is not running, so start-up costs are returned
-        according to the start-up costs of the unit and the hot/warm/cold start times.
-
-        Args:
-            op_time (int): The operation time.
-
-        Returns:
-            float: The start-up costs depending on the down time.
-        """
-        if op_time > 0:
-            # The unit is running, no start-up cost is needed
-            return 0
-
-        downtime = abs(op_time)
-
-        # Check and return the appropriate start-up cost
-        if downtime <= self.downtime_hot_start:
-            return self.hot_start_cost
-
-        if downtime <= self.downtime_warm_start:
-            return self.warm_start_cost
-
-        # If it exceeds warm start threshold, return cold start cost
-        return self.cold_start_cost
-
     def as_dict(self) -> dict:
         """
         Returns the attributes of the unit as a dictionary, including specific attributes.
@@ -432,3 +468,15 @@ class PowerPlant(SupportsMinMax):
         )
 
         return unit_dict
+
+    def get_max_lookback_optime(self):
+        # Add 1 to the warm/hot-start threshold so the window is big enough to
+        # distinguish warm/hot from cold starts (downtime > downtime_warm_start).
+        max_time = max(
+            self.min_operating_time,
+            self.min_down_time,
+            self.downtime_hot_start + 1,
+            self.downtime_warm_start + 1,
+            1,
+        )
+        return max_time

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -35,13 +35,13 @@ class PowerPlant(SupportsMinMax):
         emission_factor (float, optional): The emission factor associated with the power plant's fuel type (tons of CO2 emissions per MWh). Defaults to 0.0.
         ramp_up (Union[float, None], optional): The ramp-up rate of the power plant, indicating how quickly it can increase power output. Defaults to None.
         ramp_down (Union[float, None], optional): The ramp-down rate of the power plant, indicating how quickly it can decrease power output. Defaults to None.
-        hot_start_cost (float, optional): The cost of a hot start, where the power plant is restarted after a recent shutdown. Defaults to 0.
-        warm_start_cost (float, optional): The cost of a warm start, where the power plant is restarted after a moderate downtime. Defaults to 0.
-        cold_start_cost (float, optional): The cost of a cold start, where the power plant is restarted after a prolonged downtime. Defaults to 0.
-        min_operating_time (float, optional): The minimum duration that the power plant must operate once started, in hours. Defaults to 0.
-        min_down_time (float, optional): The minimum downtime required after a shutdown before the power plant can be restarted, in hours. Defaults to 0.
-        downtime_hot_start (int, optional): The downtime required after a hot start before the power plant can be restarted, in hours. Defaults to 8.
-        downtime_warm_start (int, optional): The downtime required after a warm start before the power plant can be restarted, in hours. Defaults to 48.
+        hot_start_cost (float, optional): The cost of a hot start [in €/MW installed capacity], where the power plant is restarted after a recent shutdown. Defaults to 0.0.
+        warm_start_cost (float, optional): The cost of a warm start [in €/MW installed capacity], where the power plant is restarted after a moderate downtime. Defaults to 0.0.
+        cold_start_cost (float, optional): The cost of a cold start [in €/MW installed capacity], where the power plant is restarted after a prolonged downtime. Defaults to 0.0.
+        min_operating_time (float, optional): The minimum duration that the power plant must operate once started, in hours. Defaults to 0.0.
+        min_down_time (float, optional): The minimum downtime required after a shutdown before the power plant can be restarted, in hours. Defaults to 0.0.
+        downtime_hot_start (float, optional): The downtime threshold for hot start classification, in hours. If the unit has been shut down for this long or less, a hot start cost applies. Defaults to 0.0.
+        downtime_warm_start (float, optional): The downtime threshold for warm start classification, in hours. If the unit has been shut down for longer than downtime_hot_start but this long or less, a warm start cost applies. Defaults to 0.0.
         max_heat_extraction (float, optional): The maximum amount of heat that the power plant can extract for external use, in some suitable unit. Defaults to 0.
         location (Tuple[float, float], optional): The geographical coordinates (latitude and longitude) of the power plant's location. Defaults to (0.0, 0.0).
         node (str, optional): The identifier of the electrical bus or network node to which the power plant is connected. Defaults to "node0".
@@ -64,14 +64,14 @@ class PowerPlant(SupportsMinMax):
         emission_factor: float = 0.0,
         ramp_up: float | None = None,
         ramp_down: float | None = None,
-        hot_start_cost: float = 0,
-        warm_start_cost: float = 0,
-        cold_start_cost: float = 0,
-        min_operating_time: int = 1,  # hours
-        min_down_time: int = 1,  # hours
-        downtime_hot_start: int = 0,  # hours
-        downtime_warm_start: int = 0,  # hours
-        max_heat_extraction: float = 0,
+        hot_start_cost: float = 0.0,
+        warm_start_cost: float = 0.0,
+        cold_start_cost: float = 0.0,
+        min_operating_time: float = 0.0,  # hours
+        min_down_time: float = 0.0,  # hours
+        downtime_hot_start: float = 0.0,  # hours
+        downtime_warm_start: float = 0.0,  # hours
+        max_heat_extraction: float = 0.0,
         location: tuple[float, float] = (0.0, 0.0),
         node: str = "node0",
         **kwargs,
@@ -209,7 +209,7 @@ class PowerPlant(SupportsMinMax):
         self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
 
-    def get_starting_costs(self, op_time: int) -> float:
+    def get_starting_costs(self, op_time: float) -> float:
         """
         Returns the start-up cost for the given operation time.
 
@@ -469,14 +469,14 @@ class PowerPlant(SupportsMinMax):
 
         return unit_dict
 
-    def get_max_lookback_optime(self):
-        # Add 1 to the warm/hot-start threshold so the window is big enough to
+    def get_max_lookback_op_time(self):
+        # Add one time step to the warm/hot-start threshold so the window is big enough to
         # distinguish warm/hot from cold starts (downtime > downtime_warm_start).
         max_time = max(
             self.min_operating_time,
             self.min_down_time,
-            self.downtime_hot_start + 1,
-            self.downtime_warm_start + 1,
-            1,
+            self.downtime_hot_start + 1.0,
+            self.downtime_warm_start + 1.0,
+            1.0,
         )
         return max_time

--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -67,8 +67,8 @@ class PowerPlant(SupportsMinMax):
         hot_start_cost: float = 0.0,
         warm_start_cost: float = 0.0,
         cold_start_cost: float = 0.0,
-        min_operating_time: float = 0.0,  # hours
-        min_down_time: float = 0.0,  # hours
+        min_operating_time: float = 1.0,  # hours, but I really don't like this. It should be 0 as a default.
+        min_down_time: float = 1.0,  # hours
         downtime_hot_start: float = 0.0,  # hours
         downtime_warm_start: float = 0.0,  # hours
         max_heat_extraction: float = 0.0,
@@ -149,7 +149,7 @@ class PowerPlant(SupportsMinMax):
 
         if min_operating_time < 0:
             raise ValidationError(
-                message=f"{min_operating_time=} must be >= 0 for unit {self.id}",
+                message=f"{min_operating_time=} must be > 0 for unit {self.id}",  # operator not alingned with statement above
                 id=self.id,
                 field="min_operating_time",
             )
@@ -157,7 +157,7 @@ class PowerPlant(SupportsMinMax):
 
         if min_down_time < 0:
             raise ValidationError(
-                message=f"{min_down_time=} must be >= 0 for unit {self.id}",
+                message=f"{min_down_time=} must be > 0 for unit {self.id}",
                 id=self.id,
                 field="min_down_time",
             )

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -331,12 +331,19 @@ class Storage(SupportsMinMaxCharge):
                     -current_power * time_delta * self.efficiency_charge
                 ) / self.capacity
 
+            # TODO op_time calculation for storages
+            op_time = 1
+            self.outputs["energy_generation_costs"].at[t] += self.get_starting_costs(
+                op_time
+            )
+
             # update the values of the state of charge and the energy
             next_freq = t + self.index.freq
             if next_freq in self.index:
                 self.outputs["soc"].at[next_freq] = soc + delta_soc
             self.outputs["energy"].at[t] = current_power
 
+        self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
 
     @lru_cache(maxsize=256)
@@ -567,7 +574,7 @@ class Storage(SupportsMinMaxCharge):
 
         return power_charge
 
-    def get_starting_costs(self, op_time):
+    def get_starting_costs(self, op_time: int) -> float:
         """
         Calculates the starting costs of the unit depending on how long it was shut down
 

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -41,11 +41,6 @@ class Storage(SupportsMinMaxCharge):
         ramp_down_charge (float): The ramp down rate of charging the storage unit in MW/15 minutes (negative value).
         ramp_up_discharge (float): The ramp up rate of discharging the storage unit in MW/15 minutes.
         ramp_down_discharge (float): The ramp down rate of discharging the storage unit in MW/15 minutes.
-        hot_start_cost (float): The hot start cost of the storage unit in €/MW.
-        warm_start_cost (float): The warm start cost of the storage unit in €/MW.
-        cold_start_cost (float): The cold start cost of the storage unit in €/MW.
-        downtime_hot_start (float): Definition of downtime before hot start in h.
-        downtime_warm_start (float): Definition of downtime before warm start in h.
         min_operating_time (float): The minimum operating time of the storage unit in hours.
         min_down_time (float): The minimum down time of the storage unit in hours.
         is_active (bool): Defines whether or not the unit bids itself or is portfolio optimized.
@@ -77,13 +72,8 @@ class Storage(SupportsMinMaxCharge):
         ramp_down_charge: float | None = None,
         ramp_up_discharge: float | None = None,
         ramp_down_discharge: float | None = None,
-        hot_start_cost: float = 0,
-        warm_start_cost: float = 0,
-        cold_start_cost: float = 0,
         min_operating_time: float = 0,  # hours
         min_down_time: float = 0,  # hours
-        downtime_hot_start: int = 8,  # hours
-        downtime_warm_start: int = 48,  # hours
         location: tuple[float, float] = (0, 0),
         node: str = "node0",
         **kwargs,
@@ -253,26 +243,6 @@ class Storage(SupportsMinMaxCharge):
                 field="min_down_time",
             )
         self.min_down_time = min_down_time
-        # The downtime before hot start of the storage unit.
-        if downtime_hot_start < 0:
-            raise ValidationError(
-                message=f"{downtime_hot_start=} must be >= 0 for unit {self.id}",
-                id=self.id,
-                field="downtime_hot_start",
-            )
-        self.downtime_hot_start = downtime_hot_start
-        # The downtime before warm start of the storage unit.
-        if downtime_warm_start < 0:
-            raise ValidationError(
-                message=f"{downtime_warm_start=} must be >= 0 for unit {self.id}",
-                id=self.id,
-                field="downtime_warm_start",
-            )
-        self.downtime_warm_start = downtime_warm_start
-
-        self.hot_start_cost = hot_start_cost * max_power_discharge
-        self.warm_start_cost = warm_start_cost * max_power_discharge
-        self.cold_start_cost = cold_start_cost * max_power_discharge
 
     def execute_current_dispatch(self, start: datetime, end: datetime) -> np.ndarray:
         """
@@ -331,18 +301,16 @@ class Storage(SupportsMinMaxCharge):
                     -current_power * time_delta * self.efficiency_charge
                 ) / self.capacity
 
-            # TODO op_time calculation for storages
-            op_time = 1
-            self.outputs["energy_generation_costs"].at[t] += self.get_starting_costs(
-                op_time
-            )
-
             # update the values of the state of charge and the energy
             next_freq = t + self.index.freq
             if next_freq in self.index:
                 self.outputs["soc"].at[next_freq] = soc + delta_soc
             self.outputs["energy"].at[t] = current_power
 
+        # Overwrite the variable generation cost series from the finalized
+        # dispatch. Storages have no start-up costs, so no start-cost booking
+        # is needed. The helper uses `=` semantics so it is safe to call
+        # repeatedly as different markets clear for the same window.
         self.calculate_generation_cost(start, end, "energy")
         return self.outputs["energy"].loc[start:end]
 
@@ -573,26 +541,6 @@ class Storage(SupportsMinMaxCharge):
             power_charge = 0
 
         return power_charge
-
-    def get_starting_costs(self, op_time: int) -> float:
-        """
-        Calculates the starting costs of the unit depending on how long it was shut down
-
-        Args:
-            op_time (float): The time the unit was shut down in hours.
-
-        Returns:
-            float: The starting costs of the unit.
-        """
-        if op_time > 0:
-            # unit is running
-            return 0
-        if -op_time < self.downtime_hot_start:
-            return self.hot_start_cost
-        elif -op_time < self.downtime_warm_start:
-            return self.warm_start_cost
-        else:
-            return self.cold_start_cost
 
     def as_dict(self) -> dict:
         """

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -72,8 +72,8 @@ class Storage(SupportsMinMaxCharge):
         ramp_down_charge: float | None = None,
         ramp_up_discharge: float | None = None,
         ramp_down_discharge: float | None = None,
-        min_operating_time: float = 0,  # hours
-        min_down_time: float = 0,  # hours
+        min_operating_time: float = 0.0,  # hours
+        min_down_time: float = 0.0,  # hours
         location: tuple[float, float] = (0, 0),
         node: str = "node0",
         **kwargs,

--- a/assume/units/storage.py
+++ b/assume/units/storage.py
@@ -227,6 +227,9 @@ class Storage(SupportsMinMaxCharge):
         self.ramp_up_discharge = ramp_up_discharge
         self.ramp_down_discharge = ramp_down_discharge
 
+        # Convert time parameters from hours to index steps
+        hours_to_steps = timedelta(hours=1) / self.index.freq
+
         # How long the storage unit has to be in operation before it can be shut down.
         if min_operating_time < 0:
             raise ValidationError(
@@ -234,7 +237,7 @@ class Storage(SupportsMinMaxCharge):
                 id=self.id,
                 field="min_operating_time",
             )
-        self.min_operating_time = min_operating_time
+        self.min_operating_time = min_operating_time * hours_to_steps
         # How long the storage unit has to be shut down before it can be started.
         if min_down_time < 0:
             raise ValidationError(
@@ -242,7 +245,7 @@ class Storage(SupportsMinMaxCharge):
                 id=self.id,
                 field="min_down_time",
             )
-        self.min_down_time = min_down_time
+        self.min_down_time = min_down_time * hours_to_steps
 
     def execute_current_dispatch(self, start: datetime, end: datetime) -> np.ndarray:
         """

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -2661,7 +2661,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -2829,7 +2829,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -5067,7 +5067,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -5235,7 +5235,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -2674,7 +2674,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -2842,7 +2842,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Gen_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -5080,7 +5080,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -5248,7 +5248,7 @@
           "group": [],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs AS \"Production costs\",\r\n  energy_cashflow - energy_generation_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs\r\nORDER BY 1",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  energy_cashflow AS \"Cashflow\",\r\n  energy_generation_costs + energy_start_costs AS \"Production costs\",\r\n  energy_start_costs AS \"Start-up costs\",\r\n  energy_cashflow - energy_generation_costs - energy_start_costs AS \"Profit\",\r\n  unit\r\nFROM unit_dispatch\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  simulation = '$simulation' AND\r\n  unit in ($Storage_Units)\r\nGROUP BY 1, unit, energy_cashflow, energy_generation_costs, energy_start_costs\r\nORDER BY 1",
           "refId": "A",
           "select": [
             [

--- a/docs/source/outputs.rst
+++ b/docs/source/outputs.rst
@@ -74,7 +74,7 @@ When the outputs are stored in CSV files, the data is organized in a similar str
 
    * - unit_dispatch
      - Unit-level dispatch data.
-     - simulation, unit, power, heat, soc, energy_generation_costs, energy_cashflow, total_costs
+     - simulation, unit, power, heat, soc, energy_generation_costs, energy_start_costs, energy_cashflow, total_costs
 
    * - market_orders
      - Market order details.

--- a/examples/inputs/example_03a/powerplant_units.csv
+++ b/examples/inputs/example_03a/powerplant_units.csv
@@ -1,4 +1,4 @@
-name,technology,bidding_EOM,fuel_type,emission_factor,max_power,min_power,efficiency,ramp_up,ramp_down,additional_costs,hot_start_costs,warm_start_costs,cold_start_costs,unit_operator
+name,technology,bidding_EOM,fuel_type,emission_factor,max_power,min_power,efficiency,ramp_up,ramp_down,additional_cost,hot_start_cost,warm_start_cost,cold_start_cost,unit_operator
 Wind Onshore,wind_onshore,powerplant_energy_heuristic_flexable,renewable,0,53190,0,1,,,-90,0,0,0,renewables_operator
 Wind Offshore,wind_offshore,powerplant_energy_heuristic_flexable,renewable,0,7560,0,1,,,-90,0,0,0,renewables_operator
 Solar,solar,powerplant_energy_heuristic_flexable,renewable,0,48860,0,1,,,-90,0,0,0,renewables_operator

--- a/examples/inputs/example_03b/powerplant_units.csv
+++ b/examples/inputs/example_03b/powerplant_units.csv
@@ -1,4 +1,4 @@
-name,technology,bidding_EOM,fuel_type,emission_factor,max_power,min_power,efficiency,ramp_up,ramp_down,additional_costs,hot_start_costs,warm_start_costs,cold_start_costs,min_operating_time,min_down_time,heat_extraction,max_heat_extraction,unit_operator
+name,technology,bidding_EOM,fuel_type,emission_factor,max_power,min_power,efficiency,ramp_up,ramp_down,additional_cost,hot_start_cost,warm_start_cost,cold_start_cost,min_operating_time,min_down_time,heat_extraction,max_heat_extraction,unit_operator
 Wind Onshore,wind_onshore,powerplant_energy_heuristic_flexable,renewable,0,53190,0,1,,,0,0,0,0,0,0,0,0,renewables_operator
 Wind Offshore,wind_offshore,powerplant_energy_heuristic_flexable,renewable,0,7560,0,1,,,0,0,0,0,0,0,0,0,renewables_operator
 Solar,solar,powerplant_energy_heuristic_flexable,renewable,0,48860,0,1,,,0,0,0,0,0,0,0,0,renewables_operator

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -119,15 +119,18 @@ def test_calculate_bids(base_unit, mock_market_config):
     # we received more, as accepted_price is higher
     assert base_unit.outputs["energy_cashflow"][start] == 10 * 11
 
-    # we somehow sold an additional 10 MW
+    # we somehow sold an additional 10 MW on a second market for the same step
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
     base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
 
-    # the final output should be 10+10
+    # the final dispatched output should be 10+10
     assert base_unit.outputs["energy"][start] == 20
-    # the marginal cost for this volume should be twice as much too
+    # generation cost is a pure function of the aggregated dispatch, so the
+    # second call overwrites the first (idempotency under multi-market
+    # re-entry): 20 MW * 10 EUR/MWh = 200
     assert base_unit.outputs["energy_generation_costs"][start] == 200
+    # cashflow on the other hand accumulates across markets: 110 + 110 = 220
     assert base_unit.outputs["energy_cashflow"][start] == 20 * 11
 
 
@@ -172,7 +175,9 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
     base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
 
-    # should be correctly applied for the sum, even if different hours are applied
+    # dispatch accumulates across markets, but generation cost is a pure
+    # function of the aggregated dispatch and therefore stays at 20 MW * 10
+    # EUR/MWh = 200 even after a second market has cleared on the same step.
     assert base_unit.outputs["energy"][index[0]] == 20
     assert base_unit.outputs["energy_generation_costs"][index[0]] == 200
     assert base_unit.outputs["energy_cashflow"][index[0]] == 220

--- a/tests/test_powerplant.py
+++ b/tests/test_powerplant.py
@@ -652,6 +652,195 @@ def test_initialising_invalid_powerplants():
         PowerPlant(**d)
 
 
+def _make_start_cost_plant(
+    periods: int = 24,
+    freq: str = "h",
+    hot_start_cost: float = 10.0,
+    warm_start_cost: float = 20.0,
+    cold_start_cost: float = 30.0,
+    downtime_hot_start: int = 2,
+    downtime_warm_start: int = 4,
+    min_down_time: int = 1,
+    min_operating_time: int = 1,
+    min_power: float = 50,
+    max_power: float = 500,
+) -> PowerPlant:
+    index = pd.date_range("2022-01-01", periods=periods, freq=freq)
+    forecaster = PowerplantForecaster(
+        index=index,
+        availability=1,
+        fuel_prices={"lignite": 10, "co2": 0},
+        market_prices={"EOM": 0},
+    )
+    return PowerPlant(
+        id="test_pp",
+        unit_operator="test_operator",
+        technology="coal",
+        bidding_strategies={"EOM": EnergyNaiveStrategy()},
+        index=forecaster.index,
+        max_power=max_power,
+        min_power=min_power,
+        efficiency=0.5,
+        additional_cost=0,
+        fuel_type="lignite",
+        emission_factor=0,
+        ramp_down=max_power,
+        ramp_up=max_power,
+        hot_start_cost=hot_start_cost,
+        warm_start_cost=warm_start_cost,
+        cold_start_cost=cold_start_cost,
+        downtime_hot_start=downtime_hot_start,
+        downtime_warm_start=downtime_warm_start,
+        min_operating_time=min_operating_time,
+        min_down_time=min_down_time,
+        forecaster=forecaster,
+    )
+
+
+def _set_energy(pp: PowerPlant, values: list[float]) -> None:
+    for i, v in enumerate(values):
+        pp.outputs["energy"].at[pp.index[i]] = v
+
+
+def _start_costs_list(pp: PowerPlant, n: int) -> list[float]:
+    return [float(pp.outputs["energy_start_costs"].at[pp.index[i]]) for i in range(n)]
+
+
+def test_start_cost_not_booked_when_always_on():
+    pp = _make_start_cost_plant(periods=5)
+    _set_energy(pp, [200, 200, 200, 200, 200])
+
+    pp._book_start_costs(pp.index[0], pp.index[-1], "energy")
+
+    assert sum(_start_costs_list(pp, 5)) == 0
+
+
+def test_start_cost_hot_start_booked_once_at_transition():
+    pp = _make_start_cost_plant(
+        periods=5,
+        hot_start_cost=10,
+        warm_start_cost=20,
+        cold_start_cost=30,
+        downtime_hot_start=2,
+        downtime_warm_start=4,
+    )
+    # off for 1 step (within hot-start window), then on for the rest
+    _set_energy(pp, [0, 200, 200, 200, 200])
+
+    pp._book_start_costs(pp.index[0], pp.index[-1], "energy")
+
+    series = _start_costs_list(pp, 5)
+    assert series == [0, pp.hot_start_cost, 0, 0, 0]
+
+
+def test_start_cost_warm_start_booked():
+    pp = _make_start_cost_plant(
+        periods=5,
+        hot_start_cost=10,
+        warm_start_cost=20,
+        cold_start_cost=30,
+        downtime_hot_start=2,
+        downtime_warm_start=4,
+    )
+    _set_energy(pp, [0, 0, 0, 200, 200])
+
+    pp._book_start_costs(pp.index[0], pp.index[-1], "energy")
+
+    series = _start_costs_list(pp, 5)
+    assert series == [0, 0, 0, pp.warm_start_cost, 0]
+
+
+def test_start_cost_cold_start_booked():
+    pp = _make_start_cost_plant(
+        periods=6,
+        hot_start_cost=10,
+        warm_start_cost=20,
+        cold_start_cost=30,
+        downtime_hot_start=2,
+        downtime_warm_start=4,
+    )
+    _set_energy(pp, [0, 0, 0, 0, 0, 200])
+
+    pp._book_start_costs(pp.index[0], pp.index[-1], "energy")
+
+    series = _start_costs_list(pp, 6)
+    assert series == [0, 0, 0, 0, 0, pp.cold_start_cost]
+
+
+def test_start_cost_two_separate_cycles():
+    pp = _make_start_cost_plant(
+        periods=5,
+        hot_start_cost=10,
+        warm_start_cost=20,
+        cold_start_cost=30,
+        downtime_hot_start=2,
+        downtime_warm_start=4,
+        min_down_time=1,
+        min_operating_time=1,
+    )
+    # on -> off -> on -> off -> on
+    _set_energy(pp, [200, 0, 200, 0, 200])
+
+    pp._book_start_costs(pp.index[0], pp.index[-1], "energy")
+
+    series = _start_costs_list(pp, 5)
+    # step 0: already running at the boundary, no transition
+    # step 2: off->on restart in hot window
+    # step 4: off->on restart in hot window
+    assert series == [0, 0, pp.hot_start_cost, 0, pp.hot_start_cost]
+
+
+def test_start_cost_idempotent_across_multiple_dispatch_calls():
+    """
+    Simulates multi-market re-entrancy: execute_current_dispatch is called
+    once per product_type clearing within a simulation tick. Start-up and
+    generation costs must be idempotent (produce the same series every time).
+    """
+    pp = _make_start_cost_plant(
+        periods=5,
+        hot_start_cost=10,
+        warm_start_cost=20,
+        cold_start_cost=30,
+        downtime_hot_start=2,
+        downtime_warm_start=4,
+    )
+    # seed a dispatch schedule on outputs["energy"] that triggers a start
+    _set_energy(pp, [0, 200, 200, 200, 200])
+
+    end = pp.index[-1]
+    first = list(pp.execute_current_dispatch(pp.index[0], end))
+    first_start = _start_costs_list(pp, 5)
+    first_gen = [
+        float(pp.outputs["energy_generation_costs"].at[pp.index[i]]) for i in range(5)
+    ]
+
+    # Simulate three more clearings on different product types hitting the
+    # same dispatch window. The final accumulated dispatch in outputs["energy"]
+    # is still the same, so every call must produce the same cost series.
+    for _ in range(3):
+        pp.execute_current_dispatch(pp.index[0], end)
+
+    assert _start_costs_list(pp, 5) == first_start
+    assert [
+        float(pp.outputs["energy_generation_costs"].at[pp.index[i]]) for i in range(5)
+    ] == first_gen
+    assert list(pp.execute_current_dispatch(pp.index[0], end)) == first
+
+
+def test_start_cost_scaled_by_max_power():
+    pp = _make_start_cost_plant(
+        hot_start_cost=1.0,
+        warm_start_cost=2.0,
+        cold_start_cost=3.0,
+        min_power=10,
+        max_power=40,
+    )
+    # Input costs are per-MW of installed (max) capacity; absolute EUR scales with max_power
+    assert pp.hot_start_cost == 1.0 * pp.max_power
+    assert pp.warm_start_cost == 2.0 * pp.max_power
+    assert pp.cold_start_cost == 3.0 * pp.max_power
+
+
 if __name__ == "__main__":
     # run pytest and enable prints
     pytest.main(["-s", __file__])

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -560,18 +560,6 @@ def test_initialising_invalid_storages():
         d = param_dict.copy()
         d["min_down_time"] = -10
         Storage(**d)
-    with pytest.raises(
-        ValueError, match="downtime_hot_start=-10 must be >= 0 for unit id"
-    ):
-        d = param_dict.copy()
-        d["downtime_hot_start"] = -10
-        Storage(**d)
-    with pytest.raises(
-        ValueError, match="downtime_warm_start=-10 must be >= 0 for unit id"
-    ):
-        d = param_dict.copy()
-        d["downtime_warm_start"] = -10
-        Storage(**d)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **User description**
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
## Related Issue

relates to #695 

## Description
This fixes calculation of start costs by using `get_starting_costs` in `execute_current_dispatch`.

This also restructures `calculate_generation_cost` to be part of `execute_current_dispatch` as this in the "general" part which should be part of all the specific implementations.

However, this still needs some fixes in the various strategies, I guess.

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->


___

### **PR Type**
Bug fix, Enhancement, Tests, Documentation


___

### **Description**
- Book start-up costs during dispatch

- Make cost booking idempotent

- Convert timing parameters to steps

- Add tests, docs, dashboard updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  dispatch["Finalized dispatch"]
  startCosts["Start-up cost booking"]
  genCosts["Generation cost booking"]
  rewards["Reward and profit calculations"]
  outputs["Dispatch outputs and dashboards"]
  dispatch -- "detect transitions" --> startCosts
  dispatch -- "overwrite variable costs" --> genCosts
  startCosts -- "read booked costs" --> rewards
  genCosts -- "read booked costs" --> rewards
  rewards -- "export totals" --> outputs
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>base.py</strong><dd><code>Centralize dispatch cost calculation hooks</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-b706f338e371a0d9a442c2ffe704f2a377749cbaff5dab2047837b7728692995">+34/-45</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>flexable.py</strong><dd><code>Reuse booked dispatch costs in rewards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-7df14820f4c52ee8fd7e540dae5687825bc403a79c60220c099043e2d10d42ab">+15/-23</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>learning_strategies.py</strong><dd><code>Avoid recomputing learning start costs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-cede22f917ccdf1a7b532bb39fc227dfcc657a5d450589924bbca16ab9c63fae">+18/-25</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>powerplant.py</strong><dd><code>Book tiered power plant start costs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-4959688f8fedc0a7a741d5465869d269c2b7925a4120eee51a1fad65f47fdc74">+105/-25</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>units_operator.py</strong><dd><code>Export start costs from unit dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-9a14867c55f7a7c764c2f32b538a8f7a614d0328364bf56a7397b11a340aa11a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage.py</strong><dd><code>Remove storage start-cost handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-9dcfbf9e003d22ee2545faafde6601904375bf74d4120d829ca189ae26cba79b">+12/-54</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Error handling</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>dmas_powerplant.py</strong><dd><code>Validate hourly DMAS timing assumptions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-f73d0da1c924564fc54d595c2984793b4e3b6ad9bd4cb3903298420ce0e0b8b1">+23/-10</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>test_baseunit.py</strong><dd><code>Clarify idempotent generation cost expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-292c963a7d3280753c206f00ebfafde1982ad4360cbf0199c5ad76d8795ea7fa">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_powerplant.py</strong><dd><code>Add power plant start-cost coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-48c10cf89c6ac5e17979e418191249a22e0f3403f744306abca30b58fb182fdf">+189/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>test_storage.py</strong><dd><code>Remove obsolete storage downtime validations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-97a131ad6711fd2807ed014b7f48f566d7e07b56f29631077d6495bed8c4f459">+0/-12</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>ASSUME.json</strong><dd><code>Display start costs in dashboards</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-00da6ebd4386ddd44ecc96a023447ced7581a0751e53cbef77e5ffdb3d178f19">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>outputs.rst</strong><dd><code>Document unit dispatch start-cost output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/696/files#diff-d3e1ea4d90ac3cfda2c71e757fcc6855d7fb1475bca2462e75c1bbaf4fe70071">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

