### PR TITLE
auto forecast registry passing

### DIFF
--- a/assume/common/forecaster.py
+++ b/assume/common/forecaster.py
@@ -185,8 +185,6 @@ class UnitForecaster:
         self.index: FastIndex = index
         self.availability: FastSeries = self._to_series(availability)
         self.forecast_algorithms = forecast_algorithms
-        if forecast_registries is None:
-            forecast_registries = {"init": {}, "preprocess": {}, "update": {}}
         self._registries = forecast_registries
         if market_prices is None:
             market_prices = {"EOM": 50}  # default value for tests

--- a/assume/scenario/loader_amiris.py
+++ b/assume/scenario/loader_amiris.py
@@ -12,7 +12,6 @@ import yaml
 from dateutil.relativedelta import relativedelta as rd
 from yaml_include import Constructor
 
-from assume.common.forecast_algorithms import get_forecast_registries
 from assume.common.forecaster import (
     DemandForecaster,
     PowerplantForecaster,
@@ -24,7 +23,6 @@ from assume.world import World
 
 logger = logging.getLogger(__name__)
 
-_forecast_registries = get_forecast_registries()
 
 translate_clearing = {
     "SAME_SHARES": "pay_as_clear",
@@ -188,7 +186,8 @@ def add_agent_to_world(
                         "price": value,
                     },
                     DemandForecaster(
-                        index, demand=-100000, forecast_registries=_forecast_registries
+                        index,
+                        demand=-100000,
                     ),
                 )
         case "EnergyExchange" | "DayAheadMarketSingleZone":
@@ -271,7 +270,6 @@ def add_agent_to_world(
                     DemandForecaster(
                         index,
                         demand=demand_series[: len(index)],
-                        forecast_registries=_forecast_registries,
                     ),
                 )
 
@@ -292,7 +290,6 @@ def add_agent_to_world(
                 index,
                 # price_forecast is used for price_EOM
                 market_prices={"eom": forecast_price},
-                forecast_registries=_forecast_registries,
             )
 
             capacity = device["EnergyToPowerRatio"] * device["InstalledPowerInMW"]
@@ -364,7 +361,6 @@ def add_agent_to_world(
                     "co2": prices.get("co2", 2),
                     translate_fuel_type[prototype["FuelType"]]: fuel_price,
                 },
-                forecast_registries=_forecast_registries,
             )
             # TODO UnplannedAvailabilityFactor is not respected
 
@@ -425,7 +421,6 @@ def add_agent_to_world(
                     translate_fuel_type[attr["EnergyCarrier"]]: fuel_price,
                     "co2": prices.get("co2", 0),
                 },
-                forecast_registries=_forecast_registries,
             )
             support_instrument = attr.get("SupportInstrument")
             support_conf = supports.get(attr.get("Set"))

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -18,7 +18,6 @@ from tqdm import tqdm
 
 from assume.common.exceptions import AssumeException
 from assume.common.fast_pandas import FastIndex
