### PR TITLE
Update grafana dashboards

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -41,7 +41,7 @@ services:
     environment:
       GF_SECURITY_ALLOW_EMBEDDING: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"
-      GF_INSTALL_PLUGINS: "marcusolsson-dynamictext-panel,orchestracities-map-panel"
+      GF_INSTALL_PLUGINS: "marcusolsson-dynamictext-panel,orchestracities-map-panel, volkovlabs-variable-panel"
       GF_SECURITY_ADMIN_USER: assume
       GF_SECURITY_ADMIN_PASSWORD: "assume"
       GF_RENDERING_SERVER_URL: http://renderer:8081/render

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -24,11 +24,13 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 2,
   "links": [],
   "panels": [
     {
-      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 5,
         "w": 24,
@@ -45,7 +47,7 @@
         "content": "# Welcome to our ASSUME demo\n\nThis is the Grafana Dashboard which makes interacting with the simulation data very easy.\n\n*IMPORTANT NOTE:* Grafana uses automated aggregation of data into time buckets with large time horizons displayed, e.g. time horizon > 1 month. It will display the average of the selected metric in the time bucket which underestimates the variance of the data and smoothes it. ",
         "mode": "markdown"
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "title": "Overview Dashboard",
       "type": "text"
     },
@@ -63,6 +65,10 @@
       "type": "row"
     },
     {
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -79,7 +85,8 @@
         "content": "# Market-specific Data\n\nData specific for the market depending on the choice made at te top of the panel\n\n",
         "mode": "markdown"
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
+      "title": "",
       "type": "text"
     },
     {
@@ -100,6 +107,7 @@
             "axisLabel": "",
             "axisPlacement": "left",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 1,
             "gradientMode": "none",
@@ -119,6 +127,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -134,7 +143,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -186,12 +195,13 @@
           ""
         ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -249,10 +259,9 @@
     },
     {
       "datasource": {
-        "type": "postgres",
+        "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "Big Point Size is demand match. Unused generation after that point",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -264,6 +273,7 @@
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
+            "fillOpacity": 50,
             "hideFrom": {
               "legend": false,
               "tooltip": false,
@@ -272,41 +282,77 @@
             "lineStyle": {
               "fill": "solid"
             },
+            "pointShape": "circle",
             "pointSize": {
-              "fixed": 2
+              "fixed": 1,
+              "max": 10,
+              "min": 0
             },
+            "pointStrokeWidth": 1,
             "scaleDistribution": {
               "type": "linear"
             },
             "show": "points+lines"
           },
-          "fieldMinMax": false,
           "mappings": [],
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
                 "value": 80
               }
             ]
-          },
-          "unit": "megwatt"
+          }
         },
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "Price"
+              "id": "byRegexp",
+              "options": ".*Demand.*"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 5
+              },
+              {
+                "id": "custom.lineStyle",
+                "value": {
+                  "dash": [
+                    10,
+                    10
+                  ],
+                  "fill": "dash"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Price.*"
             },
             "properties": [
               {
                 "id": "unit",
                 "value": "€/MWh"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*Cumulative Volume.*"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "megwatt"
               }
             ]
           }
@@ -318,149 +364,40 @@
         "x": 0,
         "y": 21
       },
