### PR TITLE
raise ValidationError when forecaster validation fails

### DIFF
--- a/assume/common/exceptions.py
+++ b/assume/common/exceptions.py
@@ -10,7 +10,7 @@ class AssumeException(Exception):
 
 
 class ValidationError(ValueError):
-    def __init__(self, message: str, id: str, field: str):
+    def __init__(self, message: str, id: str = None, field: str = None):
         super().__init__(message)
         self.field = field
         self.id = id

--- a/assume/common/forecaster.py
+++ b/assume/common/forecaster.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, TypeAlias
 
 import pandas as pd
 
+from assume.common.exceptions import ValidationError
 from assume.common.fast_pandas import FastIndex, FastSeries
 from assume.common.market_objects import MarketConfig
 
@@ -184,6 +185,10 @@ class UnitForecaster:
 
         self.index: FastIndex = index
         self.availability: FastSeries = self._to_series(availability)
+        if any(self.availability < 0) or any(self.availability > 1):
+            raise ValidationError(
+                message="Availability must be between 0 and 1", field="availability"
+            )
         self.forecast_algorithms = forecast_algorithms
         if forecast_registries is None:
             forecast_registries = {"init": {}, "preprocess": {}, "update": {}}
@@ -414,7 +419,7 @@ class DemandForecaster(UnitForecaster):
         )
         self.demand = self._to_series(demand)
         if any(self.demand > 0):
-            raise ValueError(f"{demand=} must be negative")
+            raise ValidationError(message="demand must be negative", field="demand")
 
 
 class PowerplantForecaster(UnitForecaster):

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -882,3 +882,46 @@ def set_random_seed(seed: int | None, torch_deterministic: bool = True):
             )
     except ImportError:
         pass
+
+
+def load_index_file(file_name: Path, index: pd.DatetimeIndex):
+    if not file_name.is_file():
+        return None
+    df = pd.read_csv(
+        file_name,
+        index_col=0,
+        encoding="utf-8",
+        na_values=["n.a.", "None", "-", "none", "nan"],
+        parse_dates=True,
+    )
+
+    if len(df.index) == 1:
+        return df
+
+    if len(df.index) != len(index) and not isinstance(df.index, pd.DatetimeIndex):
+        logger.warning(
+            f"{file_name}: simulation time line does not match length of dataframe and index is not a datetimeindex. Returning None."
+        )
+        return None
+
+    df.index.freq = df.index.inferred_freq
+
+    if len(df.index) < len(index) and df.index.freq == index.freq:
+        logger.warning(
+            f"{file_name}: simulation time line is longer than length of the dataframe. Returning None."
+        )
+        return None
+
+    if df.index.freq < index.freq:
+        logger.warning(
+            f"Resolution of {file_name} ({df.index.freq}) is higher than the simulation ({index.freq}). "
+            "Resampling using mean(). Make sure this is what you want."
+        )
+        df = df.resample(index.freq).mean()
+        logger.info(f"Downsampling {file_name} successful.")
+
+    elif df.index.freq > index.freq or len(df.index) < len(index):
+        logger.warning("Upsampling not implemented yet. Returning None.")
+        return None
+
+    return df.loc[index]

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -35,6 +35,7 @@ from assume.common.utils import (
     adjust_unit_operator_for_learning,
     confirm_learning_save_path,
     convert_to_rrule_freq,
+    load_index_file,
     normalize_availability,
     set_random_seed,
 )