-from assume.common.forecast_algorithms import get_forecast_registries
 from assume.common.forecaster import (
     BuildingForecaster,
     CustomUnitForecaster,
@@ -619,7 +618,6 @@ def load_config_and_create_forecaster(
         fuel_prices_df = fuel_prices_df.reindex(index, method="ffill")
 
     forecast_algorithms = config.get("forecast_algorithms", {})
-    forecast_registries = get_forecast_registries()
 
     # create shared unit index for caching!
     shared_unit_index = FastIndex(
@@ -635,7 +633,6 @@ def load_config_and_create_forecaster(
                 forecast_algorithms=get_unit_forecast_algorithms(
                     forecast_algorithms, plant
                 ),
-                forecast_registries=forecast_registries,
             )
     if demand_units is not None:
         for id, demand in demand_units.iterrows():
@@ -646,7 +643,6 @@ def load_config_and_create_forecaster(
                 forecast_algorithms=get_unit_forecast_algorithms(
                     forecast_algorithms, demand
                 ),
-                forecast_registries=forecast_registries,
             )
     if storage_units is not None:
         for id, storage in storage_units.iterrows():
@@ -656,7 +652,6 @@ def load_config_and_create_forecaster(
                 forecast_algorithms=get_unit_forecast_algorithms(
                     forecast_algorithms, storage
                 ),
-                forecast_registries=forecast_registries,
             )
     if exchange_units is not None:
         for id, exchange in exchange_units.iterrows():
@@ -666,7 +661,6 @@ def load_config_and_create_forecaster(
                 forecast_algorithms=get_unit_forecast_algorithms(
                     forecast_algorithms, exchange
                 ),
-                forecast_registries=forecast_registries,
                 volume_export=exchanges_df[f"{id}_export"],
                 volume_import=exchanges_df[f"{id}_import"],
             )
@@ -683,7 +677,6 @@ def load_config_and_create_forecaster(
                             id, pd.Series(1.0, index, name=id)
                         ),
                         forecast_algorithms=unit_forecast_algorithms,
-                        forecast_registries=forecast_registries,
                         fuel_prices=fuel_prices_df,
                         load_profile=0,  # TODO
                         ev_load_profile=0,  # TODO
@@ -698,7 +691,6 @@ def load_config_and_create_forecaster(
                             id, pd.Series(1.0, index, name=id)
                         ),
                         forecast_algorithms=unit_forecast_algorithms,
-                        forecast_registries=forecast_registries,
                         fuel_prices=fuel_prices_df,
                     )
                 if type == "hydrogen_plant":
@@ -708,7 +700,6 @@ def load_config_and_create_forecaster(
                             id, pd.Series(1.0, index, name=id)
                         ),
                         forecast_algorithms=unit_forecast_algorithms,
-                        forecast_registries=forecast_registries,
                         hydrogen_demand=unit["demand"],
                         seasonal_storage_schedule=0,  # TODO
                     )
@@ -719,7 +710,6 @@ def load_config_and_create_forecaster(
                             id, pd.Series(1.0, index, name=id)
                         ),
                         forecast_algorithms=unit_forecast_algorithms,
-                        forecast_registries=forecast_registries,
                         demand=unit["demand"],
                         fuel_prices=fuel_prices_df,
                         electricity_price_flex=0,  # TODO

--- a/assume/scenario/loader_oeds.py
+++ b/assume/scenario/loader_oeds.py
@@ -13,14 +13,11 @@ import pandas as pd
 from dateutil import rrule as rr
 
 from assume import World
-from assume.common.forecast_algorithms import get_forecast_registries
 from assume.common.forecaster import DemandForecaster, PowerplantForecaster
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.scenario.oeds.infrastructure import InfrastructureInterface
 
 logger = logging.getLogger(__name__)
-
-_forecast_registries = get_forecast_registries()
 
 
 def load_oeds(
@@ -121,7 +118,6 @@ def load_oeds(
                     index,
                     availability=offshore_wind / offshore_wind.max(),
                     fuel_prices={"others": 0.2},
-                    forecast_registries=_forecast_registries,
                 ),
             )
 
@@ -205,7 +201,8 @@ def load_oeds(
                 "price": 1e3,
             },
             DemandForecaster(
-                index, demand=-abs(demand), forecast_registries=_forecast_registries
+                index,
+                demand=-abs(demand),
             ),
         )
 
@@ -227,7 +224,6 @@ def load_oeds(
                 index,
                 availability=solar / solar.max(),
                 fuel_prices={"others": 0.1},
-                forecast_registries=_forecast_registries,
             ),
         )
         if wind.max() > 0:
@@ -248,7 +244,6 @@ def load_oeds(
                     index,
                     availability=wind / wind.max(),
                     fuel_prices={"others": 0.2},
-                    forecast_registries=_forecast_registries,
                 ),
             )
 
@@ -278,7 +273,6 @@ def load_oeds(
                 index,
                 availability=1,
                 fuel_prices={"others": fuel_prices["biomass"] + randomness},
-                forecast_registries=_forecast_registries,
             ),
         )
         water = infra_interface.get_run_river_systems_in_area(area=area)
@@ -302,7 +296,6 @@ def load_oeds(
                 index,
                 availability=1,
                 fuel_prices={"others": 0.2},
-                forecast_registries=_forecast_registries,
             ),
         )
 
