### PR TITLE
allow 0 operating- and downtime

### DIFF
--- a/assume/units/powerplant.py
+++ b/assume/units/powerplant.py
@@ -124,10 +124,10 @@ class PowerPlant(SupportsMinMax):
         self.ramp_down = None if ramp_down == 0 else ramp_down
         self.ramp_up = None if ramp_up == 0 else ramp_up
 
-        if min_operating_time <= 0:
+        if min_operating_time < 0:
             raise ValueError(f"{min_operating_time=} must be > 0 for unit {self.id}")
         self.min_operating_time = min_operating_time
-        if min_down_time <= 0:
+        if min_down_time < 0:
             raise ValueError(f"{min_down_time=} must be > 0 for unit {self.id}")
         self.min_down_time = min_down_time
         self.downtime_hot_start = downtime_hot_start / (


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers
SPDX-License-Identifier: AGPL-3.0-or-later
-->


## Description
Fix bug that forces powerplants to have a non-zero min_down_time and min_operating_time 

## Checklist
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
