### PR TITLE
Added reward calculation for unit operators

### DIFF
--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -333,11 +333,18 @@ class UnitsOperator(Role):
         """
         orderbook.sort(key=itemgetter("unit_id"))
         for unit_id, orders in groupby(orderbook, itemgetter("unit_id")):
-            orderbook = list(orders)
+            unit_orders = list(orders)
             self.units[unit_id].calculate_cashflow_and_reward(
                 marketconfig=marketconfig,
-                orderbook=orderbook,
+                orderbook=unit_orders,
             )
+
+        # Calculate reward for the portfolio strategy
+        self.portfolio_strategies.get(marketconfig.market_id).calculate_reward(
+            units_operator=self,
+            marketconfig=marketconfig,
+            orderbook=orderbook,
+        )
 
     def get_actual_dispatch(
         self, product_type: str, last: datetime

--- a/assume/strategies/portfolio_strategies.py
+++ b/assume/strategies/portfolio_strategies.py
@@ -62,6 +62,14 @@ class UnitOperatorStrategy:
 
         return total_capacity
 
+    def calculate_reward(
+        self,
+        units_operator,  # type: UnitsOperator
+        marketconfig: MarketConfig,
+        orderbook: Orderbook,
+    ):
+        pass
+
 
 class UnitsOperatorDirectStrategy(UnitOperatorStrategy):
     def calculate_bids(

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -19,6 +19,7 @@ Upcoming Release
     - ``seed: null``: Disables seed setting, allowing for non-deterministic behavior as before. May improve performance of reinforcement learning.
   - **Delete environment.yaml**: The environment.yaml file has been removed from the repository to simplify maintenance and was completely redundant with the `pyproject.toml`. Users can as before create their own environment using the provided pip installation instructions, which allows for more flexibility and easier updates.
   - **Add validation for simulation setup**: Added checks to validate the simulation setup for common issues, such as missing bidding strategies or inconsistent market configurations. Warnings are issued to inform users of potential problems that could affect simulation results.
+  - **Added reward calculation for unit operators**: Unit operators have now the opportunity to calculate rewards based on the returned orderbooks for their own purposes. This enables learning strategies on unit operator level / portfolio learning strategies.
 
 0.5.6 - (23th December 2025)
 ============================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #739


## Description
<!-- Summarise the purpose/motivation and the changes of the PR. -->
Currently the unit_operator does not calculate a reward. This is needed for Portfolio learning strategies.

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