-      "id": 100,
-      "maxPerRow": 4,
+      "id": 105,
       "options": {
         "legend": {
-          "calcs": [
-            "max",
-            "min"
-          ],
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
           "showLegend": true
         },
-        "mapping": "manual",
+        "mapping": "auto",
         "series": [
           {
-            "frame": {
-              "matcher": {
-                "id": "byIndex",
-                "options": 1
-              }
-            },
-            "name": {
-              "fixed": "Demand"
-            },
             "size": {
               "matcher": {
                 "id": "byName",
-                "options": "size"
-              }
-            },
-            "x": {
-              "matcher": {
-                "id": "byName",
-                "options": "Volume"
-              }
-            },
-            "y": {
-              "matcher": {
-                "id": "byName",
-                "options": "Price"
-              }
-            }
-          },
-          {
-            "frame": {
-              "matcher": {
-                "id": "byIndex",
-                "options": 0
-              }
-            },
-            "name": {
-              "fixed": "Generation"
-            },
-            "size": {
-              "matcher": {
-                "id": "byName",
-                "options": "size"
-              }
-            },
-            "x": {
-              "matcher": {
-                "id": "byName",
-                "options": "Volume"
-              }
-            },
-            "y": {
-              "matcher": {
-                "id": "byName",
-                "options": "Price"
+                "options": "Size"
               }
             }
           }
         ],
-        "seriesMapping": "auto",
         "tooltip": {
-          "maxHeight": 600,
+          "hideZeros": false,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
-          "datasource": {
-            "type": "postgres",
-            "uid": "P7B13B9DF907EC40C"
-          },
+          "dataset": "assume",
           "editorMode": "code",
           "format": "table",
-          "group": [],
-          "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  \n  sum(volume::float) OVER (PARTITION BY market_id ORDER BY price asc, unit_id) AS \"Volume\",\n  price::float AS \"Price\", unit_id,\n  1/(volume - accepted_volume +1)/2 as size\n  --'rgba(255,255,255,1)' as delta\nFROM market_orders\nWHERE\n  \n  start_time = (select min(start_time) from market_orders where market_id = '$market' AND\n      simulation = '$simulation' and $__timeFilter(start_time))\n  AND\n  volume > 0 AND\n  --accepted_volume != 0 AND\n  market_id = '$market' AND\n  simulation = '$simulation'\nGROUP BY unit_id, volume, accepted_volume, price, market_id --, bid_id\nORDER BY price asc\n\n-- ",
-          "refId": "Volume",
-          "select": [
-            [
-              {
-                "params": [
-                  "supply_volume"
-                ],
-                "type": "column"
-              }
-            ]
-          ],
-          "sql": {
-            "columns": [
-              {
-                "parameters": [],
-                "type": "function"
-              }
-            ],
-            "groupBy": [
-              {
-                "property": {
-                  "type": "string"
-                },
-                "type": "groupBy"
-              }
-            ],
-            "limit": 50
-          },
-          "table": "market_meta",
-          "timeColumn": "product_start",
-          "timeColumnType": "timestamp",
-          "where": [
-            {
-              "name": "$__timeFilter",
-              "params": [],
-              "type": "macro"
-            }
-          ]
-        },
-        {
-          "datasource": {
-            "type": "postgres",
-            "uid": "P7B13B9DF907EC40C"
-          },
-          "editorMode": "code",
-          "format": "table",
-          "hide": false,
-          "rawQuery": true,
-          "rawSql": "SELECT\n  -sum(volume::float) OVER (PARTITION BY market_id ORDER BY accepted_price asc, unit_id) AS \"Volume\",\n  accepted_price::float AS \"Price\", unit_id,\n  10 as size\nFROM market_orders\nWHERE\n  \n  start_time = (select min(start_time) from market_orders where market_id = '$market' AND\n  simulation = '$simulation' and $__timeFilter(start_time))\n  AND\n  volume < 0 AND\n  --accepted_volume != 0 AND\n  market_id = '$market' AND\n  simulation = '$simulation'\nGROUP BY unit_id, volume, accepted_volume, accepted_price, market_id --, bid_id\nORDER BY accepted_price asc\n\n-- ",
-          "refId": "Demand",
+          "rawSql": "SELECT\r\n  lag(cum_vol, 1, 0) OVER (ORDER BY cum_vol) AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  5 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = (\r\n        SELECT min(start_time) FROM market_orders\r\n        WHERE market_id = '$market'\r\n          AND simulation = '$simulation'\r\n          AND $__timeFilter(start_time)\r\n      )\r\n      AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  cum_vol AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = (\r\n        SELECT min(start_time) FROM market_orders\r\n        WHERE market_id = '$market'\r\n          AND simulation = '$simulation'\r\n          AND $__timeFilter(start_time)\r\n      )\r\n      AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  0::float AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  (SELECT max(price::float) FROM market_orders\r\n   WHERE market_id = '$market'\r\n     AND simulation = '$simulation'\r\n     AND accepted_volume > 0\r\n     AND start_time = (\r\n       SELECT min(start_time) FROM market_orders\r\n       WHERE market_id = '$market'\r\n         AND simulation = '$simulation'\r\n         AND $__timeFilter(start_time)\r\n     )\r\n  ) AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nORDER BY \"Cumulative Volume\" ASC, \"Price\" ASC",
+          "refId": "A",
           "sql": {
             "columns": [
               {
@@ -481,6 +418,17 @@
         }
       ],
       "title": "Merit Order $market at $min_time",
+      "transformations": [
+        {
+          "id": "partitionByValues",
+          "options": {
+            "fields": [
+              "Technology"
+            ],
+            "keepFields": false
+          }
+        }
+      ],
       "type": "xychart"
     },
     {
@@ -501,6 +449,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 76,
             "gradientMode": "none",
@@ -517,6 +466,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -532,7 +482,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -712,12 +662,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -851,6 +802,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -867,6 +819,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -882,7 +835,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -911,12 +864,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -942,7 +896,7 @@
           ],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\n  $__timeGroupAlias(start_time,$__interval),\n  avg(accepted_price::float) AS \"Price\", unit_id\nFROM market_orders\nWHERE\n  $__timeFilter(start_time) AND\n  market_id = '$market' AND\n  simulation = '$simulation'\nGROUP BY 1, unit_id --, bid_id\nORDER BY 1",
+          "rawSql": "SELECT\n  $__timeGroupAlias(start_time,$__interval),\n  avg(accepted_price::float) AS \"Price\", unit_id, bid_id\nFROM market_orders\nWHERE\n  $__timeFilter(start_time) AND\n  market_id = '$market' AND\n  simulation = '$simulation'\nGROUP BY 1, unit_id, bid_id\nORDER BY 1",
           "refId": "A",
           "select": [
             [
@@ -1050,6 +1004,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1066,6 +1021,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -1081,7 +1037,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1110,12 +1066,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1281,7 +1238,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1348,6 +1305,7 @@
         "showValue": "never",
         "stacking": "none",
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
@@ -1356,7 +1314,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 0
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1365,7 +1323,6 @@
           },
           "format": "table",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  simulation,\n  sum(round(CAST(value AS numeric), 2))  FILTER (WHERE variable = 'total_cost') as \"Total cost\",\n  sum(round(CAST(value AS numeric), 2))  FILTER (WHERE variable = 'total_volume') as \"Total volume\"\nFROM kpis\nWHERE simulation = '$simulation'\ngroup by simulation",
@@ -1407,6 +1364,9 @@
             "cellOptions": {
               "type": "auto"
             },
+            "footer": {
+              "reducers": []
+            },
             "inspect": false
           },
           "mappings": [],
@@ -1415,7 +1375,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1485,14 +1445,6 @@
       "id": 76,
       "options": {
         "cellHeight": "sm",
-        "footer": {
-          "countRows": false,
-          "fields": "",
-          "reducer": [
-            "sum"
-          ],
-          "show": false
-        },
         "showHeader": true,
         "sortBy": [
           {
@@ -1501,7 +1453,7 @@
           }
         ]
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1511,7 +1463,6 @@
           "editorMode": "code",
           "format": "table",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  simulation,\n  avg(round(CAST(value AS numeric), 2))  FILTER (WHERE variable = 'avg_price') as avg_price,\n  sum(round(CAST(value AS numeric), 2))  FILTER (WHERE variable = 'total_cost') as total_cost,\n  sum(round(CAST(value AS numeric), 2)*1000)  FILTER (WHERE variable = 'total_volume') as total_volume\nFROM kpis\ngroup by simulation\nORDER BY simulation",
@@ -1606,13 +1557,15 @@
           "fields": "/^sum$/",
           "values": true
         },
+        "sort": "desc",
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1628,7 +1581,6 @@
               "type": "column"
             }
           ],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT \n  NOW() as time_sec,\n  SUM(max_power),\n  technology\nFROM power_plant_meta\nWHERE \"simulation\" LIKE '$simulation'\nGROUP BY technology, simulation;\n\n\n",
@@ -1675,7 +1627,6 @@
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1687,14 +1638,17 @@
             "axisColorMode": "series",
             "axisLabel": "Market price €/MWh",
             "axisPlacement": "auto",
+            "fillOpacity": 50,
             "hideFrom": {
               "legend": false,
               "tooltip": false,
               "viz": false
             },
+            "pointShape": "circle",
             "pointSize": {
               "fixed": 4
             },
+            "pointStrokeWidth": 1,
             "scaleDistribution": {
               "type": "linear"
             },
@@ -1706,7 +1660,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1744,14 +1698,37 @@
           "placement": "bottom",
           "showLegend": true
         },
-        "series": [],
-        "seriesMapping": "auto",
+        "mapping": "auto",
+        "series": [
+          {
+            "frame": {
+              "matcher": {
+                "id": "byIndex",
+                "options": 0
+              }
+            },
+            "x": {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              }
+            },
+            "y": {
+              "matcher": {
+                "id": "byType",
+                "options": "number"
+              }
+            }
+          }
+        ],
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1799,7 +1776,10 @@
       "type": "row"
     },
     {
-      "description": "",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
       "gridPos": {
         "h": 3,
         "w": 24,
@@ -1816,7 +1796,8 @@
         "content": "# Unit Specific Data\n\nFor the chosen market and the chosen unit here the dispatch is displayed.",
         "mode": "markdown"
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
+      "title": "",
       "type": "text"
     },
     {
@@ -1836,6 +1817,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -1855,6 +1837,7 @@
               "type": "linear"
             },
             "showPoints": "always",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -1870,7 +1853,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -1902,12 +1885,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1917,7 +1901,6 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  $__timeGroupAlias(datetime,$__interval),\n  avg(power) AS \"Market dispatch\",\n  concat(unit_id, ' - ', market_id) as \"unit\"\nFROM market_dispatch\nWHERE\n  $__timeFilter(datetime) AND\n  simulation = '$simulation' AND\n  unit_id in ($Gen_Units)\nGROUP BY 1, unit_id, power, market_id\nORDER BY 1",
@@ -1967,7 +1950,6 @@
           },
           "editorMode": "code",
           "format": "time_series",
-          "hide": false,
           "rawQuery": true,
           "rawSql": "SELECT\n  $__timeGroupAlias(time,$__interval),\n  avg(power) AS \"Actual dispatch\",\n  unit\nFROM unit_dispatch\nWHERE\n  $__timeFilter(time) AND\n  simulation = '$simulation' AND\n  unit in ($Gen_Units)\nGROUP BY 1, unit\nORDER BY 1",
           "refId": "B",
