### PR TITLE
add documentation to build docs using a venv

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,9 +85,26 @@ The upload to PyPi has to be confirmed by one of the core developers.
 
 First, create an environment that includes the documentation dependencies:
 
+
+### Conda
+
+Conda installs the required dependencies and pandoc as well:
+
 ```bash
 conda env create -f environment_docs.yaml
 ```
+
+### Venv
+
+To use a venv without conda, a system installation of pandoc is required: https://pandoc.org/installing.html
+
+You then need to install the dependencies into your venv using:
+
+```bash
+pip install -e .[docs]
+```
+
+### Building Docs
 
 To generate or update the automatically created docs in `docs/source/assume*`, run:
 


### PR DESCRIPTION
## Description
This improves docs for venv users to build the docs locally

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->

Verified using conda and venv with and without local installed pandoc