### PR TITLE
Consistent use of emission factor

### DIFF
--- a/assume/scenario/loader_pypsa.py
+++ b/assume/scenario/loader_pypsa.py
@@ -172,7 +172,6 @@ def load_pypsa(
                 "capacity": storage.p_nom * storage.max_hours,
                 "bidding_strategies": bidding_strategies[unit_type][storage.name],
                 "technology": storage.carrier,
-                "emission_factor": storage.emission_factor or 0,
                 "node": storage.bus,
             },
             UnitForecaster(index),

--- a/docker_configs/dashboard-definitions/ASSUME Comparison.json
+++ b/docker_configs/dashboard-definitions/ASSUME Comparison.json
@@ -2179,7 +2179,7 @@
       "id": 47,
       "options": {
         "afterRender": "",
-        "content": "### General Information\n\nName: {{index}} <br>\nTechnology: {{technology}} <br>\n\n### Technical Specifications\nEmissions: {{emission_factor}} t/MWh <br>\nCapacity: {{capacity}} MWh <br>\nMaximum Power Disharge: {{max_power_discharge}} MW <br>\nMinimum Power Discharge: {{min_power_discharge}} MW <br>\nEfficiency Discharge: {{efficiency_discharge}} % <br>\n\nMaximum Power Charge: {{max_power_charge}} MW <br>\nMinimum Power Charge: {{min_power_charge}} MW <br>\nEfficiency Charge: {{efficiency_charge}} % <br>\n\n##### Unit Operator: {{unit_operator}}\n  ",
+        "content": "### General Information\n\nName: {{index}} <br>\nTechnology: {{technology}} <br>\n\n### Technical Specifications\nEmissions: {{emission_factor}} t/MWh_thermal <br>\nCapacity: {{capacity}} MWh <br>\nMaximum Power Disharge: {{max_power_discharge}} MW <br>\nMinimum Power Discharge: {{min_power_discharge}} MW <br>\nEfficiency Discharge: {{efficiency_discharge}} % <br>\n\nMaximum Power Charge: {{max_power_charge}} MW <br>\nMinimum Power Charge: {{min_power_charge}} MW <br>\nEfficiency Charge: {{efficiency_charge}} % <br>\n\n##### Unit Operator: {{unit_operator}}\n  ",
         "contentPartials": [],
         "defaultContent": "The query didn't return any results.",
         "editor": {

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -3109,7 +3109,7 @@
       "id": 37,
       "options": {
         "afterRender": "",
-        "content": "### General Information\n\nName: {{index}} <br>\nTechnology: {{technology}} <br>\n\n### Technical Specifications\nEmissions: {{emission_factor}} t/MWh <br>\nMaximum Power: {{max_power}} MW <br>\nMinimum Power: {{min_power}} MW <br>\nEfficiency: {{efficiency}} <br>\n\n##### Unit Operator: {{unit_operator}}\n  ",
+        "content": "### General Information\n\nName: {{index}} <br>\nTechnology: {{technology}} <br>\n\n### Technical Specifications\nEmissions: {{emission_factor}} t/MWh_thermal <br>\nMaximum Power: {{max_power}} MW <br>\nMinimum Power: {{min_power}} MW <br>\nEfficiency: {{efficiency}} <br>\n\n##### Unit Operator: {{unit_operator}}\n  ",
         "contentPartials": [],
         "defaultContent": "The query didn't return any results.",
         "editor": {

--- a/examples/notebooks/02_automated_run_example.ipynb
+++ b/examples/notebooks/02_automated_run_example.ipynb
@@ -159,7 +159,7 @@
     "\n",
     "- `fuel_type`: The primary fuel source used by each unit. This information is crucial as it relates to fuel costs and availability, as well as emissions.\n",
     "\n",
-    "- `emission_factor`: A numerical value representing the amount of CO2 (or equivalent) emissions produced per unit of electricity generated.\n",
+    "- `emission_factor`: A numerical value representing the amount of CO2 (or equivalent) emissions produced per unit of thermal energy input (t_CO2/MWh_thermal).\n",
     "\n",
     "- `max_power`: The maximum power output each unit can deliver. This is the upper limit of the unit's operational capacity given in MW.\n",
     "\n",

--- a/examples/notebooks/08_market_zone_coupling.ipynb
+++ b/examples/notebooks/08_market_zone_coupling.ipynb
@@ -552,7 +552,7 @@
     "    - **technology:** Type of technology (`nuclear` for all units).\n",
     "    - **bidding_nodal:** Bidding strategy used (`powerplant_energy_naive` for all units).\n",
     "    - **fuel_type:** Type of fuel used (`uranium` for all units).\n",
-    "    - **emission_factor:** Emissions per unit of energy produced (`0.0` for all units).\n",
+    "    - **emission_factor:** Emissions per unit of primary energy consumed (`0.0` t_CO2/MWh_thermal for all units).\n",
     "    - **max_power, min_power:** Operational power limits (`1000.0` MW max, `0.0` MW min for all units).\n",
     "    - **efficiency:** Conversion efficiency (`0.3` for all units).\n",
     "    - **additional_cost:** Additional operational costs (`5` to `34`, with southern units being more expensive).\n",

--- a/examples/notebooks/11_redispatch.ipynb
+++ b/examples/notebooks/11_redispatch.ipynb
@@ -473,7 +473,7 @@
     "    \"unit_operator\": [\"Operator 1\", \"Operator 2\", \"Operator 3\"],\n",
     "    \"fuel_type\": [\"lignite\", \"hard coal\", \"natural gas\"],\n",
     "    \"additional_cost\": [10, 20, 50],\n",
-    "    \"emission_factor\": [0, 0, 0],  # Emission factor in kg CO2/kWh\n",
+    "    \"emission_factor\": [0, 0, 0],  # Emission factor in t CO2/MWh\n",
     "}\n",
     "powerplant_units = pd.DataFrame(powerplant_units_data)\n",
     "\n",


### PR DESCRIPTION
We use emission_factor as amount of emissions per unit fuel input (i.e. t_CO2/MWh_thermal) in our framework. Not as emissions per electricity output. Descriptions in some notebooks are wrong.

## Description
This PR clarifies our use of emission_factor in 2 areas:
- the grafana dashboards, where this PR introduces the word 'thermal' for clarification
- notebooks 02, 08 and 11, where description was stating we use it as emissions per electricity output

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)