@@ -2005,7 +1987,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2115,6 +2097,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2131,6 +2114,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2146,7 +2130,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2190,12 +2174,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2205,10 +2190,9 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  $__timeGroupAlias(start_time,$__interval),\r\n  avg(accepted_price::float) AS \"Accepted price:\",\r\n  avg(price) AS \"Bid price:\",\r\n  concat(unit_id, ' - ', market_id) as \"unit_id\"\r\nFROM market_orders\r\nWHERE\r\n  $__timeFilter(start_time) AND\r\n  unit_id in ($Gen_Units) AND\r\n  simulation = '$simulation'\r\nGROUP BY 1, unit_id, market_id\r\nORDER BY 1\r\n",
+          "rawSql": "SELECT\r\n  $__timeGroupAlias(start_time,$__interval),\r\n  avg(accepted_price::float) AS \"Accepted price:\",\r\n  avg(price) AS \"Bid price:\",\r\n  concat(unit_id, ' - ', market_id) as \"unit_id\",\r\n  max(bid_id) AS \"bid_id\"\r\nFROM market_orders\r\nWHERE\r\n  $__timeFilter(start_time) AND\r\n  unit_id in ($Gen_Units) AND\r\n  simulation = '$simulation'\r\nGROUP BY 1, unit_id, market_id\r\nORDER BY 1",
           "refId": "B",
           "select": [
             [
@@ -2350,7 +2334,6 @@
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2363,6 +2346,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2379,6 +2363,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2394,7 +2379,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2453,12 +2438,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2570,7 +2556,6 @@
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2582,7 +2567,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2649,7 +2634,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2710,7 +2695,6 @@
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -2723,6 +2707,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2739,6 +2724,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -2754,7 +2740,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2812,12 +2798,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2903,6 +2890,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -2919,6 +2907,7 @@
               "type": "linear"
             },
             "showPoints": "always",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -2934,7 +2923,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -2965,12 +2954,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3030,7 +3020,6 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  $__timeGroupAlias(time,$__interval),\n  power AS \"Actual dispatch\",\n  unit\nFROM unit_dispatch\nWHERE\n  $__timeFilter(time) AND\n  simulation = '$simulation' AND\n  unit in ($Demand_Units)\nGROUP BY 1, unit, power\nORDER BY 1",
@@ -3089,7 +3078,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3199,6 +3188,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -3215,6 +3205,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3230,7 +3221,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3274,12 +3265,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3411,7 +3403,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3487,7 +3479,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3497,7 +3489,6 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  -energy_cashflow AS \"Cashflow\",\r\n  unit\r\nFROM unit_dispatch d\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  d.simulation = '$simulation' AND\r\n  unit in ($Demand_Units)\r\nGROUP BY 1, unit, energy_cashflow, power\r\nORDER BY 1",
@@ -3549,7 +3540,6 @@
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -3562,6 +3552,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -3578,6 +3569,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3593,7 +3585,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3652,12 +3644,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3747,7 +3740,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3783,7 +3776,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3793,7 +3786,6 @@
           "editorMode": "code",
           "format": "table",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  sum(energy_cashflow)/sum(power) as \"Price per MW\",\n  unit\nFROM unit_dispatch d\nWHERE\n  $__timeFilter(time) AND\n  d.simulation = '$simulation' AND\n  unit in ($Demand_Units)\nGROUP BY unit\nORDER BY 1",
@@ -3856,7 +3848,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -3892,7 +3884,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -3902,7 +3894,6 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\r\n  $__timeGroupAlias(time,$__interval),\r\n  -power*1e3 as \"Volume\",\r\n  unit\r\nFROM unit_dispatch d\r\nWHERE\r\n  $__timeFilter(time) AND\r\n  d.simulation = '$simulation' AND\r\n  unit in ($Demand_Units)\r\nGROUP BY 1, unit, energy_cashflow, power\r\nORDER BY 1",
@@ -3966,6 +3957,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -3982,6 +3974,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -3997,7 +3990,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4045,12 +4038,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -4136,6 +4130,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -4152,6 +4147,7 @@
               "type": "linear"
             },
             "showPoints": "always",
+            "showValues": false,
             "spanNulls": true,
             "stacking": {
               "group": "A",
@@ -4167,7 +4163,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4198,12 +4194,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -4263,7 +4260,6 @@
           "editorMode": "code",
           "format": "time_series",
           "group": [],
-          "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
           "rawSql": "SELECT\n  $__timeGroupAlias(time,$__interval),\n  power AS \"Actual dispatch\",\n  unit\nFROM unit_dispatch\nWHERE\n  $__timeFilter(time) AND\n  simulation = '$simulation' AND\n  unit in ($Storage_Units)\nGROUP BY 1, unit, power\nORDER BY 1",
@@ -4322,7 +4318,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4414,6 +4410,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -4430,6 +4427,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -4445,7 +4443,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4476,12 +4474,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "single",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -4555,6 +4554,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -4571,6 +4571,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -4586,7 +4587,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4630,12 +4631,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "desc"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -4756,7 +4758,6 @@
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4769,6 +4770,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -4785,6 +4787,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -4800,7 +4803,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -4859,12 +4862,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -4976,7 +4980,6 @@
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -4988,7 +4991,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -5055,7 +5058,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "11.0.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -5116,7 +5119,6 @@
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
-      "description": "",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -5129,6 +5131,7 @@
             "axisLabel": "",
             "axisPlacement": "auto",
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -5145,6 +5148,7 @@
               "type": "linear"
             },
             "showPoints": "auto",
+            "showValues": false,
             "spanNulls": false,
             "stacking": {
               "group": "A",
@@ -5160,7 +5164,7 @@
             "steps": [
               {
                 "color": "green",
-                "value": null
+                "value": 0
               },
               {
                 "color": "red",
@@ -5218,12 +5222,13 @@
           "showLegend": true
         },
         "tooltip": {
+          "hideZeros": false,
           "maxHeight": 600,
           "mode": "multi",
           "sort": "none"
         }
       },
-      "pluginVersion": "11.4.0",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -5280,14 +5285,14 @@
       "type": "timeseries"
     }
   ],
+  "preload": false,
   "refresh": "",
-  "schemaVersion": 39,
+  "schemaVersion": 42,
   "tags": [],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
           "text": "example_01c_eom_only",
           "value": "example_01c_eom_only"
         },
@@ -5297,21 +5302,18 @@
         },
         "definition": "SELECT simulation\nFROM market_meta",
         "description": "Can choose which simulation we want to show ",
-        "hide": 0,
         "includeAll": false,
-        "multi": false,
         "name": "simulation",
         "options": [],
         "query": "SELECT simulation\nFROM market_meta",
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": false,
           "text": "EOM",
           "value": "EOM"
         },
@@ -5321,26 +5323,23 @@
         },
         "definition": "SELECT \n  market_id\nFROM market_meta\nwhere simulation='$simulation'\ngroup by market_id ;",
         "description": "Choose for which market the data is displayed",
-        "hide": 0,
         "includeAll": false,
-        "multi": false,
         "name": "market",
         "options": [],
         "query": "SELECT \n  market_id\nFROM market_meta\nwhere simulation='$simulation'\ngroup by market_id ;",
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
           "text": [
-            "Unit 4"
+            "Biomass"
           ],
           "value": [
-            "Unit 4"
+            "Biomass"
           ]
         },
         "datasource": {
@@ -5349,7 +5348,6 @@
         },
         "definition": "SELECT index\nFROM power_plant_meta\nwhere simulation = '$simulation';",
         "description": "Can choose which units we want to display ",
-        "hide": 0,
         "includeAll": false,
         "multi": true,
         "name": "Gen_Units",
@@ -5357,13 +5355,12 @@
         "query": "SELECT index\nFROM power_plant_meta\nwhere simulation = '$simulation';",
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "demand_EOM"
           ],
@@ -5377,7 +5374,6 @@
         },
         "definition": "SELECT index\nFROM demand_meta\nwhere simulation = '$simulation';",
         "description": "Can choose which units we want to display ",