@@ -106,72 +107,40 @@ def load_file(
     if file_name in config:
         if config[file_name] is None:
             return None
-        file_path = f"{path}/{config[file_name]}"
+        file_path = Path(path) / config[file_name]
     else:
-        file_path = f"{path}/{file_name}.csv"
+        file_path = Path(path) / f"{file_name}.csv"
 
     try:
-        df = pd.read_csv(
-            file_path,
-            index_col=0,
-            encoding="utf-8",
-            na_values=["n.a.", "None", "-", "none", "nan"],
-            parse_dates=index is not None,
-        )
-        for col in df:
-            # check if the column is of dtype int
-            if df[col].dtype == "int":
-                # convert the column to float
-                df[col] = df[col].astype(float)
-
         if index is not None:
-            if len(df.index) == 1:
-                return df
+            df = load_index_file(file_path, index)
+        else:
+            df = pd.read_csv(
+                file_path,
+                index_col=0,
+                encoding="utf-8",
+                na_values=["n.a.", "None", "-", "none", "nan"],
+                parse_dates=index is not None,
+            )
+            for col in df:
+                # check if the column is of dtype int
+                if df[col].dtype == "int":
+                    # convert the column to float
+                    df[col] = df[col].astype(float)
 
-            if len(df.index) != len(index) and not isinstance(
-                df.index, pd.DatetimeIndex
-            ):
-                logger.warning(
-                    f"{file_name}: simulation time line does not match length of dataframe and index is not a datetimeindex. Returning None."
-                )
-                return None
+            if check_duplicates:
+                # Check if duplicate unit names exist and raise an error
+                duplicates = df.index[df.index.duplicated()].unique()
 
-            df.index.freq = df.index.inferred_freq
-
-            if len(df.index) < len(index) and df.index.freq == index.freq:
-                logger.warning(
-                    f"{file_name}: simulation time line is longer than length of the dataframe. Returning None."
-                )
-                return None
-
-            if df.index.freq < index.freq:
-                logger.warning(
-                    f"Resolution of {file_name} ({df.index.freq}) is higher than the simulation ({index.freq}). "
-                    "Resampling using mean(). Make sure this is what you want."
-                )
-                df = df.resample(index.freq).mean()
-                logger.info(f"Downsampling {file_name} successful.")
-
-            elif df.index.freq > index.freq or len(df.index) < len(index):
-                logger.warning("Upsampling not implemented yet. Returning None.")
-                return None
-
-            df = df.loc[index]
-
-        elif check_duplicates:
-            # Check if duplicate unit names exist and raise an error
-            duplicates = df.index[df.index.duplicated()].unique()
-
-            if len(duplicates) > 0:
-                duplicate_names = ", ".join(map(str, duplicates))
-                raise ValueError(
-                    f"Duplicate unit names found in {file_name}: {duplicate_names}. Please rename them to avoid conflicts."
-                )
-
+                if len(duplicates) > 0:
+                    duplicate_names = ", ".join(map(str, duplicates))
+                    raise ValueError(
+                        f"Duplicate unit names found in {file_name}: {duplicate_names}. Please rename them to avoid conflicts."
+                    )
         return df
 
     except FileNotFoundError:
-        logger.info(f"{file_name} not found. Returning None")
+        logger.info(f"{file_path} not found. Returning None")
         return None
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@
 import calendar
 import time
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from unittest.mock import patch
 
 import numpy as np
@@ -23,6 +24,7 @@ from assume.common.utils import (
     get_products_index,
     get_supported_solver,
     initializer,
+    load_index_file,
     parse_duration,
     plot_orderbook,
     separate_orders,
@@ -821,6 +823,28 @@ def test_solver_unavailable(monkeypatch):
     monkeypatch.setattr("assume.common.utils.check_available_solvers", lambda *args: [])
     with pytest.raises(RuntimeError):
         get_supported_solver()
+
+
+def test_load_index_file():
+    path = Path("./tests/fixtures/forecast_init/demand.csv")
+
+    index = pd.date_range("2019-01-01", periods=10, freq="h")
+    df = load_index_file(path, index)
+    assert len(df) == 10
+
+    index = pd.date_range("2019-01-01", periods=24, freq="h")
+    df = load_index_file(path, index)
+    assert len(df) == 24
+
+    index = pd.date_range("2019-01-01", periods=36, freq="h")
+    df = load_index_file(path, index)
+    assert df is None
+
+    invalid_path = Path("./tests/fixtures/forecast_init/invalid")
+
+    index = pd.date_range("2019-01-01", periods=36, freq="h")
+    df = load_index_file(invalid_path, index)
+    assert df is None
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
use validation error to indicate wrong forecaster values. Make id and field values optional since they are not always provided
