### PR TITLE
remove pin from pip-tools to build docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN useradd -m -s /bin/bash admin
 RUN mkdir /src
 WORKDIR /src
 COPY README.md pyproject.toml .
-# https://github.com/jazzband/pip-tools/pull/2221
-RUN pip install "pip-tools<7.5.0"
+RUN pip install pip-tools
 RUN mkdir assume assume_cli
 RUN touch assume/__init__.py
 RUN pip-compile --resolver=backtracking -o requirements.txt ./pyproject.toml


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Description

This removes the pin from pip-tools, so that the docker build succeeds with setuptools-scm

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