-        "hide": 0,
         "includeAll": false,
         "multi": true,
         "name": "Demand_Units",
@@ -5385,13 +5381,12 @@
         "query": "SELECT index\nFROM demand_meta\nwhere simulation = '$simulation';",
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": true,
           "text": [
             "Storage 1"
           ],
@@ -5405,7 +5400,6 @@
         },
         "definition": "SELECT index\nFROM storage_meta\nwhere simulation = '$simulation';",
         "description": "Can choose which storage units we want to display ",
-        "hide": 0,
         "includeAll": false,
         "multi": true,
         "name": "Storage_Units",
@@ -5413,15 +5407,14 @@
         "query": "SELECT index\nFROM storage_meta\nwhere simulation = '$simulation';",
         "refresh": 2,
         "regex": "",
-        "skipUrlSync": false,
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "selected": false,
-          "text": "2019-01-01 02:00:00",
-          "value": "2019-01-01 02:00:00"
+          "text": "2019-01-12 12:00:00",
+          "value": "2019-01-12 12:00:00"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
@@ -5431,23 +5424,20 @@
         "description": "The minimum time we have in the time range.\nUsed for the merit order plot title",
         "hide": 2,
         "includeAll": false,
-        "multi": false,
         "name": "min_time",
         "options": [],
         "query": "select min(start_time)::text from market_orders where market_id = '$market' AND\n      simulation = '$simulation' and $__timeFilter(start_time)",
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]
   },
   "time": {
-    "from": "2019-01-01T01:11:53.495Z",
-    "to": "2019-01-31T18:05:53.940Z"
+    "from": "2019-01-12T11:21:04.921Z",
+    "to": "2019-01-16T12:57:43.188Z"
   },
-  "timeRangeUpdatedDuringEditOrView": false,
   "timepicker": {
     "refresh_intervals": [
       "5s",

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -396,7 +396,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\r\n  lag(cum_vol, 1, 0) OVER (ORDER BY cum_vol) AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  5 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = (\r\n        SELECT min(start_time) FROM market_orders\r\n        WHERE market_id = '$market'\r\n          AND simulation = '$simulation'\r\n          AND $__timeFilter(start_time)\r\n      )\r\n      AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  cum_vol AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = (\r\n        SELECT min(start_time) FROM market_orders\r\n        WHERE market_id = '$market'\r\n          AND simulation = '$simulation'\r\n          AND $__timeFilter(start_time)\r\n      )\r\n      AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  0::float AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  (SELECT max(price::float) FROM market_orders\r\n   WHERE market_id = '$market'\r\n     AND simulation = '$simulation'\r\n     AND accepted_volume > 0\r\n     AND start_time = (\r\n       SELECT min(start_time) FROM market_orders\r\n       WHERE market_id = '$market'\r\n         AND simulation = '$simulation'\r\n         AND $__timeFilter(start_time)\r\n     )\r\n  ) AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nORDER BY \"Cumulative Volume\" ASC, \"Price\" ASC",
+          "rawSql": "SELECT\r\n  lag(cum_vol, 1, 0) OVER (ORDER BY cum_vol) AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  5 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = '$merit_order_select'   AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  cum_vol AS \"Cumulative Volume\",\r\n  price::float AS \"Price\",\r\n  tech AS \"Technology\",\r\n  unit_id::text AS \"Unit\",\r\n  volume::text AS \"Volume\",\r\n  bid_id::text AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM (\r\n  SELECT\r\n    price,\r\n    unit_id,\r\n    bid_id,\r\n    volume,\r\n    tech,\r\n    sum(volume::float) OVER (ORDER BY price ASC, bid_id) AS cum_vol\r\n  FROM (\r\n    SELECT\r\n      mo.bid_id,\r\n      mo.unit_id,\r\n      mo.price,\r\n      COALESCE(pp.technology, sm.technology, dm.technology, 'unknown') AS tech,\r\n      sum(mo.volume) AS volume\r\n    FROM market_orders mo\r\n    LEFT JOIN power_plant_meta pp ON pp.index = mo.unit_id AND pp.simulation = mo.simulation\r\n    LEFT JOIN storage_meta sm ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\r\n    LEFT JOIN demand_meta dm ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\r\n    WHERE\r\n      mo.start_time = (\r\n        SELECT min(start_time) FROM market_orders\r\n        WHERE market_id = '$market'\r\n          AND simulation = '$simulation'\r\n          AND $__timeFilter(start_time)\r\n      )\r\n      AND mo.volume > 0\r\n      AND mo.market_id = '$market'\r\n      AND mo.simulation = '$simulation'\r\n    GROUP BY mo.bid_id, mo.unit_id, mo.price, tech\r\n  ) bids\r\n) ranked\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  0::float AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nUNION ALL\r\n\r\nSELECT\r\n  mm.demand_volume::float AS \"Cumulative Volume\",\r\n  (SELECT max(price::float) FROM market_orders\r\n   WHERE market_id = '$market'\r\n     AND simulation = '$simulation'\r\n     AND accepted_volume > 0\r\n     AND start_time = (\r\n       SELECT min(start_time) FROM market_orders\r\n       WHERE market_id = '$market'\r\n         AND simulation = '$simulation'\r\n         AND $__timeFilter(start_time)\r\n     )\r\n  ) AS \"Price\",\r\n  'Demand' AS \"Technology\",\r\n  '' AS \"Unit\",\r\n  '' AS \"Volume\",\r\n  '' AS \"Bid\",\r\n  0 AS \"Size\"\r\nFROM market_meta mm\r\nWHERE mm.market_id = '$market'\r\n  AND mm.simulation = '$simulation'\r\n  AND mm.product_start = (\r\n    SELECT min(start_time) FROM market_orders\r\n    WHERE market_id = '$market'\r\n      AND simulation = '$simulation'\r\n      AND $__timeFilter(start_time)\r\n  )\r\n\r\nORDER BY \"Cumulative Volume\" ASC, \"Price\" ASC",
           "refId": "A",
           "sql": {
             "columns": [
@@ -417,7 +417,7 @@
           }
         }
       ],
-      "title": "Merit Order $market at $min_time",
+      "title": "Merit Order $market at $merit_order_select",
       "transformations": [
         {
           "id": "partitionByValues",
@@ -5534,24 +5534,19 @@
         "type": "query"
       },
       {
+        "allowCustomValue": false,
         "current": {
-          "text": "2019-01-12 12:00:00",
-          "value": "2019-01-12 12:00:00"
+          "text": "2023-03-01 01:00:00",
+          "value": "2023-03-01 01:00:00"
         },
-        "datasource": {
-          "type": "grafana-postgresql-datasource",
-          "uid": "P7B13B9DF907EC40C"
-        },
-        "definition": "select min(start_time)::text from market_orders where market_id = '$market' AND\n      simulation = '$simulation' and $__timeFilter(start_time)",
-        "description": "The minimum time we have in the time range.\nUsed for the merit order plot title",
-        "hide": 2,
-        "includeAll": false,
-        "name": "min_time",
+        "definition": "select start_time::text from market_orders where market_id = '$market' and simulation = '$simulation' and $__timeFilter(start_time)",
+        "label": "merit order plot for",
+        "name": "merit_order_select",
         "options": [],
-        "query": "select min(start_time)::text from market_orders where market_id = '$market' AND\n      simulation = '$simulation' and $__timeFilter(start_time)",
-        "refresh": 1,
+        "query": "select start_time::text from market_orders where market_id = '$market' and simulation = '$simulation' and $__timeFilter(start_time)",
+        "refresh": 2,
         "regex": "",
-        "regexApplyTo": "value",
+        "sort": 1,
         "type": "query"
       }
     ]

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -556,13 +556,13 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "volume gas"
+              "options": "volume combined cycle gas turbine"
             },
             "properties": [
               {
                 "id": "color",
                 "value": {
-                  "fixedColor": "orange",
+                  "fixedColor": "light-orange",
                   "mode": "fixed"
                 }
               }
@@ -642,6 +642,126 @@
                 }
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume open cycle gas turbine"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "semi-dark-orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume inflex_demand"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#cfcfcf",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume exchange import"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume exchange export"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "dark-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume BESS charge"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume BESS discharge"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "super-light-purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume PSPP charge"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#130987",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "volume PSPP discharge"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#130987",
+                  "mode": "fixed"
+                }
+              }
+            ]
           }
         ]
       },