@@ -379,7 +372,6 @@ def load_oeds(
                             "others": fuel_prices[fuel_type] + randomness,
                             "co2": fuel_prices["co2"],
                         },
-                        forecast_registries=_forecast_registries,
                     ),
                 )
 

--- a/assume/scenario/loader_pypsa.py
+++ b/assume/scenario/loader_pypsa.py
@@ -10,7 +10,6 @@ import pypsa
 from dateutil import rrule as rr
 
 from assume import World
-from assume.common.forecast_algorithms import get_forecast_registries
 from assume.common.forecaster import (
     DemandForecaster,
     PowerplantForecaster,
@@ -19,8 +18,6 @@ from assume.common.forecaster import (
 from assume.common.market_objects import MarketConfig, MarketProduct
 
 logger = logging.getLogger(__name__)
-
-_forecast_registries = get_forecast_registries()
 
 
 def load_pypsa(
@@ -115,7 +112,6 @@ def load_pypsa(
                 index,
                 fuel_prices={generator.carrier: generator.marginal_cost},
                 availability=av,
-                forecast_registries=_forecast_registries,
             ),
         )
 
@@ -141,7 +137,8 @@ def load_pypsa(
                 "price": 1e3,
             },
             DemandForecaster(
-                index, demand=-abs(load_t), forecast_registries=_forecast_registries
+                index,
+                demand=-abs(load_t),
             ),
         )
 
@@ -178,9 +175,10 @@ def load_pypsa(
                 "capacity": storage.p_nom * storage.max_hours,
                 "bidding_strategies": bidding_strategies[unit_type][storage.name],
                 "technology": storage.carrier,
+                "emission_factor": storage.emission_factor or 0,
                 "node": storage.bus,
             },
-            UnitForecaster(index, forecast_registries=_forecast_registries),
+            UnitForecaster(index),
         )
 
     world.init_forecasts()

--- a/assume/world.py
+++ b/assume/world.py
@@ -36,6 +36,7 @@ from assume.common import (
     mango_codec_factory,
 )
 from assume.common.base import LearningConfig
+from assume.common.forecast_algorithms import get_forecast_registries
 from assume.common.forecaster import UnitForecaster
 from assume.common.utils import datetime2timestamp, timestamp2datetime
 from assume.markets import MarketRole, clearing_mechanisms
@@ -934,8 +935,10 @@ class World:
     ):
         units = self.units.values()  # make same object for cache
         markets = self.markets.values()  # make same object for cache
-
+        registries = get_forecast_registries()
         for unit in self.units.values():
