### PR TITLE
pin down pypsa version to latest working state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ learning = [
     "tensorboard >=2.7.0",
 ]
 network = [
-    "pypsa",
+    "pypsa<1.1.0",
 ]
 oeds = [
     "demandlib >=0.1.9",


### PR DESCRIPTION
## Description
Pin pypsa to 1.0.7 until we migrated to the latest version

## Checklist
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
