### PR TITLE
feat(rl): add renewable strategy compatible with shared MATD3 critics

### DIFF
--- a/assume/strategies/__init__.py
+++ b/assume/strategies/__init__.py
@@ -102,6 +102,7 @@ try:
         EnergyLearningSingleBidStrategy,
         StorageEnergyLearningStrategy,
         RenewableEnergyLearningSingleBidStrategy,
+        RenewableEnergyLearningCompatibleStrategy,
     )
 
     deprecated_bidding_strategies["pp_learning"] = EnergyLearningStrategy
@@ -118,6 +119,9 @@ try:
     bidding_strategies["storage_energy_learning"] = StorageEnergyLearningStrategy
     bidding_strategies["renewable_energy_learning_single_bid"] = (
         RenewableEnergyLearningSingleBidStrategy
+    )
+    bidding_strategies["renewable_energy_learning_compatible"] = (
+        RenewableEnergyLearningCompatibleStrategy
     )
 
     from assume.strategies.portfolio_learning_strategies import (

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -1331,3 +1331,180 @@ class RenewableEnergyLearningSingleBidStrategy(EnergyLearningSingleBidStrategy):
             self.learning_role.add_reward_to_cache(
                 unit.id, start, reward, regret, profit
             )
+
+
+class RenewableEnergyLearningCompatibleStrategy(EnergyLearningSingleBidStrategy):
+    """
+    Reinforcement Learning Strategy for renewable units that is dimension-compatible
+    with storage and generator learning strategies.
+
+    This strategy inherits from ``EnergyLearningSingleBidStrategy`` and sets
+    ``unique_obs_dim=2`` so that the resulting observation dimension (``obs_dim=74``)
+    matches the storage and generator strategies exactly.  This allows all three
+    unit types to share a single centralised MATD3 critic.
+
+    Compared to ``RenewableEnergyLearningSingleBidStrategy`` (which uses
+    ``unique_obs_dim=3``), this variant drops marginal cost from the individual
+    observations.  Marginal cost is near-zero and essentially constant for
+    renewables, so it provides no useful learning signal.  The availability
+    observation — which tells the agent how much generation capacity is actually
+    available — is retained.
+
+    Individual observations returned:
+        - ``scaled_total_dispatch``  – current output / max_power
+        - ``scaled_available_power`` – available power / max_power
+
+    The ``calculate_reward`` method uses renewable-specific opportunity-cost logic
+    (based on available generation rather than installed capacity), identical to
+    ``RenewableEnergyLearningSingleBidStrategy``.
+
+    Attributes
+    ----------
+    foresight : int
+        Number of forecast look-ahead time steps.  Default 24.
+    act_dim : int
+        Action dimension (single bid price).  Default 1.
+    unique_obs_dim : int
+        Unit-specific observation dimension.  Fixed at 2 for critic compatibility.
+    """
+
+    def __init__(self, *args, **kwargs):
+        foresight = kwargs.pop("foresight", 24)
+        act_dim = kwargs.pop("act_dim", 1)
+        # Force unique_obs_dim=2 so obs_dim matches storage/generator strategies
+        kwargs.pop("unique_obs_dim", None)
+        super().__init__(
+            foresight=foresight,
+            act_dim=act_dim,
+            unique_obs_dim=2,
+            *args,
+            **kwargs,
+        )
+
+    def get_individual_observations(
+        self, unit: SupportsMinMaxCharge, start: datetime, end: datetime
+    ):
+        """
+        Return unit-specific observations for renewable units (compatible variant).
+
+        Only two observations are returned so that ``unique_obs_dim`` equals 2,
+        matching the storage and generator learning strategies.
+
+        Parameters
+        ----------
+        unit : SupportsMinMaxCharge
+            The renewable unit.
+        start : datetime.datetime
+            Start of the observation period.
+        end : datetime.datetime
+            End of the observation period.
+
+        Returns
+        -------
+        np.ndarray
+            ``[scaled_total_dispatch, scaled_available_power]``
+        """
+        current_volume = unit.get_output_before(start)
+        _, available_power = unit.calculate_min_max_power(start, end)
+
+        scaled_total_dispatch = current_volume / unit.max_power
+        scaled_available_power = available_power[0] / unit.max_power
+
+        return np.array([scaled_total_dispatch, scaled_available_power])
+
+    def calculate_reward(
+        self,
+        unit: SupportsMinMaxCharge,
+        marketconfig: MarketConfig,
+        orderbook: Orderbook,
+    ):
+        """
+        Calculate the reward for the renewable unit.
+
+        Uses renewable-specific opportunity-cost logic identical to
+        ``RenewableEnergyLearningSingleBidStrategy``: opportunity cost is
+        computed against the *available* generation (from the offered volume)
+        rather than the full installed capacity.
+
+        Parameters
+        ----------
+        unit : SupportsMinMaxCharge
+            The renewable unit.
+        marketconfig : MarketConfig
+            Market configuration.
+        orderbook : Orderbook
+            Executed orders from market clearing.
+        """
+        product_type = marketconfig.product_type
+
+        start = orderbook[0]["start_time"]
+        end = orderbook[0]["end_time"]
+        end_excl = end - unit.index.freq
+
+        marginal_cost = unit.calculate_marginal_cost(
+            start, unit.outputs[product_type].at[start]
+        )
+        market_clearing_price = orderbook[0]["accepted_price"]
+
+        duration = (end - start) / timedelta(hours=1)
+
+        income = 0.0
+        operational_cost = 0.0
+
+        accepted_volume_total = 0
+        offered_volume_total = 0
+
+        for order in orderbook:
+            accepted_volume = order.get("accepted_volume", 0)
+            accepted_volume_total += accepted_volume
+
+            offered_volume_total += order["volume"]
+
+            order_income = market_clearing_price * accepted_volume * duration
+            order_cost = marginal_cost * accepted_volume * duration
+
+            income += order_income
+            operational_cost += order_cost
+
+        if (
+            unit.outputs[product_type].at[start] != 0
+            and unit.outputs[product_type].at[start - unit.index.freq] == 0
+        ):
+            operational_cost += unit.hot_start_cost / 2
+        elif (
+            unit.outputs[product_type].at[start] == 0
+            and unit.outputs[product_type].at[start - unit.index.freq] != 0
+        ):
+            operational_cost += unit.hot_start_cost / 2
+
+        profit = income - operational_cost
+
+        profit_scale = 1
+        profit = min(profit, profit_scale * abs(profit))
+
+        available_power = offered_volume_total
+
+        opportunity_cost = (
+            (market_clearing_price - marginal_cost)
+            * (available_power - accepted_volume_total)
+            * duration
+        )
+        opportunity_cost = max(opportunity_cost, 0)
+
+        regret_scale = 0.1 if accepted_volume_total > unit.min_power else 0.5
+
+        if available_power == 0:
+            scaling = 0
+        else:
+            scaling = 1 / (self.max_bid_price * available_power)
+
+        regret = regret_scale * opportunity_cost
+        reward = scaling * (profit - regret)
+
+        unit.outputs["profit"].loc[start:end_excl] += profit
+        unit.outputs["total_costs"].loc[start:end_excl] += operational_cost
+
+        if self.learning_mode:
+            self.learning_role.add_reward_to_cache(
+                unit.id, start, reward, regret, profit
+            )

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -1412,6 +1412,84 @@ class RenewableEnergyLearningCompatibleStrategy(EnergyLearningSingleBidStrategy)
 
         return np.array([scaled_total_dispatch, scaled_available_power])
 
+    def get_actions(self, next_observation):
+        """
+        Determines actions based on the current observation.
+
+        Overrides EnergyLearningStrategy.get_actions to remove the marginal cost
+        exploration bias, which is inappropriate for renewables where marginal cost
+        has been removed from the observation space. Falls back to pure noise-driven
+        exploration during initial experience collection.
+        """
+        curr_action, noise = TorchLearningStrategy.get_actions(self, next_observation)
+        return curr_action, noise
+
+    def calculate_bids(
+        self,
+        unit: SupportsMinMax,
+        market_config: MarketConfig,
+        product_tuples: list[Product],
+        **kwargs,
+    ) -> Orderbook:
+        """
+        Generates a single price bid for the full available capacity (max_power).
+
+        Overrides the parent to remap the action space from [-1, 1] to [0, max_bid_price]
+        instead of [-max_bid_price, +max_bid_price]. This prevents negative bids, which
+        are not meaningful for renewable units with near-zero marginal cost.
+
+        Returns
+        -------
+        Orderbook
+            A list containing one bid with start/end time, full volume, and calculated price.
+        """
+
+        start = product_tuples[0][0]
+        end = product_tuples[0][1]
+        # get technical bounds for the unit output from the unit
+        _, max_power = unit.calculate_min_max_power(start, end)
+        max_power = max_power[0]
+
+        # =============================================================================
+        # 1. Get the Observations, which are the basis of the action decision
+        # =============================================================================
+        next_observation = self.create_observation(
+            unit=unit,
+            market_id=market_config.market_id,
+            start=start,
+            end=end,
+        )
+
+        # =============================================================================
+        # 2. Get the Actions, based on the observations
+        # =============================================================================
+        actions, noise = self.get_actions(next_observation)
+
+        # =============================================================================
+        # 3. Transform Actions into bids
+        # =============================================================================
+        # Remap from [-1, 1] to [0, max_bid_price] for renewables.
+        # A linear remap (instead of clamping) preserves full gradient resolution
+        # across the valid bid range.
+        bid_price = ((actions[0] + 1) / 2) * self.max_bid_price
+
+        # actually formulate bids in orderbook format
+        bids = [
+            {
+                "start_time": start,
+                "end_time": end,
+                "only_hours": None,
+                "price": bid_price,
+                "volume": max_power,
+                "node": unit.node,
+            },
+        ]
+
+        if self.learning_mode:
+            self.learning_role.add_actions_to_cache(self.unit_id, start, actions, noise)
+
+        return bids
+
     def calculate_reward(
         self,
         unit: SupportsMinMaxCharge,
@@ -1484,21 +1562,17 @@ class RenewableEnergyLearningCompatibleStrategy(EnergyLearningSingleBidStrategy)
 
         available_power = offered_volume_total
 
-        opportunity_cost = (
-            (market_clearing_price - marginal_cost)
-            * (available_power - accepted_volume_total)
-            * duration
-        )
-        opportunity_cost = max(opportunity_cost, 0)
-
-        regret_scale = 0.1 if accepted_volume_total > unit.min_power else 0.5
-
         if available_power == 0:
             scaling = 0
         else:
             scaling = 1 / (self.max_bid_price * available_power)
 
-        regret = regret_scale * opportunity_cost
+        # Regret term removed for renewables: near-zero marginal cost causes the regret
+        # mechanism to create a one-directional incentive to bid at the price floor,
+        # regardless of market conditions. Profit-only reward provides sufficient signal:
+        # positive reward when dispatched at positive prices, negative reward at negative
+        # prices, zero when not dispatched.
+        regret = 0
         reward = scaling * (profit - regret)
 
         unit.outputs["profit"].loc[start:end_excl] += profit

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -1371,12 +1371,15 @@ class RenewableEnergyLearningCompatibleStrategy(EnergyLearningSingleBidStrategy)
     def __init__(self, *args, **kwargs):
         foresight = kwargs.pop("foresight", 24)
         act_dim = kwargs.pop("act_dim", 1)
-        # Force unique_obs_dim=2 so obs_dim matches storage/generator strategies
-        kwargs.pop("unique_obs_dim", None)
+        # Default unique_obs_dim=2 so obs_dim matches storage/generator strategies.
+        # Allow override (e.g. from _CongestionObsMixin, which inflates this to
+        # 2 + n_lines * congestion_foresight so the inserted congestion windows
+        # land in the unique-observation tail).
+        unique_obs_dim = kwargs.pop("unique_obs_dim", 2)
         super().__init__(
             foresight=foresight,
             act_dim=act_dim,
-            unique_obs_dim=2,
+            unique_obs_dim=unique_obs_dim,
             *args,
             **kwargs,
         )

--- a/docs/source/bidding_strategies.rst
+++ b/docs/source/bidding_strategies.rst
@@ -209,6 +209,9 @@ powerplant_energy_learning_single_bid EOM                Reinforcement Learning 
                                                          effectively treating the full capacity as inflexible from a bidding perspective.
 renewable_energy_learning_single_bid  EOM                Reinforcement Learning Strategy for a renewable unit that enables the agent to learn
                                                          optimal bidding strategies on an Energy-Only Market.
+renewable_energy_learning_compatible  EOM                Renewable single-bid learning strategy with observation dimensions aligned to the
+                                                         generator and storage learning strategies so mixed-agent MATD3 setups can share a
+                                                         centralised critic while avoiding negative-price floor-seeking behaviour.
 ===================================== ================== =============================================================
 
 Learning method API references:
@@ -217,6 +220,7 @@ Learning method API references:
 - :py:meth:`assume.strategies.learning_strategies.EnergyLearningSingleBidStrategy`
 - :py:meth:`assume.strategies.learning_strategies.StorageEnergyLearningStrategy`
 - :py:meth:`assume.strategies.learning_strategies.RenewableEnergyLearningSingleBidStrategy`
+- :py:meth:`assume.strategies.learning_strategies.RenewableEnergyLearningCompatibleStrategy`
 
 Other
 -----

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Upcoming Release
 
 **New Features:**
   - **Generic Forecasting Interface**: This interface enables to specify different forecast algorithms for preprocess, initialization and update during runtime. They can be specified in the config.yaml or unit csv files. For more information about currently implemented algorithms and how to specify them please read the documentation on Unit forecasts.
+  - **Renewable-compatible RL strategy**: Added a renewable single-bid learning strategy with observation dimensions that match the generator and storage learning strategies, enabling shared MATD3 critics in mixed-agent training setups.
 
 **Improvements:**
   - **In complex clearing, the solver instance is now created once during initialization of the clearing role and reused for each market clearing**. This improves performance for e.g. year-long simulations.
@@ -25,6 +26,7 @@ Upcoming Release
   - **Fix bug in forecasts**, that occurred when using complex clearing
   - **Fix infeasible power output in PowerPlant**: ``calculate_min_max_power`` now correctly accounts for base load, positive/negative capacity reserves, and heat demand when computing additional power. If reduced availability makes the unit infeasible to run, both min and max power are set to 0. A warning is issued if previous dispatch exceeded available power.
   - **Fix upward redispatch potential**, so that availabilities are now correctly considered instead of the nominal power output of the unit
+  - **Improve renewable RL bidding behaviour**: Renewable-compatible learning now remaps its action space to a non-negative bid range and removes a regret signal that otherwise pushed agents toward pathological floor-bidding.
 
 0.6.1 - (25th March 2026)
 =========================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->


## Description
This PR adds a renewable learning strategy that is compatible with the observation dimensions used by the existing generator and storage learning strategies.

The main motivation is mixed-agent RL training. The new strategy keeps renewable units dimension-compatible with the other learning agents so they can share a centralized MATD3 critic. In addition, it adjusts the renewable-specific bidding and reward logic to avoid pathological floor-seeking behaviour and persistent negative-price bidding which result in negative prices.

Changes in this PR:
- add `RenewableEnergyLearningCompatibleStrategy`
- align renewable observation dimensions with the generator and storage learning strategies
- keep the strategy compatible with shared centralized-critic MATD3 training
- remap the renewable action space to a non-negative bid range
- remove renewable regret handling that was encouraging race-to-the-bottom bidding
- document the new strategy in the bidding-strategies docs

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0