### PR TITLE
remove constraint to xarray with latest pypsa,linopy and xarray releases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "pyyaml >=6.0",
     "pyyaml-include >=2.2a",
     "pyomo >=6.8.0",
-    "xarray <2025.7.0", # https://github.com/PyPSA/linopy/issues/470
+    "xarray",
     "highspy",
 ]
 


### PR DESCRIPTION
## Description
We can unpin the xarray version, now that this is fixed upstream

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
