### PR TITLE
upload the coverage report of all tests, not just of the pytorch tests

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -91,7 +91,7 @@ jobs:
 
     - name: Test pytest with torch & integration tests
       run: |
-        pytest -m "require_learning" --cov --cov-report=xml --junitxml="result.xml"
+        pytest --cov --cov-report=xml --junitxml="result.xml"
 
     - name: Upload tests results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers 
SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Description
I just noticed that the code coverage displayed by codecov is not correct. Currently, we run our tests in three stages in the pipeline:

1. Tests without pytorch and pypsa (which are most of the tests)
2. Pypsa Tests
3. Pytorch tests

But we only upload the coverage report of step 3 to codecov.
This PR runs all tests in step three, which produces a correct coverage report with the disadvantage of a longer program runtime

It would also be possible to create three different reports and to merge them (see [this stack overflow question](https://stackoverflow.com/questions/26214055/combine-python-coverage-files)), but this requires another dependency 

## Checklist
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
