### PR TITLE
changed simulation column name to fix db query error

### DIFF
--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -668,7 +668,7 @@ class WriteOutput(Role):
                 f"select '{variable}' as variable, market_id as ident, {kpi_def['value']} as value from {kpi_def['from_table']} where {simulation_col} = '{self.simulation_id}' group by {group_bys}"
             )
 
-        if self.episode:
+        if self.learning_mode or self.evaluation_mode:
             queries.extend(
                 [
                     f"SELECT 'sum_reward' as variable, simulation as ident, sum(reward) as value FROM rl_params WHERE episode='{self.episode}' AND simulation='{self.simulation_id}' GROUP BY simulation",
@@ -681,8 +681,6 @@ class WriteOutput(Role):
         for query in queries:
             try:
                 df = pd.read_sql(query, self.db)
-            except (ProgrammingError, OperationalError, DataError):
-                continue
             except Exception as e:
                 logger.error("could not read query: %s", e)
                 continue

--- a/assume/common/outputs.py
+++ b/assume/common/outputs.py
@@ -120,6 +120,7 @@ class WriteOutput(Role):
                 "value": "avg(power/max_power)",
                 "from_table": 'market_dispatch ud join power_plant_meta um on ud.unit_id = um."index" and ud.simulation=um.simulation',
                 "group_bys": ["market_id", "variable"],
+                "simulation_col": "ud.simulation",
             },
         }
         self.kpi_defs.update(additional_kpis)
@@ -662,8 +663,9 @@ class WriteOutput(Role):
         queries = []
         for variable, kpi_def in self.kpi_defs.items():
             group_bys = ",".join(kpi_def.get("group_bys", ["market_id"]))
+            simulation_col = kpi_def.get("simulation_col", "simulation")
             queries.append(
-                f"select '{variable}' as variable, market_id as ident, {kpi_def['value']} as value from {kpi_def['from_table']} where simulation = '{self.simulation_id}' group by {group_bys}"
+                f"select '{variable}' as variable, market_id as ident, {kpi_def['value']} as value from {kpi_def['from_table']} where {simulation_col} = '{self.simulation_id}' group by {group_bys}"
             )
 
         if self.episode:

--- a/assume/world.py
+++ b/assume/world.py
@@ -204,6 +204,8 @@ class World:
             save_frequency_hours (int): The frequency (in hours) at which to save simulation data.
             bidding_params (dict, optional): Parameters for bidding. Defaults to an empty dictionary.
             learning_dict (dict, optional): Configuration for the learning process. Defaults to an empty dictionary.
+            episode (int, optional): The episode number for learning. Defaults to 1.
+            eval_episode (int, optional): The episode number for evaluation. Defaults to 1.
             manager_address: The address of the manager.
             **kwargs: Additional keyword arguments.
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #754 


## Description
<!-- Summarise the purpose/motivation and the changes of the PR. -->
A kpi query has the ambiguos column query "simulation" for kpi `capacity_factor`. This results in query errors like the following during runtime.

This is fixed by using "ud.simulation" as column name instead.

```
ERROR:assume.common.outputs:could not read query: Execution failed on sql 'select 'capacity_factor' as variable, market_id as ident, avg(power/max_power) as value from market_dispatch ud join power_plant_meta um on ud.unit_id = um."index" and ud.simulation=um.simulation where simulation = 'example_02a_base' group by market_id,variable': (sqlite3.OperationalError) ambiguous column name: simulation
[SQL: select 'capacity_factor' as variable, market_id as ident, avg(power/max_power) as value from market_dispatch ud join power_plant_meta um on ud.unit_id = um."index" and ud.simulation=um.simulation where simulation = 'example_02a_base' group by market_id,variable]
```

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
