### PR TITLE
pin dependency versions

### DIFF
--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -16,6 +16,8 @@ Upcoming Release
 **New Features:**
   - **Generic Forecasting Interface**: This interface enables to specify different forecast algorithms for preprocess, initialization and update during runtime. They can be specified in the config.yaml or unit csv files. For more information about currently implemented algorithms and how to specify them please read the documentation on Unit forecasts.
 
+**Bug Fixes:**
+  - **dependencies**: pin xarray and setuptools dependencies until upstream fixes are available
 
 0.6.0 - (18th March 2026)
 =========================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "pyyaml >=6.0",
     "pyyaml-include >=2.2a",
     "pyomo >=6.8.0",
-    "xarray",
+    "xarray <v2026.04.0", # https://github.com/assume-framework/assume/issues/790
     "highspy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
 learning = [
     "torch >=2.0.1",
     "tensorboard >=2.7.0",
+    "setuptools <82" # https://github.com/tensorflow/tensorboard/issues/7003
 ]
 network = [
     "pypsa",


### PR DESCRIPTION
## Related Issue
closes #790
closes #774 

## Description

pin setuptools to <82 when installing tensorboard - can be removed after release of https://github.com/tensorflow/tensorboard/pull/7057

pin xarray version as latest changes break in linopy


## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
