### PR TITLE
add link to matrix room

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Developed as an open-source model, its primary objectives are to ensure usabilit
 A unique feature of the ASSUME toolbox is its integration of **Deep Reinforcement Learning** methods into the behavioral strategies of market agents. The model offers various predefined agent representations for both the demand and generation sides, which can be used as plug-and-play modules, simplifying the reinforcement of learning strategies.
 This setup enables research into new market designs and dynamics in energy markets.
 
+**If you have any questions - get in contact on matrix: https://matrix.to/#/#assume-framework:matrix.org**
+
 ### What can the software do?
 The main motivation of ASSUME is to overcome the limitations of fixed, rule-based behaviors in existing ABMs.
 For this, it leverages advancements in artificial intelligence, particularly deep reinforcement learning (DRL), enabling agents to adapt their behavior dynamically in response to market conditions.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ Developed as an open-source model, its primary objectives are to ensure usabilit
 A unique feature of the ASSUME toolbox is its integration of **Deep Reinforcement Learning** methods into the behavioral strategies of market agents. The model offers various predefined agent representations for both the demand and generation sides, which can be used as plug-and-play modules, simplifying the reinforcement of learning strategies.
 This setup enables research into new market designs and dynamics in energy markets.
 
-**If you have any questions - get in contact on matrix: https://matrix.to/#/#assume-framework:matrix.org**
+**If you have any questions - get in contact on matrix: https://matrix.to/#/#assume-framework:matrix.org**<br>
+Log into your existing matrix account or create a new one. Paste the URL in the search field.
 
 ### What can the software do?
 The main motivation of ASSUME is to overcome the limitations of fixed, rule-based behaviors in existing ABMs.


### PR DESCRIPTION
## Description
This adds a link to our new public matrix room, where all users can talk and discuss issues and features.

Matrix is a federated open-source communication ecosystem: https://matrix.to/#/#assume-framework:matrix.org
One can use an account on any home server (just like e-mail).
People from KIT already have an account from their institution: https://www.scc.kit.edu/en/services/matrix.php
Same for uni-freiburg: https://matrix.uni-freiburg.de/#/welcome

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
