### PR TITLE
Smooth reward calculation for nice gradients

### DIFF
--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -694,7 +694,7 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
 
         opportunity_cost_smooth = (
             (market_clearing_price - marginal_cost)
-            * (unit.max_power - accepted_volume_smooth)
+            * (unit.max_power - accepted_volume_total_smooth)
             * duration
         )
 
@@ -706,6 +706,9 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
         # - If accepted volume is positive, apply lower regret (0.1) to avoid punishment for being on the edge of the merit order.
         # - If no dispatch happens, apply higher regret (0.5) to discourage idle behavior, if it could have been profitable.
         regret_scale = 0.1 if accepted_volume_total > unit.min_power else 0.5
+        regret_scale_smooth = (
+            0.1 if accepted_volume_total_smooth > unit.min_power else 0.5
+        )
 
         # --------------------
         # 4.1 Calculate Reward
@@ -714,7 +717,7 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
 
         # scaling factor to normalize the reward to the range [-1,1]
         scaling = 1 / (self.max_bid_price * unit.max_power)
-        regret = regret_scale * opportunity_cost_smooth
+        regret = regret_scale_smooth * opportunity_cost_smooth
         reward = scaling * (profit_smooth - regret)
 
         # Store results in unit outputs


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Description

The current reward calculation in `EnergyLearningStrategy` uses a hard threshold (step function) to determine whether a bid is accepted or not. This creates:
- Discontinuous reward signals that make learning difficult
- Sharp gradients ( or honestly no gardients) at the market clearing price boundary

In another study, I replaced a nasty binary with a sigmoid, and it did miracles. 
Replace the discrete acceptance logic with a **smooth sigmoid-based acceptance probability** that provides:
- Continuous, differentiable reward signals
- Gradual transitions around the market clearing price
- More stable learning dynamics?

<img width="690" height="390" alt="image" src="https://github.com/user-attachments/assets/65cbd471-0492-4e81-9f94-88811a1b3261" />
Instead of the orange dashed line (old reward) I implemented the sigmoid rewrad to have proper gradients. This will lead to inaccuracies for the reward close to the marginal costs. They get smaller the steeper the curve (chose k higher) 

### In `EnergyLearningStrategy.calculate_reward()`:

1. **Sigmoid acceptance probability:**
   ```python
   k = 2  # controls steepness
   accept_prob = 1 / (1 + exp(k * (bid_price - market_clearing_price)))
   accepted_volume_smooth = accepted_volume * accept_prob

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Testing
Compared it for example_02a (green and grey with sigmoid) and example_02b (oragne and blue with sigmoid)

<img width="1371" height="297" alt="image" src="https://github.com/user-attachments/assets/c257cbf6-f13a-4cfe-98d5-b236e96bbbba" />


For an agent that sets the market price as in example_02a, it does not have any effect besides a differently scaled reward. As you can see the profit behavior is identical. However, for many agents who are supposed to bid their marginal costs most of the time, they seem to find it quicker and stay close to their marginal costs. 
