### PR TITLE
assert simulation_length >= train_freq

### DIFF
--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -171,6 +171,9 @@ class Learning(Role):
             )
             return None
         total_length = self.end_datetime - self.start_datetime
+        assert total_length >= train_freq, (
+            f"Simulation length ({total_length}) must be at least as long as train_freq ({train_freq_str})"
+        )
         quotient, remainder = divmod(total_length, train_freq)
 
         if remainder != pd.Timedelta(0):


### PR DESCRIPTION
## Related Issue
If users set train_freq longer than simulation time by mistake, this might be hard to discover as no error raises. Only when writing output, a tensorboard warning occurs.

## Description
As we re-calculate the train_freq anyway depending on the simulation length, a simple check can be introduced by this PR

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.) (not needed)
- [x] New unit/integration tests added (not applicable)
- [x] Changes noted in release notes (not applicable)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