+            if unit.forecaster._registries is None:
+                unit.forecaster._registries = registries
             unit.forecaster.initialize(
                 units,
                 markets,

--- a/docs/source/assume.common.rst
+++ b/docs/source/assume.common.rst
@@ -64,6 +64,14 @@ assume.common.utils module
    :undoc-members:
    :show-inheritance:
 
+assume.common.forecast\_algorithms module
+-----------------------------------------
+
+.. automodule:: assume.common.forecast_algorithms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 assume.common.grid\_utils module
 ------------------------------------
 

--- a/docs/source/demand_side_agent.rst
+++ b/docs/source/demand_side_agent.rst
@@ -88,6 +88,19 @@ Example Workflow
 2. Define objectives, such as minimizing electricity costs.
 3. Run the optimization to generate bids for the electricity market.
 
+.. note::
+
+   DSM units (e.g. :class:`~assume.units.steel_plant.SteelPlant`,
+   :class:`~assume.units.building.Building`,
+   :class:`~assume.units.hydrogen_plant.HydrogenPlant`,
+   :class:`~assume.units.steam_generation_plant.SteamGenerationPlant`) build their internal
+   optimisation model inside the forecaster's ``initialize`` step.  When running the
+   simulation through the normal world / scenario loader this happens automatically.  However,
+   if you create a unit programmatically and do **not** call
+   :meth:`~assume.common.forecaster.UnitForecaster.initialize` (or
+   :func:`~assume.world.World.init_forecasts`), you must call
+   ``unit.setup_model()`` explicitly before running optimisation on the unit.
+
 Residential Agent: Building
 ----------------------------
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -12,6 +12,11 @@ Upcoming Release
   The features in this section are not released yet, but will be part of the next release! To use the features already you have to install the main branch,
   e.g. ``pip install git+https://github.com/assume-framework/assume``
 
+
+**New Features:**
+  - **Generic Forecasting Interface**: This interface enables to specify different forecast algorithms for preprocess, initialization and update during runtime. They can be specified in the config.yaml or unit csv files. For more information about currently implemented algorithms and how to specify them please read the documentation on Unit forecasts.
+
+
 0.6.0 - (18th March 2026)
 =========================
 
@@ -31,10 +36,6 @@ Upcoming Release
   - **Fix buffer and update order**: Fixed the order of buffer writing and policy updating in the learning role to ensure that both have the exact same order, which is necessary so that during updates the correct data is used. This bug will have compromised learning with very heterogeneous units after the last release.
   - **Fix data loss in RL learning role**: Fixed data loss in RL learning role by implementing atomic swap with carry-over for incomplete timesteps in cache
   - **Update notebooks to always install latest repo version from Google Colab**: This ensures that the latest version is always used
-
-
-  **New Features:**
-  - **Generic Forecasting Interface**: This interface enables to specify different forecast algorithms for preprocess, initialization and update during runtime. They can be specified in the config.yaml or unit csv files. For more information about currently implemented algorithms and how to specify them please read the documentation on Unit forecasts.
 
 0.5.6 - (23th December 2025)
 ============================

--- a/docs/source/unit_forecasts.rst
+++ b/docs/source/unit_forecasts.rst
@@ -274,6 +274,14 @@ Besides configuring algorithms, there are two additional ways to supply forecast
    corresponding algorithm to ``{forecast_metric}_keep_given`` to prevent the initialize step
    from overwriting your data.
 
+.. note::
+
+   When using direct instantiation you are responsible for driving the forecast lifecycle.
+   If you do not call :meth:`~assume.common.forecaster.UnitForecaster.initialize` (or
+   :func:`~assume.world.World.init_forecasts`), DSM units will not have their internal
+   optimisation model built and you must call ``unit.setup_model()`` explicitly before
+   running optimisation or dispatching the unit.
+
 ***********************************
 Adding Custom Algorithms
 ***********************************

--- a/examples/notebooks/10a_DSU_and_flexibility.ipynb
+++ b/examples/notebooks/10a_DSU_and_flexibility.ipynb
@@ -628,6 +628,8 @@
     "    bidding_strategies={\"eom\": DsmEnergyOptimizationStrategy()},\n",
     ")\n",
     "\n",
+    "paper_plant.setup_model()\n",
+    "\n",
     "# ---- Step 5: Solve for optimal operation with flexibility ----\n",
     "paper_plant.determine_optimal_operation_without_flex()\n",
     "flex_profile = paper_plant.opt_power_requirement"
@@ -1323,6 +1325,8 @@
     "    peak_load_cap=10,\n",
     "    bidding_strategies={\"eom\": DsmEnergyOptimizationStrategy()},\n",
     ")\n",
+    "\n",
+    "paper_plant_1.setup_model()\n",
     "\n",
     "# ---- Step 5: Solve for optimal operation with flexibility ----\n",
     "paper_plant_1.determine_optimal_operation_with_flex()\n",
@@ -2893,7 +2897,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "assume",
+   "display_name": "assume3",
    "language": "python",
    "name": "python3"
   },
@@ -2907,7 +2911,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.19"
+   "version": "3.12.12"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #771


## Description
<!-- Summarise the purpose/motivation and the changes of the PR. -->
This change automatically adds forecast registries in `world.init_forecasts()` to the forecasters if not passed to the units directly.
As a result the scenario loaders dont need to pass the registry to each forecaster separately and instead the registries are passed at one point only (as long as one uses world.init_forecasts()).

Also fixes forecaster related bug in notebook 10a (missing unit.setup_model) and adds documentation on this.

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