@@ -659,7 +779,9 @@
           ],
           "displayMode": "table",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": true,
+          "sortBy": "Mean",
+          "sortDesc": true
         },
         "tooltip": {
           "hideZeros": false,
@@ -694,7 +816,7 @@
           ],
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "select time, sum(volume) as \"volume\", tech FROM \n(\nSELECT\n  $__timeGroupAlias(start_time,$__interval),\n  avg(accepted_volume) AS \"volume\", unit_id, pm.technology as tech\nFROM market_orders mo\njoin power_plant_meta pm on pm.index=mo.unit_id and pm.simulation=mo.simulation\nWHERE\n\n  $__timeFilter(start_time) AND\n  market_id = '$market' AND\n  mo.simulation = '$simulation'\n\nGROUP BY 1, unit_id, bid_id, pm.technology\nORDER BY 1\n\n) a\ngroup by 1, tech\nORDER BY 1, tech desc",
+          "rawSql": "SELECT\n  $__timeGroupAlias(mo.start_time, $__interval),\n  SUM(mo.accepted_volume) AS \"volume\",\n  CASE\n    WHEN pm.index IS NOT NULL THEN pm.technology\n    WHEN sm.index IS NOT NULL AND mo.accepted_volume >= 0 THEN COALESCE(sm.technology, 'storage') || ' discharge'\n    WHEN sm.index IS NOT NULL AND mo.accepted_volume < 0 THEN COALESCE(sm.technology, 'storage') || ' charge'\n    WHEN dm.index IS NOT NULL THEN COALESCE(dm.technology, 'demand')\n    WHEN em.index IS NOT NULL AND mo.accepted_volume >= 0 THEN COALESCE(em.technology, 'exchange') || ' import'\n    WHEN em.index IS NOT NULL AND mo.accepted_volume < 0 THEN COALESCE(em.technology, 'exchange') || ' export'\n    ELSE 'unknown technology'\n  END AS tech\nFROM market_orders mo\nLEFT JOIN power_plant_meta pm\n  ON pm.index = mo.unit_id AND pm.simulation = mo.simulation\nLEFT JOIN storage_meta sm\n  ON sm.index = mo.unit_id AND sm.simulation = mo.simulation\nLEFT JOIN demand_meta dm\n  ON dm.index = mo.unit_id AND dm.simulation = mo.simulation\nLEFT JOIN exchange_meta em\n  ON em.index = mo.unit_id AND em.simulation = mo.simulation\nWHERE\n  $__timeFilter(mo.start_time) AND\n  mo.market_id = '$market' AND\n  mo.simulation = '$simulation'\nGROUP BY 1, 3\nORDER BY 1, 3 DESC",
           "refId": "A",
           "select": [
             [

--- a/docker_configs/dashboard-definitions/ASSUME_Learning.json
+++ b/docker_configs/dashboard-definitions/ASSUME_Learning.json
@@ -25,11 +25,9 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 3,
   "links": [],
   "panels": [
     {
-      "description": "",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -50,12 +48,11 @@
         "content": "# Welcome to Learning Dashboard by ASSUME\n",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "title": "",
       "type": "text"
     },
     {
-      "description": "",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -76,12 +73,11 @@
         "content": "## How to Use the Dashboard  \n\nThis interactive tool provides insights into the learning process of our reinforcement learning (RL) agent. While the TensorBoard integration (compare ReadMe) provides an overview of the general learning performance of all agents, this dashboard gives you the option to inspect **each agent individually or in comparison**. To effectively navigate the dashboard, keep the following key points in mind:  \n\n### 1. Dashboard Structure  \n\nThe dashboard is divided into two main rows and two columns:  \n\n**COLUMNS**  \n- **Training Episode:** Depicts the results of the selected training episodes at the top of the dashboard. Note that training episodes have special properties such as noise added for exploration purposes.  \n- **Evaluation Episode:** Depicts the results of the selected evaluation episodes.  \n\n**ROWS**  \n- **Per Simulation:** Summarizes results across all simulated episodes, distinguishing between \"training\" and \"evaluation\" episodes.  \n- **Per Episode:** Focuses on specific units and episodes, allowing for detailed analysis.  \n\n### 2. Selecting Metrics and Simulations  \n\nAt the top of the dashboard, you can filter data using the following options:  \n\n- **Simulation ID:** Choose the simulation run you want to analyze.  \n- **Unit & Episode:** Select specific units and episodes for detailed insights. You can also select all units, but be cautious—visualizing a large number of agents may cause performance issues.  \n\nThe selected metrics will be displayed in corresponding visualization areas.  \n\n### 3. Interacting with Plots  \n\nThe plots are fully interactive:  \n\n- **Zoom** in and out to explore trends.  \n- **Click** on data points for detailed values.  \n- **Hover** over the upper-left corner of each plot for additional insights.  \n\n### How to Interpret the Data  \n\nTo make the most of the dashboard, follow these key steps:  \n\n1. **Understand Learning Trends:**  \n   - Observe how **reward** and **profitability** metrics evolve over time.  \n   - Look for an upward trend in evaluation runs (where exploration is off). Unlike fluctuating training rewards, evaluation rewards should show a steady increase.  \n\n2. **Analyze Policy & Action Patterns:**  \n   - Examine the agent's learned policy and action distribution.  \n   - Identify patterns and assess whether they align with\n",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "title": "",
       "type": "text"
     },
     {
-      "description": "",
       "fieldConfig": {
         "defaults": {},
         "overrides": []
@@ -102,7 +98,7 @@
         "content": "## Training Episode ",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "title": "",
       "type": "text"
     },
@@ -127,7 +123,7 @@
         "content": "## Evaluation Episode",
         "mode": "markdown"
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "title": "",
       "type": "text"
     },
@@ -239,7 +235,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -251,7 +247,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "WITH rewards_by_unit AS (\n    SELECT \n        episode,\n        unit, \n        SUM(reward) AS total_reward\n    FROM rl_params\n    WHERE simulation = '${simulation}'\n      AND evaluation_mode = FALSE\n    GROUP BY episode, unit\n),\nepisode_avg_rewards AS (\n    SELECT \n        episode, \n        SUM(total_reward) / COUNT(DISTINCT unit) AS avg_reward\n    FROM rewards_by_unit\n    GROUP BY episode\n)\nSELECT episode, avg_reward\nFROM episode_avg_rewards\nORDER BY episode;",
+          "rawSql": "SELECT \n    episode, \n    SUM(reward) / COUNT(DISTINCT unit) AS avg_reward\nFROM rl_params\nWHERE simulation = '${simulation}'\n    AND evaluation_mode = FALSE\nGROUP BY episode\nORDER BY episode;",
           "refId": "A",
           "select": [
             [
@@ -438,7 +434,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -450,7 +446,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "WITH rewards_by_unit AS (\n    SELECT \n        episode,\n        unit, \n        SUM(reward) AS total_reward\n    FROM rl_params\n    WHERE simulation = '${simulation}'\n      AND evaluation_mode = TRUE\n    GROUP BY episode, unit\n),\nepisode_avg_rewards AS (\n    SELECT \n        episode, \n        SUM(total_reward) / COUNT(DISTINCT unit) AS avg_reward\n    FROM rewards_by_unit\n    GROUP BY episode\n)\nSELECT episode, avg_reward\nFROM episode_avg_rewards\nORDER BY episode;",
+          "rawSql": "SELECT \n    episode, \n    SUM(reward) / COUNT(DISTINCT unit) AS avg_reward\nFROM rl_params\nWHERE simulation = '${simulation}'\n    AND evaluation_mode = TRUE\nGROUP BY episode\nORDER BY episode;",
           "refId": "A",
           "select": [
             [
@@ -650,7 +646,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -662,7 +658,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "WITH rewards_by_unit AS (\n    SELECT \n        episode,\n        unit, \n        SUM(reward) AS total_reward\n    FROM rl_params\n    WHERE simulation = '${simulation}'\n      AND evaluation_mode = FALSE\n      AND unit IN (${rl_unit})\n    GROUP BY episode, unit\n)\nSELECT \n    episode, \n    unit, \n    total_reward\nFROM rewards_by_unit\nORDER BY episode, unit;\n",
+          "rawSql": "SELECT \n    episode, \n    unit, \n    SUM(reward) AS total_reward\nFROM rl_params\nWHERE simulation = '${simulation}'\n    AND evaluation_mode = FALSE\n    AND unit IN (${rl_unit})\nGROUP BY episode, unit\nORDER BY episode, unit;",
           "refId": "A",
           "select": [
             [
@@ -849,7 +845,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -861,7 +857,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "WITH rewards_by_unit AS (\n    SELECT \n        episode,\n        unit, \n        SUM(reward) AS total_reward\n    FROM rl_params\n    WHERE simulation = '${simulation}'\n      AND evaluation_mode = TRUE\n      AND unit IN (${rl_unit})\n    GROUP BY episode, unit\n)\nSELECT \n    episode, \n    unit, \n    total_reward\nFROM rewards_by_unit\nORDER BY episode, unit;\n",
+          "rawSql": "SELECT \n    episode, \n    unit, \n    SUM(reward) AS total_reward\nFROM rl_params\nWHERE simulation = '${simulation}'\n    AND evaluation_mode = TRUE\n    AND unit IN (${rl_unit})\nGROUP BY episode, unit\nORDER BY episode, unit;",
           "refId": "A",
           "select": [
             [
@@ -1048,7 +1044,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1247,7 +1243,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1460,7 +1456,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1472,7 +1468,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    reward\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit, \n    avg(reward) AS \"Reward\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nGROUP BY 1, unit\nORDER BY 1, unit;\n",
           "refId": "A",
           "select": [
             [
@@ -1657,7 +1653,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1669,7 +1665,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    reward\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit, \n    avg(reward) AS \"Reward\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nGROUP BY 1, unit\nORDER BY 1, unit;\n",
           "refId": "A",
           "select": [
             [
@@ -1760,6 +1756,194 @@
     },
     {
       "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 55,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    --datetime,\r\n    unit as unit, \r\n    reward as reward\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = FALSE\r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${episode}  -- Filtering for the specific episode\r\n\r\n--ORDER BY datetime, unit;\r\n",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Training REWARD during Episode ${episode}",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 56,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    datetime,\r\n    unit, \r\n    reward\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = TRUE\r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\r\nORDER BY datetime, unit;\r\n",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Evaluation REWARD during Eval Episode ${eval_episode}",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
@@ -1832,7 +2016,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 57
       },
       "id": 44,
       "options": {
@@ -1854,7 +2038,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -1866,7 +2050,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    profit / 1000 as profit\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit, \n    avg(profit / 1000) as \"Profit\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nGROUP BY 1, unit\nORDER BY 1, unit;\n",
           "refId": "A",
           "select": [
             [
@@ -2029,7 +2213,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 57
       },
       "id": 45,
       "options": {
@@ -2051,7 +2235,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2063,7 +2247,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    profit / 1000 as profit\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit, \n    avg(profit / 1000) as \"Profit\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)  -- Ensures time filtering aligns with Grafana's dashboard\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE\n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nGROUP BY 1, unit\nORDER BY 1, unit;\n",
           "refId": "A",
           "select": [
             [
@@ -2215,7 +2399,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 65
       },
       "id": 46,
       "options": {
@@ -2236,7 +2420,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2248,7 +2432,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    actions_0 AS noisy_action_0,\n    actions_0 - exploration_noise_0 AS action_0\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE \n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit AS \"Unit\", \n    avg(actions_0) AS \"noisy_action_0\",\n    avg(actions_0 - exploration_noise_0) AS \"action_0\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE \n    AND unit IN (${rl_unit})\n    AND episode = ${episode}\nGROUP BY 1, unit\nORDER BY 1, unit;",
           "refId": "A",
           "select": [
             [
@@ -2329,9 +2513,8 @@
           },
           "editorMode": "code",
           "format": "table",
-          "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    actions_1 AS noisy_action_1,  -- Handle missing actions_1\n    actions_1 - exploration_noise_1 AS action_1\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE \n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit AS \"Unit\", \n    avg(actions_1) AS \"noisy_action_1\",\n    avg(actions_1 - exploration_noise_1) AS \"action_1\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = FALSE \n    AND unit IN (${rl_unit})\n    AND episode = ${episode}\nGROUP BY 1, unit\nORDER BY 1, unit;",
           "refId": "B",
           "sql": {
             "columns": [
@@ -2365,7 +2548,7 @@
     },
     {
       "datasource": {
-        "type": "postgres",
+        "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
       },
       "fieldConfig": {
@@ -2426,9 +2609,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 65
       },
-      "id": 47,
+      "id": 60,
       "options": {
         "legend": {
           "calcs": [
@@ -2447,7 +2630,7 @@
           "sort": "none"
         }
       },
-      "pluginVersion": "12.2.1",
+      "pluginVersion": "12.4.1",
       "targets": [
         {
           "datasource": {
@@ -2459,7 +2642,7 @@
           "group": [],
           "metricColumn": "simulation",
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    actions_0\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE \n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit AS \"Unit\", \n    avg(actions_0 - exploration_noise_0) AS \"action_0\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE \n    AND unit IN (${rl_unit})\n    AND episode = ${eval_episode}\nGROUP BY 1, unit\nORDER BY 1, unit;",
           "refId": "A",
           "select": [
             [
@@ -2540,9 +2723,264 @@
           },
           "editorMode": "code",
           "format": "table",
-          "hide": false,
           "rawQuery": true,
-          "rawSql": "SELECT \n    datetime,\n    unit, \n    actions_1\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE \n    AND unit IN (${rl_unit})  -- Supports multiple units\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\nORDER BY datetime, unit;\n",
+          "rawSql": "SELECT \n    $__timeGroupAlias(datetime, $__interval),\n    unit AS \"Unit\", \n    avg(actions_1 - exploration_noise_1) AS \"action_1\"\nFROM rl_params\nWHERE \n    $__timeFilter(datetime)\n    AND simulation = '$simulation'\n    AND evaluation_mode = TRUE \n    AND unit IN (${rl_unit})\n    AND episode = ${eval_episode}\nGROUP BY 1, unit\nORDER BY 1, unit;",
+          "refId": "B",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Evaluation ACTIONS during Episode ${eval_episode}",
+      "transformations": [
+        {
+          "id": "prepareTimeSeries",
+          "options": {
+            "format": "multi"
+          }
+        }
+      ],
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 73
+      },
+      "id": 53,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    datetime,\r\n    unit,\r\n    --actions_1 AS noisy_action_1,  -- Handle missing actions_1\r\n    actions_0 - exploration_noise_0 AS action_0\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = FALSE \r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${episode}  -- Filtering for the specific episode\r\n--ORDER BY datetime, unit;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
+        {
+          "dataset": "assume",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "P7B13B9DF907EC40C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    datetime,\r\n    unit,\r\n    --actions_1 AS noisy_action_1,  -- Handle missing actions_1\r\n    actions_1 - exploration_noise_1 AS action_1\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = FALSE \r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${episode}  -- Filtering for the specific episode\r\n--ORDER BY datetime, unit;",
+          "refId": "B",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Histrogram of Training ACTIONS during Episode ${episode}",
+      "transformations": [
+        {
+          "id": "partitionByValues",
+          "options": {}
+        }
+      ],
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "mappings": [],
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 73
+      },
+      "id": 54,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    datetime,\r\n    unit,\r\n    --actions_1 AS noisy_action_1,  -- Handle missing actions_1\r\n    actions_0 - exploration_noise_0 AS action_0\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = TRUE \r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\r\n--ORDER BY datetime, unit;",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        },
+        {
+          "dataset": "assume",
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "P7B13B9DF907EC40C"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT \r\n    datetime,\r\n    unit,\r\n    --actions_1 AS noisy_action_1,  -- Handle missing actions_1\r\n    actions_1 - exploration_noise_1 AS action_1\r\nFROM rl_params\r\nWHERE \r\n    $__timeFilter(datetime)\r\n    AND simulation = '$simulation'\r\n    AND evaluation_mode = TRUE \r\n    AND unit IN (${rl_unit})  -- Supports multiple units\r\n    AND episode = ${eval_episode}  -- Filtering for the specific episode\r\n--ORDER BY datetime, unit;",
           "refId": "B",
           "sql": {
             "columns": [
@@ -2564,15 +3002,7 @@
         }
       ],
       "title": "Evaluation ACTIONS during Eval Episode ${eval_episode}",
-      "transformations": [
-        {
-          "id": "prepareTimeSeries",
-          "options": {
-            "format": "multi"
-          }
-        }
-      ],
-      "type": "timeseries"
+      "type": "histogram"
     }
   ],
   "preload": false,
@@ -2583,8 +3013,8 @@
     "list": [
       {
         "current": {
-          "text": "example_02a_base",
-          "value": "example_02a_base"
+          "text": "example_02e_base",
+          "value": "example_02e_base"
         },
         "datasource": {
           "type": "postgres",
@@ -2599,13 +3029,14 @@
         "query": "SELECT DISTINCT simulation\nFROM rl_meta",
         "refresh": 2,
         "regex": "",
+        "regexApplyTo": "value",
         "sort": 1,
         "type": "query"
       },
       {
         "current": {
-          "text": "1",
-          "value": "1"
+          "text": "30",
+          "value": "30"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
@@ -2619,12 +3050,13 @@
         "query": "SELECT episode\nFROM rl_meta\nWHERE simulation = '$simulation' \nAND evaluation_mode = False\nORDER BY episode;",
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
         "current": {
-          "text": "1",
-          "value": "1"
+          "text": "5",
+          "value": "5"
         },
         "datasource": {
           "type": "grafana-postgresql-datasource",
@@ -2638,15 +3070,16 @@
         "query": "SELECT eval_episode\nFROM rl_meta\nWHERE simulation = '$simulation'\nAND evaluation_mode = True\nORDER BY eval_episode;",
         "refresh": 1,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       },
       {
         "current": {
           "text": [
-            "pp_6"
+            "Storage 2"
           ],
           "value": [
-            "pp_6"
+            "Storage 2"
           ]
         },
         "datasource": {
@@ -2663,6 +3096,7 @@
         "query": "SELECT DISTINCT unit \nFROM rl_params\nWHERE simulation = '$simulation'\nAND episode = 1\nAND evaluation_mode = False;",
         "refresh": 2,
         "regex": "",
+        "regexApplyTo": "value",
         "type": "query"
       }
     ]

--- a/docker_configs/dashboard-definitions/ASSUME_Learning.json
+++ b/docker_configs/dashboard-definitions/ASSUME_Learning.json
@@ -1360,6 +1360,190 @@
       "title": "Per episode per unit",
       "type": "row"
     },
+        {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "color",
+              "thresholds": []
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 0,
+        "y": 41
+      },
+      "id": 53,
+      "options": {
+        "alertCustomMessage": "",
+        "alwaysVisibleFilter": false,
+        "autoScroll": false,
+        "browserTabNamePattern": "",
+        "collapsedByDefault": false,
+        "customValue": false,
+        "displayMode": "slider",
+        "emptyValue": false,
+        "favorites": {
+          "enabled": false,
+          "storage": "browser"
+        },
+        "filter": false,
+        "groupSelection": false,
+        "header": true,
+        "isMinimizeForTable": false,
+        "isMinimizeViewShowCustomIcon": false,
+        "isPinTabsEnabled": false,
+        "isUseLocalTime": false,
+        "minimizeOutputFormat": "text",
+        "minimizeViewCustomIcon": "",
+        "minimizeViewNativeIcon": "gf-movepane-right",
+        "padding": 10,
+        "persistent": false,
+        "requestLatency": "low",
+        "saveSelectedGroup": false,
+        "saveSelectedGroupKey": "",
+        "selectedValues": {
+          "showSelected": false
+        },
+        "showGroupTotal": false,
+        "showLabel": true,
+        "showName": false,
+        "showResetButton": false,
+        "showTotal": false,
+        "statusSort": false,
+        "tableViewPosition": "normal",
+        "tabsInOrder": true,
+        "toolbarMode": "tabs",
+        "variable": "episode",
+        "wordBreak": "normal"
+      },
+      "pluginVersion": "5.1.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "builder",
+          "format": "table",
+          "rawSql": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Training Episode",
+      "type": "volkovlabs-variable-panel"
+    },
+        {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "thresholdsStyle": {
+              "mode": "color",
+              "thresholds": []
+            }
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 12,
+        "x": 12,
+        "y": 41
+      },
+      "id": 54,
+      "options": {
+        "alertCustomMessage": "",
+        "alwaysVisibleFilter": false,
+        "autoScroll": false,
+        "browserTabNamePattern": "",
+        "collapsedByDefault": false,
+        "customValue": false,
+        "displayMode": "slider",
+        "emptyValue": false,
+        "favorites": {
+          "enabled": false,
+          "storage": "browser"
+        },
+        "filter": false,
+        "groupSelection": false,
+        "header": true,
+        "isMinimizeForTable": false,
+        "isMinimizeViewShowCustomIcon": false,
+        "isPinTabsEnabled": false,
+        "isUseLocalTime": false,
+        "minimizeOutputFormat": "text",
+        "minimizeViewCustomIcon": "",
+        "minimizeViewNativeIcon": "gf-movepane-right",
+        "padding": 10,
+        "persistent": false,
+        "requestLatency": "low",
+        "saveSelectedGroup": false,
+        "saveSelectedGroupKey": "",
+        "selectedValues": {
+          "showSelected": false
+        },
+        "showGroupTotal": false,
+        "showLabel": true,
+        "showName": false,
+        "showResetButton": false,
+        "showTotal": false,
+        "statusSort": false,
+        "tableViewPosition": "normal",
+        "tabsInOrder": true,
+        "toolbarMode": "tabs",
+        "variable": "eval_episode",
+        "wordBreak": "normal"
+      },
+      "pluginVersion": "5.1.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "builder",
+          "format": "table",
+          "rawSql": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Evaluation Episode",
+      "type": "volkovlabs-variable-panel"
+    },
     {
       "datasource": {
         "type": "postgres",

--- a/docker_configs/dashboard-definitions/ASSUME_Learning.json
+++ b/docker_configs/dashboard-definitions/ASSUME_Learning.json
@@ -142,6 +142,352 @@
     },
     {
       "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p25"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p10"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p75"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "median"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p75"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "median"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p25"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "median"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 15
+      },
+      "id": 61,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\r\n    episode,\r\n    percentile_cont(0.10) WITHIN GROUP (ORDER BY total_reward) AS p10,\r\n    percentile_cont(0.25) WITHIN GROUP (ORDER BY total_reward) AS p25,\r\n    percentile_cont(0.50) WITHIN GROUP (ORDER BY total_reward) AS median,\r\n    percentile_cont(0.75) WITHIN GROUP (ORDER BY total_reward) AS p75,\r\n    percentile_cont(0.90) WITHIN GROUP (ORDER BY total_reward) AS p90\r\nFROM (\r\n    SELECT\r\n        episode,\r\n        unit,\r\n        SUM(reward) AS total_reward\r\n    FROM rl_params\r\n    WHERE simulation = '${simulation}'\r\n        AND evaluation_mode = FALSE\r\n        AND unit IN (${rl_unit})\r\n    GROUP BY episode, unit\r\n) sub\r\nGROUP BY episode\r\nORDER BY episode",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Distribution of Reward over Training Episodes",
+      "type": "trend"
+    },
+    {
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "P7B13B9DF907EC40C"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "smooth",
+            "lineWidth": 1,
+            "pointSize": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "showValues": false,
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": 0
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p25"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p10"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p75"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "median"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "p90"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p75"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "median"
+            },
+            "properties": [
+              {
+                "id": "custom.fillBelowTo",
+                "value": "p25"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "median"
+            },
+            "properties": [
+              {
+                "id": "custom.lineWidth",
+                "value": 3
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 15
+      },
+      "id": 65,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.4.1",
+      "targets": [
+        {
+          "dataset": "assume",
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\r\n    episode,\r\n    percentile_cont(0.10) WITHIN GROUP (ORDER BY total_reward) AS p10,\r\n    percentile_cont(0.25) WITHIN GROUP (ORDER BY total_reward) AS p25,\r\n    percentile_cont(0.50) WITHIN GROUP (ORDER BY total_reward) AS median,\r\n    percentile_cont(0.75) WITHIN GROUP (ORDER BY total_reward) AS p75,\r\n    percentile_cont(0.90) WITHIN GROUP (ORDER BY total_reward) AS p90\r\nFROM (\r\n    SELECT\r\n        episode,\r\n        unit,\r\n        SUM(reward) AS total_reward\r\n    FROM rl_params\r\n    WHERE simulation = '${simulation}'\r\n        AND evaluation_mode = TRUE\r\n        AND unit IN (${rl_unit})\r\n    GROUP BY episode, unit\r\n) sub\r\nGROUP BY episode\r\nORDER BY episode",
+          "refId": "A",
+          "sql": {
+            "columns": [
+              {
+                "parameters": [],
+                "type": "function"
+              }
+            ],
+            "groupBy": [
+              {
+                "property": {
+                  "type": "string"
+                },
+                "type": "groupBy"
+              }
+            ],
+            "limit": 50
+          }
+        }
+      ],
+      "title": "Distribution of Reward over Evaluation Episodes",
+      "type": "trend"
+    },
+    {
+      "datasource": {
         "type": "postgres",
         "uid": "P7B13B9DF907EC40C"
       },
@@ -202,7 +548,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 15
+        "y": 23
       },
       "id": 50,
       "options": {
@@ -401,7 +747,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 15
+        "y": 23
       },
       "id": 51,
       "options": {
@@ -544,7 +890,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 23
+        "y": 31
       },
       "id": 40,
       "panels": [],
@@ -613,7 +959,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 24
+        "y": 32
       },
       "id": 31,
       "options": {
@@ -812,7 +1158,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 24
+        "y": 32
       },
       "id": 37,
       "options": {
@@ -1011,7 +1357,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 32
+        "y": 40
       },
       "id": 38,
       "options": {
@@ -1210,7 +1556,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 32
+        "y": 40
       },
       "id": 39,
       "options": {
@@ -1353,14 +1699,14 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 40
+        "y": 48
       },
       "id": 42,
       "panels": [],
       "title": "Per episode per unit",
       "type": "row"
     },
-        {
+    {
       "datasource": {
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
@@ -1393,7 +1739,7 @@
         "h": 3,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 49
       },
       "id": 53,
       "options": {
@@ -1452,7 +1798,7 @@
       "title": "Training Episode",
       "type": "volkovlabs-variable-panel"
     },
-        {
+    {
       "datasource": {
         "type": "grafana-postgresql-datasource",
         "uid": "P7B13B9DF907EC40C"
@@ -1485,7 +1831,7 @@
         "h": 3,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 49
       },
       "id": 54,
       "options": {
@@ -1618,7 +1964,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 41
+        "y": 52
       },
       "id": 41,
       "options": {
@@ -1815,7 +2161,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 41
+        "y": 52
       },
       "id": 43,
       "options": {
@@ -1985,7 +2331,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 49
+        "y": 60
       },
       "id": 55,
       "options": {
@@ -2079,7 +2425,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 49
+        "y": 60
       },
       "id": 56,
       "options": {
@@ -2200,7 +2546,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 57
+        "y": 68
       },
       "id": 44,
       "options": {
@@ -2397,7 +2743,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 57
+        "y": 68
       },
       "id": 45,
       "options": {
@@ -2583,7 +2929,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 65
+        "y": 76
       },
       "id": 46,
       "options": {
@@ -2793,7 +3139,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 65
+        "y": 76
       },
       "id": 60,
       "options": {
@@ -2983,9 +3329,9 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 73
+        "y": 84
       },
-      "id": 53,
+      "id": 57,
       "options": {
         "legend": {
           "calcs": [],
@@ -3112,9 +3458,9 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 73
+        "y": 84
       },
-      "id": 54,
+      "id": 58,
       "options": {
         "legend": {
           "calcs": [],
@@ -3303,5 +3649,5 @@
   "timezone": "",
   "title": "ASSUME: Training progress",
   "uid": "JKQzx0q4k",
-  "version": 13
+  "version": 14
 }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #762, #763 #761, #796 

## Description
- #796: Plot for market results on main dashboard now includes dispatch for both directions (generation, loads), with exchange and storage units <img width="186" height="156" alt="grafik" src="https://github.com/user-attachments/assets/82a84c9d-c720-4b4a-8255-d9f812aea39b" />
- #763: Improved merit order plot and added slider to change period of interest without needing to adjust the whole horizon <img width="262" height="37" alt="grafik" src="https://github.com/user-attachments/assets/499a9d96-ed47-4c95-9fcd-7b6a65baf2de" />
- Learning Dashboard: add slider to change episode of interest faster and see progression of rewards and actions <img width="1851" height="366" alt="grafik" src="https://github.com/user-attachments/assets/9f871cf8-501f-4a8f-a8d9-429768564130" />




## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0
## PR Specific Checklist
- [ ] Multi-market example working ("small" and "small_dam")

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
