### PR TITLE
Avoid torch seeding in non-RL simulations (+ minor general typos + default example fixed)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,7 +12,7 @@ Closes #<issue‑number>
 <!-- Summarise the purpose/motivation and the changes of the PR. -->
 
 ## Checklist
-- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
+- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
 - [ ] New unit/integration tests added (if applicable)
 - [ ] Changes noted in release notes (if any)
 - [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ pre-commit run --all-files
 4. Install also testing capabilities:
 
 ```bash
-pip install -e ".[testing]"
+pip install -e ".[test]"
 ```
 
 5. Implement your changes and push the changes to a fork
@@ -68,9 +68,9 @@ pip install -e ".[testing]"
 
 ### Creating a new release
 
-To release a new version, create a git tag of the release commit and release notes in GitHub (also possible via `Draft new release` function of Github). No adjusted toml file necessary anymore.
-A github action automatically uploads the release to PyPI.
-The upload to PyPi has to be confirmed by one of the core developers.
+To release a new version, create a git tag of the release commit and release notes in GitHub (also possible via `Draft new release` function of GitHub). No adjusted toml file necessary anymore.
+A GitHub Action automatically uploads the release to PyPI.
+The upload to PyPI has to be confirmed by one of the core developers.
 
 ## Building documentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Developed as an open-source model, its primary objectives are to ensure usabilit
 
 ## Introduction
 
-A unique feature of the ASSUME toolbox is its integration of **Deep Reinforcement Learning** methods into the behavioral strategies of market agents. The model offers various predefined agent representations for both the demand and generation sides, which can be used as plug-and-play modules, simplifying the reinforcement of learning strategies.
+A unique feature of the ASSUME toolbox is its integration of **Deep Reinforcement Learning** methods into the behavioral strategies of market agents. The model offers predefined agent representations for both the demand and generation sides that can be used as plug-and-play modules, simplifying the implementation of learning strategies.
 This setup enables research into new market designs and dynamics in energy markets.
 
 **If you have any questions - get in contact on matrix: https://matrix.to/#/#assume-framework:matrix.org**<br>
@@ -72,8 +72,8 @@ pip install assume-framework
 pip install 'assume-framework[learning]'
 ```
 
-Please keep in mind, that the above installation method will install pytorch package without CUDA support.
-If you want to make use of your GPU with CUDA cores, please install pytorch with GPU support separately as described [here](https://pytorch.org/get-started/locally/).
+Please keep in mind that the above installation method will install the PyTorch package without CUDA support.
+If you want to make use of your GPU with CUDA cores, please install PyTorch with GPU support separately as described [here](https://pytorch.org/get-started/locally/).
 
 We also include **network-based market clearing algorithms** such as for the re-dispatch, zonal clearing with NTCs and nodal market clearing, which all require the PyPSA library.
 To install the package with these capabilities, use:
@@ -92,7 +92,7 @@ pip install 'assume-framework[all]'
 ### Timescale Database and Grafana Dashboards
 The Timescale Database and Grafana Dashboard are used to store and represent simulation results.
 
-If you want to benefit from a supported database and integrated Grafana dashboards for scenario analysis, you can use the provided Docker Compose file.
+If you want to use the supported TimescaleDB and integrated Grafana dashboards for scenario analysis, you can use the provided Docker Compose file.
 
 Follow these steps:
 
@@ -132,10 +132,10 @@ The former are helpful if you would like to get an impression of how ASSUME work
 
 ### The Tutorial Notebooks
 
-You can run the tutorials locally using the notebooks [here](examples/notebooks) or use [google colab](https://assume.readthedocs.io/en/latest/examples_basic.html)
+You can run the tutorials locally using the notebooks [here](examples/notebooks) or use [Google Colab](https://assume.readthedocs.io/en/latest/examples_basic.html).
 The tutorials begin with the basics of ASSUME, e.g., introducing a new unit, while the later tutorials cover more advanced use cases.
 
-We particularly recommend these tutorials; more can be found under the given Link:
+We particularly recommend these tutorials; more can be found at the linked pages:
 
 
 How to configure a new unit in ASSUME?
@@ -155,7 +155,7 @@ How to use reinforcement learning for new market participants in ASSUME?
 
 ### Preconfigured Examples
 
-To explore the provided example simualtions [here](examples/inputs), follow these steps:
+To explore the provided example simulations [here](examples/inputs), follow these steps:
 
 1. Clone the repository and navigate to its directory:
 
@@ -189,7 +189,7 @@ For additional CLI options, run `assume -h`.
 
 ## Development
 
-[The Contribution Guidelines explain how to setup your development environment and contribute to the project.](./CONTRIBUTING.md#development-setup)
+[The Contribution Guidelines explain how to set up your development environment and contribute to the project.](./CONTRIBUTING.md#development-setup)
 
 ## Creating Documentation
 

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -893,14 +893,18 @@ def confirm_learning_save_path(save_path: str, continue_learning: bool) -> None:
             )
 
 
-def set_random_seed(seed: int | None, torch_deterministic: bool = True):
+def set_random_seed(
+    seed: int | None,
+    torch_deterministic: bool = True,
+    learning_mode: bool = False,
+):
     """
     Args:
-     seed (int | None): Integer seed for random number generators or None to disable seeding.
-     torch_deterministic (bool): If True, enforces PyTorch deterministic algorithms.
-                           May reduce performance. Default is True.
+        seed (int | None): Integer seed for random number generators or None to disable seeding.
+        torch_deterministic (bool): If True, enforces PyTorch deterministic algorithms. May reduce performance. Default is True.
+        learning_mode (bool): If True, PyTorch seeding is enabled. Default is False and PyTorch seeding is skipped.
 
-     Notes:
+    Notes:
          - Completely reproducible results are not guaranteed across different PyTorch versions, hardware, or CUDA configurations.
          - See https://docs.pytorch.org/docs/stable/notes/randomness.html
     """
@@ -910,15 +914,18 @@ def set_random_seed(seed: int | None, torch_deterministic: bool = True):
     random.seed(seed)
     np.random.seed(seed)
 
+    if not learning_mode:
+        return
+
     try:
         import torch as th
-
-        if "CUBLAS_WORKSPACE_CONFIG" not in os.environ:
-            os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
 
         th.manual_seed(seed)
 
         if torch_deterministic:
+            if "CUBLAS_WORKSPACE_CONFIG" not in os.environ:
+                os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+
             th.backends.cudnn.deterministic = True
             th.backends.cudnn.benchmark = False
 

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -545,9 +545,13 @@ def load_config_and_create_forecaster(
     if not study_case:
         study_case = list(config.keys())[0]
     config = config[study_case]
+    learning_config = config.get("learning_config", {})
+    learning_mode = learning_config.get("learning_mode", False) or learning_config.get(
+        "continue_learning", False
+    )
 
     # Set seed, or disable with `seed: null` in config
-    set_random_seed(config.get("seed", 42))
+    set_random_seed(seed=config.get("seed", 42), learning_mode=learning_mode)
 
     simulation_id = config.get("simulation_id", f"{scenario}_{study_case}")
 

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -24,12 +24,14 @@ Upcoming Release
   - **Extended ``min_max_scale`` to support arbitrary output ranges**: Added optional ``out_min`` and ``out_max`` parameters, enabling both forward scaling and inverse rescaling with a single function instead of two separate ones.
   - **Add test for portfolio learning strategy and ``min_max_scale`` function**: Added a test for the portfolio learning strategy and ``min_max_rescale`` function to ensure its functionality and stability.
   - **Readme naming of examples/tutorials**: Slight changing of tutorial and example in the read me to make difference clearer and more consistent with the naming of the notebooks and to align with readthedocs.
+
 **Bug Fixes:**
   - **Dependencies**: pin xarray and setuptools dependencies until upstream fixes are available
   - **Fix bug in forecasts**, that occurred when using complex clearing
   - **Fix infeasible power output in PowerPlant**: ``calculate_min_max_power`` now correctly accounts for base load, positive/negative capacity reserves, and heat demand when computing additional power. If reduced availability makes the unit infeasible to run, both min and max power are set to 0. A warning is issued if previous dispatch exceeded available power.
   - **Fix upward redispatch potential**, so that availabilities are now correctly considered instead of the nominal power output of the unit
   - **Fix errors in portfolio learning strategies**: The ``min_max_rescale`` function was missing from ``utils.py``, causing an ``ImportError`` in ``portfolio_learning_strategies.py``. Resolved by extending ``min_max_scale`` to cover the rescaling use case. And fix minor construction bug for observation space.
+  - **Skip torch seeding when torch is installed but not used**: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
 
 0.6.1 - (25th March 2026)
 =========================

--- a/examples/examples.py
+++ b/examples/examples.py
@@ -121,7 +121,7 @@ if __name__ == "__main__":
     data_format = "local_db"  # "local_db" or "timescale"
 
     # select the example to run from the available examples above
-    example = "small_with_redispatch"
+    example = "small_with_vre_and_storage"
 
     if data_format == "local_db":
         db_uri = "sqlite:///./examples/local_db/assume_db.db"

--- a/examples/notebooks/04a_reinforcement_learning_algorithm_example.ipynb
+++ b/examples/notebooks/04a_reinforcement_learning_algorithm_example.ipynb
@@ -248,7 +248,7 @@
     "from assume.world import World\n",
     "\n",
     "# Set random seed for reproducibility\n",
-    "set_random_seed(42)\n",
+    "set_random_seed(42, learning_mode=True)\n",
     "\n",
     "logger = logging.getLogger(__name__)"
    ]

--- a/examples/notebooks/04b_reinforcement_learning_example.ipynb
+++ b/examples/notebooks/04b_reinforcement_learning_example.ipynb
@@ -278,7 +278,7 @@
     ")\n",
     "\n",
     "# Set random seed for reproducibility\n",
-    "set_random_seed(42)"
+    "set_random_seed(42, learning_mode=True)"
    ]
   },
   {

--- a/examples/notebooks/04c_reinforcement_learning_storage_example.ipynb
+++ b/examples/notebooks/04c_reinforcement_learning_storage_example.ipynb
@@ -267,7 +267,7 @@
     ")\n",
     "\n",
     "# Set random seed for reproducibility\n",
-    "set_random_seed(42)"
+    "set_random_seed(42, learning_mode=True)"
    ]
   },
   {

--- a/examples/notebooks/09_example_Sim_and_xRL.ipynb
+++ b/examples/notebooks/09_example_Sim_and_xRL.ipynb
@@ -226,7 +226,7 @@
     "\n",
     "from assume.common.utils import set_random_seed\n",
     "\n",
-    "set_random_seed(42)"
+    "set_random_seed(42, learning_mode=True)"
    ]
   },
   {
@@ -236,7 +236,7 @@
     "id": "636ea9ae"
    },
    "source": [
-    "**Please note:** for complete reproducability we set `seed: 42` here which can also ge set in the general config. Also the choices of the learning algorithm get deterministic with this function which slows down learning performance. We, therefore, advise only using it when absolutely necessary. \n",
+    "**Please note:** for reproducability we set `seed: 42` here which can also be set in the general config. Also the choices of the underlying PyTorch algorithms get deterministic with this function which slows down learning performance. We, therefore, advise only using it when absolutely necessary.\n",
     "\n",
     "#### 1.1.2 Create and Load Example Files from Market Splitting Tutorial\n",
     "\n",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Description
- Skip torch seeding when torch is installed but not used: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
- While at it, fixed the default example, some typos and minor rephrasing for clarity

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
