### PR TITLE
ci: codecov: increase patch threshold

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -7,3 +7,6 @@ coverage:
     project:
       default:
         threshold: 1%
+    patch:
+      default:
+        threshold: 20%   # allow patch coverage to be up to 20% worse than the base


### PR DESCRIPTION
## Description
I think that prioritising patch coverage too much can be often very hard and does not help a lot. Allow patch coverage to be 20% worse, to be less strict on patch coverage requirements


## Checklist

- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->
