### PR TITLE
Remove unused functions in grid_utils.py

### DIFF
--- a/assume/common/grid_utils.py
+++ b/assume/common/grid_utils.py
@@ -123,39 +123,6 @@ def add_redispatch_loads(
         )
 
 
-def add_nodal_loads(
-    network: pypsa.Network,
-    loads: pd.DataFrame,
-) -> None:
-    """
-    This adds loads to the nodal PyPSA network with respective bus data to which they are connected.
-    The loads are added as generators with negative sign so their dispatch can be also curtailed,
-    since regular load in PyPSA represents only an inelastic demand.
-    """
-    zeros = pd.DataFrame(
-        np.zeros((len(network.snapshots), len(loads.index))),
-        index=network.snapshots,
-        columns=loads.index,
-    )
-    loads_c = loads.copy()
-
-    if "sign" in loads_c.columns:
-        del loads_c["sign"]
-
-    # add loads as negative generators
-    network.add(
-        "Generator",
-        name=loads.index,
-        bus=loads["node"],  # bus to which the generator is connected to
-        p_nom=loads["max_power"],  # Nominal capacity of the powerplant/generator
-        p_min_pu=zeros,
-        p_max_pu=zeros + 1,
-        marginal_cost=zeros,
-        sign=-1,
-        **loads_c,
-    )
-
-
 def read_pypsa_grid(
     network: pypsa.Network,
     grid_dict: dict[str, pd.DataFrame],

--- a/assume/common/grid_utils.py
+++ b/assume/common/grid_utils.py
@@ -96,34 +96,6 @@ def add_redispatch_generators(
     )
 
 
-def add_loads(
-    network: pypsa.Network,
-    loads: pd.DataFrame,
-) -> None:
-    """
-    Add loads normally to the grid
-
-    Args:
-        network (pypsa.Network): the pypsa network to which the loads are
-        loads (pandas.DataFrame): the loads dataframe
-    """
-
-    # add loads
-    network.add(
-        "Load",
-        name=loads.index,
-        bus=loads["node"],  # bus to which the generator is connected to
-        **loads,
-    )
-
-    if "p_set" not in loads.columns:
-        network.loads_t["p_set"] = pd.DataFrame(
-            np.zeros((len(network.snapshots), len(loads.index))),
-            index=network.snapshots,
-            columns=loads.index,
-        )
-
-
 def add_redispatch_loads(
     network: pypsa.Network,
     loads: pd.DataFrame,

--- a/assume/common/grid_utils.py
+++ b/assume/common/grid_utils.py
@@ -16,68 +16,6 @@ from assume.common.utils import SUPPORTED_SOLVERS
 logger = logging.getLogger(__name__)
 
 
-def add_generators(
-    network: pypsa.Network,
-    generators: pd.DataFrame,
-) -> None:
-    """
-    Add generators normally to the grid
-
-    Args:
-        network (pypsa.Network): the pypsa network to which the generators are
-        generators (pandas.DataFrame): the generators dataframe
-    """
-    zeros = pd.DataFrame(
-        np.zeros((len(network.snapshots), len(generators.index))),
-        index=network.snapshots,
-        columns=generators.index,
-    )
-
-    if isinstance(generators, dict):
-        gen_c = generators.copy()
-
-        if "p_min_pu" not in gen_c.columns:
-            gen_c["p_min_pu"] = zeros
-        if "p_max_pu" not in gen_c.columns:
-            gen_c["p_max_pu"] = zeros + 1
-        if "marginal_cost" not in gen_c.columns:
-            gen_c["marginal_cost"] = zeros
-
-        network.add(
-            "Generator",
-            name=generators.index,
-            bus=generators["node"],  # bus to which the generator is connected to
-            p_nom=generators[
-                "max_power"
-            ],  # Nominal capacity of the powerplant/generator
-            **gen_c,
-        )
-    elif isinstance(generators, pd.DataFrame):
-        # add generators
-        generators.drop(
-            ["p_min_pu", "p_max_pu", "marginal_cost"],
-            axis=1,
-            inplace=True,
-            errors="ignore",
-        )
-        network.add(
-            "Generator",
-            name=generators.index,
-            bus=generators["node"],  # bus to which the generator is connected to
-            p_nom=generators[
-                "max_power"
-            ],  # Nominal capacity of the powerplant/generator
-            p_min_pu=zeros,
-            p_max_pu=zeros + 1,
-            marginal_cost=zeros,
-            **generators,
-        )
-    else:
-        raise ValueError(
-            "Generators must be provided as a pandas DataFrame or a dictionary of pandas Series."
-        )
-
-
 def add_redispatch_generators(
     network: pypsa.Network,
     generators: pd.DataFrame,

--- a/assume/common/grid_utils.py
+++ b/assume/common/grid_utils.py
@@ -96,29 +96,6 @@ def add_redispatch_generators(
     )
 
 
-def add_backup_generators(
-    network: pypsa.Network,
-    backup_marginal_cost: float = 1e5,
-) -> None:
-    """
-    Add generators normally to the grid
-
-    Args:
-        network (pypsa.Network): the pypsa network to which the generators are
-        generators (pandas.DataFrame): the generators dataframe
-    """
-
-    # add backup generators at each node
-    network.add(
-        "Generator",
-        name=network.buses.index,
-        suffix="_backup",
-        bus=network.buses.index,  # bus to which the generator is connected to
-        p_nom=10e4,
-        marginal_cost=backup_marginal_cost,
-    )
-
-
 def add_loads(
     network: pypsa.Network,
     loads: pd.DataFrame,

--- a/tests/test_grid_utils.py
+++ b/tests/test_grid_utils.py
@@ -11,7 +11,6 @@ pytest.importorskip("pypsa")
 import pypsa
 
 from assume.common.grid_utils import (
-    add_nodal_loads,
     add_redispatch_generators,
     add_redispatch_loads,
     read_pypsa_grid,
@@ -163,43 +162,6 @@ def test_add_redispatch_loads(n_2bus_1line, loads_for_n_2_bus_1line):
     assert actual_loads_t.index == "now"
     # p_set should be initialized as 0 for all loads and snapshots
     assert (actual_loads_t == expected_loads_t).all().all()
-
-
-def test_add_nodal_loads(n_2bus_1line, loads_for_n_2_bus_1line):
-    expected_nodal_loads = pd.DataFrame(
-        {
-            "name": ["loadN", "loadS"],
-            "bus": ["N", "S"],
-            "p_nom": [0.0, 3000.0],
-            "p_min_pu": [0.0, 0.0],
-            "p_max_pu": [1.0, 1.0],
-            "marginal_cost": [0.0, 0.0],
-            "sign": [-1.0, -1.0],
-        }
-    ).set_index("name")
-
-    expected_nodal_loads_t = pd.DataFrame(
-        {
-            "name": ["now"],  # empty dataframe
-        }
-    ).set_index("name")
-
-    add_nodal_loads(n_2bus_1line, loads_for_n_2_bus_1line)
-    actual_nodal_loads = n_2bus_1line.generators.filter(like="load", axis=0)
-    assert (actual_nodal_loads.index == expected_nodal_loads.index).all()
-    assert (actual_nodal_loads.bus == expected_nodal_loads["bus"]).all()
-    assert (actual_nodal_loads.p_nom == expected_nodal_loads["p_nom"]).all()
-    assert (actual_nodal_loads.p_min_pu == expected_nodal_loads["p_min_pu"]).all()
-    assert (actual_nodal_loads.p_max_pu == expected_nodal_loads["p_max_pu"]).all()
-    assert (
-        actual_nodal_loads.marginal_cost == expected_nodal_loads["marginal_cost"]
-    ).all()
-    assert (actual_nodal_loads.sign == expected_nodal_loads["sign"]).all()
-
-    actual_nodal_loads_t = n_2bus_1line.generators_t.p_set
-    assert actual_nodal_loads_t.index == "now"
-    # p_set should be initialized as 0 for all loads and snapshots
-    assert (actual_nodal_loads_t == expected_nodal_loads_t).all().all()
 
 
 # use grid_dict fixture from test_redispatch.py - does not seem to work


### PR DESCRIPTION
### **User description**
## Description
Historically we had add_loads, add_generators and add_backup_generators in grid_utils.py
Nowadays, we only use add_redispatch_loads, add_redispatch_generators in our framework. They incorporate adding backup generators to the network.

I would think we can remove these functions, as they give no value.
Is there anyone using them?

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Remove unused grid utility helpers

- Keep only redispatch grid additions

- Drop nodal-loads test and import


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["assume/common/grid_utils.py"] 
  B["Remove unused add_* helpers"]
  C["Keep redispatch helpers"]
  D["tests/test_grid_utils.py"]
  E["Remove add_nodal_loads coverage"]
  A -- "deletes" --> B
  A -- "retains" --> C
  D -- "removes test/import" --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>grid_utils.py</strong><dd><code>Remove unused generator and load helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assume/common/grid_utils.py

<ul><li>Delete <code>add_generators</code> legacy helper<br> <li> Remove <code>add_backup_generators</code> function<br> <li> Remove <code>add_loads</code> and <code>add_nodal_loads</code></ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/814/files#diff-dc54ce1ceb8f71a0494bb087f0cbb407627ec3a559c6da7e354115057e037314">+0/-146</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_grid_utils.py</strong><dd><code>Remove `add_nodal_loads` import and test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/test_grid_utils.py

<ul><li>Drop <code>add_nodal_loads</code> from imports<br> <li> Remove <code>test_add_nodal_loads</code> test case</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/814/files#diff-e08cab43a217f5801f839cff04666ebeec80b1327cc3f77ae55e7089e43ef04d">+0/-38</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

