### PR TITLE
Add units operator forecaster

### DIFF
--- a/assume/common/forecaster.py
+++ b/assume/common/forecaster.py
@@ -1001,3 +1001,35 @@ class ExchangeForecaster(UnitForecaster):
         )
         self.volume_import = self._to_series(volume_import)
         self.volume_export = self._to_series(volume_export)
+
+
+class UnitsOperatorForecaster(UnitForecaster):
+    """Forecaster for units operator
+    
+    Provides price, residual load, and availability forecasts (see :class:`UnitForecaster`).
+    Arbitrary other forecasts can be given to the UnitsOperatorForecaster through kwargs.
+    For now, this ensures flexibility for the many possible cases UnitsOperators can be used.
+    """
+    def __init__(
+        self,
+        index: ForecastIndex,
+        market_prices: dict[str, ForecastSeries] = None,
+        residual_load: dict[str, ForecastSeries] = None,
+        availability: ForecastSeries = 1,
+        forecast_algorithms: dict[str, str] = {},
+        forecast_registries: dict[str, dict] = None,
+        **kwargs,
+    ):
+        super().__init__(
+            index=index,
+            availability=availability,
+            forecast_algorithms=forecast_algorithms,
+            forecast_registries=forecast_registries,
+            market_prices=market_prices,
+            residual_load=residual_load,
+        )
+
+        for k, v in kwargs.items():
+            if isinstance(v, pd.Series):
+                v = self._to_series(v)
+            self.__setattr__(k, v)

--- a/assume/common/forecaster.py
+++ b/assume/common/forecaster.py
@@ -1004,25 +1004,31 @@ class ExchangeForecaster(UnitForecaster):
 
 
 class UnitsOperatorForecaster(UnitForecaster):
-    """Forecaster for units operator
-    
-    Provides price, residual load, and availability forecasts (see :class:`UnitForecaster`).
-    Arbitrary other forecasts can be given to the UnitsOperatorForecaster through kwargs.
-    For now, this ensures flexibility for the many possible cases UnitsOperators can be used.
+    """Forecaster owned by a units operator (rather than a single unit).
+
+    Gives a units operator (or a portfolio manager) its own notion of future
+    market prices and residual loads, instead of having to reach into the
+    forecaster of an arbitrary unit it manages. It reuses the price and
+    residual load lifecycle of :class:`UnitForecaster` (these are market-wide
+    signals, so the operator initializes them against all units in the world).
+
+    Unlike a unit forecaster, an operator has no ``availability`` of its own, so
+    that attribute is left at the harmless inherited default and is not used.
+    Arbitrary additional operator-level forecasts can be supplied through
+    kwargs, keeping this flexible for the many ways UnitsOperators can be used.
     """
+
     def __init__(
         self,
         index: ForecastIndex,
         market_prices: dict[str, ForecastSeries] = None,
         residual_load: dict[str, ForecastSeries] = None,
-        availability: ForecastSeries = 1,
         forecast_algorithms: dict[str, str] = {},
         forecast_registries: dict[str, dict] = None,
         **kwargs,
     ):
         super().__init__(
             index=index,
-            availability=availability,
             forecast_algorithms=forecast_algorithms,
             forecast_registries=forecast_registries,
             market_prices=market_prices,

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from mango import Role, create_acl, sender_addr
 from mango.messages.message import Performatives
 
+from assume.common.forecaster import UnitsOperatorForecaster
 from assume.common.market_objects import (
     ClearingMessage,
     DataRequestMessage,
@@ -52,18 +53,22 @@ class UnitsOperator(Role):
     Args:
         available_markets (list[MarketConfig]): The available markets.
         portfolio_strategies (dict[str, UnitOperatorStrategy], optional): Optimized portfolio strategy. Defaults to an empty dict.
+        forecaster (UnitsOperatorForecaster, optional): Operator-level forecaster providing market
+            price and residual load forecasts shared across the operator's units. Defaults to None.
     """
 
     def __init__(
         self,
         available_markets: list[MarketConfig],
         portfolio_strategies: dict[str, UnitOperatorStrategy] = {},
+        forecaster: UnitsOperatorForecaster = None,
     ):
         super().__init__()
 
         self.available_markets = available_markets
         self.registered_markets: dict[str, MarketConfig] = {}
         self.last_sent_dispatch = defaultdict(lambda: 0)
+        self.forecaster = forecaster
 
         self.portfolio_strategies = portfolio_strategies
         for market in self.available_markets:

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -29,6 +29,7 @@ from assume.common.forecaster import (
     SteamgenerationForecaster,
     SteelplantForecaster,
     UnitForecaster,
+    UnitsOperatorForecaster,
 )
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.utils import (
@@ -780,7 +781,12 @@ def load_config_and_create_forecaster(
                         electricity_price_flex=0,  # TODO
                         thermal_storage_schedule=0,  # TODO
                         thermal_demand=0,  # TODO
-                    )
+                    )       
+    units_operator_forecast_data = {
+        "shared_unit_index": shared_unit_index,
+        "availability": availability,
+        "forecast_algorithms": forecast_algorithms
+    }
     return {
         "config": config,
         "simulation_id": simulation_id,
@@ -796,6 +802,7 @@ def load_config_and_create_forecaster(
         "unit_forecasts": unit_forecasts,
         "index": index,
         "forecasts_df": forecasts_df,
+        "units_operator_forecast_data": units_operator_forecast_data,
     }
 
 
@@ -837,6 +844,7 @@ def setup_world(
     dsm_units = scenario_data["dsm_units"]
     unit_forecasts = scenario_data["unit_forecasts"]
     forecasts_df = scenario_data["forecasts_df"]
+    units_operator_forecast_data = scenario_data["units_operator_forecast_data"]
 
     # save every thousand steps by default to free up memory
     save_frequency_hours = config.get("save_frequency_hours", 48)
@@ -1004,6 +1012,9 @@ def setup_world(
             unit_operators_strategies[operator] = converted_strategies
     else:
         unit_operators_strategies = {}
+
+
+    # FIXME: Add forecaster to units_operator
 
     # if distributed_role is true - there is a manager available
     # and we can add each units_operator as a separate process

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -781,7 +781,7 @@ def load_config_and_create_forecaster(
                         electricity_price_flex=0,  # TODO
                         thermal_storage_schedule=0,  # TODO
                         thermal_demand=0,  # TODO
-                    )       
+                    )
     # shared inputs used to build one UnitsOperatorForecaster per operator in
     # setup_world. An operator has no availability of its own (that is a
     # per-unit concept), so only the index and algorithms are shared here.
@@ -1004,24 +1004,29 @@ def setup_world(
     for op, op_units in exchange_units.items():
         units[op].extend(op_units)
 
+    config_forecast_algorithms = units_operator_forecast_data["forecast_algorithms"]
+    operator_forecast_algorithms: dict[str, dict] = {}
     if unit_operators is not None:
         logger.info("Create unit_operators for portfolio strategies")
         unit_operators_strategies = unit_operators.to_dict("index")
         # remove starting "bidding_" string from market names
         for operator in unit_operators_strategies.keys():
-            raw_strategies = unit_operators_strategies[operator]
-            converted_strategies = bidding_strategies_from_param_dict(raw_strategies)
-            unit_operators_strategies[operator] = converted_strategies
+            raw_params = unit_operators_strategies[operator]
+            operator_forecast_algorithms[operator] = get_unit_forecast_algorithms(
+                config_forecast_algorithms, raw_params
+            )
+            unit_operators_strategies[operator] = bidding_strategies_from_param_dict(
+                raw_params
+            )
     else:
         unit_operators_strategies = {}
 
-    # build one operator-level forecaster per operator, so each operator has its
-    # own (independent) notion of future prices and residual loads. They are
-    # initialized later in world.init_forecasts once all units exist.
     operator_forecasts = {
         op: UnitsOperatorForecaster(
             index=units_operator_forecast_data["shared_unit_index"],
-            forecast_algorithms=units_operator_forecast_data["forecast_algorithms"],
+            forecast_algorithms=operator_forecast_algorithms.get(
+                op, config_forecast_algorithms
+            ),
         )
         for op in set(units.keys())
     }

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -782,10 +782,12 @@ def load_config_and_create_forecaster(
                         thermal_storage_schedule=0,  # TODO
                         thermal_demand=0,  # TODO
                     )       
+    # shared inputs used to build one UnitsOperatorForecaster per operator in
+    # setup_world. An operator has no availability of its own (that is a
+    # per-unit concept), so only the index and algorithms are shared here.
     units_operator_forecast_data = {
         "shared_unit_index": shared_unit_index,
-        "availability": availability,
-        "forecast_algorithms": forecast_algorithms
+        "forecast_algorithms": forecast_algorithms,
     }
     return {
         "config": config,
@@ -1013,8 +1015,16 @@ def setup_world(
     else:
         unit_operators_strategies = {}
 
-
-    # FIXME: Add forecaster to units_operator
+    # build one operator-level forecaster per operator, so each operator has its
+    # own (independent) notion of future prices and residual loads. They are
+    # initialized later in world.init_forecasts once all units exist.
+    operator_forecasts = {
+        op: UnitsOperatorForecaster(
+            index=units_operator_forecast_data["shared_unit_index"],
+            forecast_algorithms=units_operator_forecast_data["forecast_algorithms"],
+        )
+        for op in set(units.keys())
+    }
 
     # if distributed_role is true - there is a manager available
     # and we can add each units_operator as a separate process
@@ -1022,12 +1032,18 @@ def setup_world(
         logger.info("Adding unit operators and units - with subprocesses")
         for op, op_units in units.items():
             strategies = unit_operators_strategies.get(op, {})
-            world.add_units_with_operator_subprocess(op, op_units, strategies)
+            world.add_units_with_operator_subprocess(
+                op, op_units, strategies, forecaster=operator_forecasts.get(op)
+            )
     else:
         logger.info("Adding unit operators and units")
         for company_name in set(units.keys()):
             strategies = unit_operators_strategies.get(company_name, {})
-            world.add_unit_operator(id=str(company_name), strategies=strategies)
+            world.add_unit_operator(
+                id=str(company_name),
+                strategies=strategies,
+                forecaster=operator_forecasts.get(company_name),
+            )
 
         # add the units to corresponding unit operators
         for op, op_units in units.items():

--- a/assume/strategies/portfolio_learning_strategies.py
+++ b/assume/strategies/portfolio_learning_strategies.py
@@ -276,11 +276,11 @@ class PortfolioLearningStrategy(TorchLearningStrategy, UnitOperatorStrategy):
         # marginal cost lower than forecasted price. Indicates the
         # leverage of the portfolio operator on the markets.
         gen_obs = 0
+        price_forecast = units_operator.forecaster.price[market_id]
+        residual_load = units_operator.forecaster.residual_load[market_id]
 
         for u_id, unit in units_operator.units.items():
             unit_gen = FastSeries(index=unit.index, value=0)
-            price_forecast = unit.forecaster.price[market_id]
-            residual_load = unit.forecaster.residual_load[market_id]
 
             for start in price_forecast.index:
                 marginal_cost = unit.calculate_marginal_cost(start, unit.max_power)
@@ -489,12 +489,12 @@ class PortfolioLearningStrategy(TorchLearningStrategy, UnitOperatorStrategy):
         # Iterate over all orders in the orderbook to calculate order-specific profit.
         for product, product_orders in groupby(orderbook, market_getter):
             start, end, _ = product
+            comp_price = units_operator.forecaster.price[market_id][start]
 
             for order in product_orders:
                 unit_id = order["unit_id"]
                 unit = units_operator.units[unit_id]
 
-                comp_price = unit.forecaster.price[market_id][start]
                 clearing_price = order.get("accepted_price", 0)
                 accepted_volume = order.get("accepted_volume", 0)
 

--- a/assume/world.py
+++ b/assume/world.py
@@ -37,7 +37,7 @@ from assume.common import (
 )
 from assume.common.base import LearningConfig
 from assume.common.forecast_algorithms import get_forecast_registries
-from assume.common.forecaster import UnitForecaster
+from assume.common.forecaster import UnitForecaster, UnitsOperatorForecaster
 from assume.common.utils import datetime2timestamp, timestamp2datetime
 from assume.markets import MarketRole, clearing_mechanisms
 from assume.strategies import (
@@ -398,7 +398,10 @@ class World:
             output_agent.suspendable_tasks = False
 
     def add_unit_operator(
-        self, id: str, strategies: dict[str, UnitOperatorStrategy] = {}
+        self,
+        id: str,
+        strategies: dict[str, UnitOperatorStrategy] = {},
+        forecaster: UnitsOperatorForecaster = None,
     ) -> None:
         """
         Add a unit operator to the simulation, creating a new role agent and applying the role of a unit operator to it.
@@ -407,6 +410,8 @@ class World:
 
         Args:
             id (str): The identifier for the unit operator.
+            strategies (dict[str, UnitOperatorStrategy], optional): Portfolio strategies for the operator.
+            forecaster (UnitsOperatorForecaster, optional): Operator-level forecaster. Defaults to None.
         """
 
         if self.unit_operators.get(id):
@@ -430,6 +435,7 @@ class World:
         units_operator = UnitsOperator(
             available_markets=list(self.markets.values()),
             portfolio_strategies=bidding_strategies,
+            forecaster=forecaster,
         )
 
         # creating a new role agent and apply the role of a units operator
@@ -450,7 +456,11 @@ class World:
             )
 
     def add_units_with_operator_subprocess(
-        self, id: str, units: list[dict], strategies: dict[str, UnitOperatorStrategy]
+        self,
+        id: str,
+        units: list[dict],
+        strategies: dict[str, UnitOperatorStrategy],
+        forecaster: UnitsOperatorForecaster = None,
     ):
         """
         Adds a units operator with given ID in a separate process
@@ -460,6 +470,7 @@ class World:
         Args:
             id (str): the id of the units operator
             units (list[dict]): list of unit dictionaries forwarded to create_unit
+            forecaster (UnitsOperatorForecaster, optional): Operator-level forecaster. Defaults to None.
         """
         clock_agent_name = f"clock_agent_{id}"
         markets = list(self.markets.values())
@@ -471,7 +482,9 @@ class World:
                 market.opening_hours._cache_gen = None
         self.addresses.append(addr(self.addr, clock_agent_name))
         units_operator = UnitsOperator(
-            available_markets=markets, portfolio_strategies=strategies
+            available_markets=markets,
+            portfolio_strategies=strategies,
+            forecaster=forecaster,
         )
 
         for unit in units:
@@ -936,4 +949,18 @@ class World:
                 markets,
                 forecast_df,
                 unit,
+            )
+
+        # operator-level forecasters provide market-wide price / residual load
+        # signals, so they initialize against all units and markets, with no
+        # single initializing unit.
+        for operator in self.unit_operators.values():
+            if operator.forecaster is None:
+                continue
+            if operator.forecaster._registries is None:
+                operator.forecaster._registries = registries
+            operator.forecaster.initialize(
+                units,
+                markets,
+                forecast_df,
             )

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -15,6 +15,7 @@ Upcoming Release
 
 **New Features:**
   - **Generic Forecasting Interface**: This interface enables to specify different forecast algorithms for preprocess, initialization and update during runtime. They can be specified in the config.yaml or unit csv files. For more information about currently implemented algorithms and how to specify them please read the documentation on Unit forecasts.
+  - **Operator-level forecaster**: Unit operators can now own a ``UnitsOperatorForecaster`` providing their own market price and residual load forecasts (accessible via ``units_operator.forecaster``), instead of reading them from a managed unit. Forecast algorithms can be set per operator via ``forecast_*`` columns in ``unit_operators.csv``, and the portfolio learning strategy now reads its price/residual-load observations from this operator forecaster.
 
 **Improvements:**
   - **In complex clearing, the solver instance is now created once during initialization of the clearing role and reused for each market clearing**. This improves performance for e.g. year-long simulations.

--- a/docs/source/unit_forecasts.rst
+++ b/docs/source/unit_forecasts.rst
@@ -35,6 +35,12 @@ Hydrogen Units                ``HydrogenForecaster``                    DSM attr
 Custom Units (CSV import)     ``CustomUnitForecaster``                  *(arbitrary keyword attributes)*
 ============================= ========================================= ===========================================
 
+.. note::
+   Unit operators can also own a forecaster, :class:`~assume.common.forecaster.UnitsOperatorForecaster`,
+   giving the operator its own ``price`` and ``residual_load`` forecasts (see :doc:`unit_operator`).
+   It reuses the same lifecycle, algorithms, and registries described below; its algorithms can be set per
+   operator through ``forecast_*`` columns in ``unit_operators.csv``.
+
 ***********************
 Forecast Lifecycle
 ***********************
@@ -116,6 +122,10 @@ is the ``algorithm_id``. (Prefix is empty for initialize algorithms, and ``prepr
    (only when the CSV cell is not empty/None).
 
 If neither CSV nor config specifies a certain algorithm, a default is chosen automatically.
+
+The same ``forecast_{prefix}_{forecast_metric}`` columns can be added to ``unit_operators.csv`` to set the
+algorithms of an operator's :class:`~assume.common.forecaster.UnitsOperatorForecaster` per operator, with the
+same config-fallback behaviour.
 
 ***********************************
 Available Algorithms

--- a/docs/source/unit_operator.rst
+++ b/docs/source/unit_operator.rst
@@ -25,6 +25,22 @@ The unit operator is responsible for the following tasks:
 As one can see from all the task the unit oporator covers, that it orchestrates and coordinates the technical units and the markets.
 
 
+Operator Forecaster
+----------------------
+
+Just like each technical unit, a unit operator can own a :class:`~assume.common.forecaster.UnitsOperatorForecaster`.
+This gives the operator (or a portfolio strategy acting on its behalf) its own notion of future **market prices** and
+**residual loads**, instead of having to reach into one of its managed units for them. The forecaster is available as
+``units_operator.forecaster`` and exposes ``price[market_id]`` and ``residual_load[market_id]`` (plus any custom series
+provided at construction).
+
+It reuses the same forecasting machinery as the unit forecasters (see :doc:`unit_forecasts`): its algorithms can be
+selected per operator via ``forecast_*`` columns in ``unit_operators.csv`` (falling back to the config-level
+``forecast_algorithms``), and the series are populated automatically during
+:func:`~assume.world.World.init_forecasts`. The :class:`~assume.strategies.portfolio_learning_strategies.PortfolioLearningStrategy`
+below reads its forecasted price and residual load observations from this operator forecaster.
+
+
 Portfolio Strategies
 ----------------------
 

--- a/tests/test_forecast_interface.py
+++ b/tests/test_forecast_interface.py
@@ -10,7 +10,7 @@ import pandas as pd
 import pytest
 from pandas._testing import assert_series_equal
 
-from assume.common.fast_pandas import FastIndex
+from assume.common.fast_pandas import FastIndex, FastSeries
 from assume.common.forecast_algorithms import (
     calculate_naive_congestion_signal,
     calculate_naive_price,
@@ -23,6 +23,7 @@ from assume.common.forecaster import (
     DemandForecaster,
     DsmUnitForecaster,
     PowerplantForecaster,
+    UnitsOperatorForecaster,
 )
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.strategies import EnergyHeuristicElasticStrategy, EnergyNaiveStrategy
@@ -365,7 +366,7 @@ def test_forecast_interface__elastic_demand(index, market_setup, forecast_setup)
     assert np.isclose(list(market_forecast["EOM"]), [8.0] * 7).all()
 
 
-def test_forecast_interface__cache(market_setup, forecast_setup):
+def test_forecast_interface__cache(market_setup, forecast_setup, shared_FastIndex):
     # clear cache uses
     calculate_naive_price.cache_clear()
     calculate_naive_residual_load.cache_clear()
@@ -385,20 +386,29 @@ def test_forecast_interface__cache(market_setup, forecast_setup):
             None,  # forecaster has no unit
         )
 
+    # an operator-level forecaster initializes against the same units/markets
+    # objects, so it shares the price / residual_load cache too
+    operator_forecaster = UnitsOperatorForecaster(
+        index=shared_FastIndex,
+        forecast_registries=get_forecast_registries(),
+    )
+    operator_forecaster.initialize(
+        forecast_setup["units"], market_setup["market_configs"], None
+    )
+
     for unit in forecast_setup["units"]:
         unit.forecaster.initialize(
             forecast_setup["units"], market_setup["market_configs"], None, unit
         )
 
-    # price and residual_load are called by all initializations
-    assert (
-        calculate_naive_price.cache_info().hits == len(forecast_setup["units"]) + n - 1
-    )
+    # price and residual_load are called by all initializations: the n dsm runs,
+    # the operator run, and one per unit. Only the first call misses.
+    assert calculate_naive_price.cache_info().hits == len(forecast_setup["units"]) + n
     assert calculate_naive_price.cache_info().misses == 1
 
     assert (
         calculate_naive_residual_load.cache_info().hits
-        == len(forecast_setup["units"]) + n - 1
+        == len(forecast_setup["units"]) + n
     )
     assert calculate_naive_residual_load.cache_info().misses == 1
 
@@ -412,3 +422,52 @@ def test_forecast_interface__cache(market_setup, forecast_setup):
     # NOTE: only missed once & no hits due to lru_cache also on calculate_naive_price
     assert calculate_naive_price_inelastic.cache_info().hits == 0
     assert calculate_naive_price_inelastic.cache_info().misses == 1
+
+
+def test_units_operator_forecaster__matches_unit_forecasts(
+    index, market_setup, forecast_setup, shared_FastIndex
+):
+    """An operator-level forecaster computes the same market-wide price and
+    residual load as a unit forecaster, since it initializes against all units."""
+    expected_price = pd.read_csv(path / "results/price.csv", **parse_date)
+    expected_load = pd.read_csv(path / "results/load_forecast.csv", **parse_date)
+
+    operator_forecaster = UnitsOperatorForecaster(
+        index=shared_FastIndex,
+        forecast_registries=get_forecast_registries(),
+    )
+
+    # the operator has no single unit, so initialize without an initializing_unit
+    operator_forecaster.initialize(
+        forecast_setup["units"],
+        market_setup["market_configs"],
+        None,  # no forecast_df --> calculate on its own
+    )
+
+    assert_series_equal(
+        expected_price["price"],
+        pd.Series(operator_forecaster.price["EOM"], index),
+        check_names=False,
+        check_dtype=False,
+        check_freq=False,
+    )
+    assert_series_equal(
+        expected_load["load_forecast"],
+        pd.Series(operator_forecaster.residual_load["EOM"], index),
+        check_names=False,
+        check_dtype=False,
+        check_freq=False,
+    )
+
+
+def test_units_operator_forecaster__extra_kwargs(index, shared_FastIndex):
+    """Arbitrary operator-level forecasts passed via kwargs are stored, with
+    pd.Series converted to FastSeries."""
+    custom_series = pd.Series(2.0, index=index)
+    operator_forecaster = UnitsOperatorForecaster(
+        index=shared_FastIndex,
+        custom_forecast=custom_series,
+    )
+
+    assert isinstance(operator_forecaster.custom_forecast, FastSeries)
+    assert list(operator_forecaster.custom_forecast) == [2.0] * len(index)

--- a/tests/test_portfolio_learning_strategy.py
+++ b/tests/test_portfolio_learning_strategy.py
@@ -12,7 +12,7 @@ from dateutil import rrule as rr
 from dateutil.relativedelta import relativedelta as rd
 
 from assume.common.base import LearningConfig
-from assume.common.forecaster import PowerplantForecaster
+from assume.common.forecaster import PowerplantForecaster, UnitsOperatorForecaster
 from assume.common.market_objects import MarketConfig, MarketProduct
 
 try:
@@ -40,6 +40,7 @@ EXPECTED_OBS_DIM = 46
 class MockUnitsOperator:
     id: str
     units: dict
+    forecaster: UnitsOperatorForecaster = None
 
 
 @pytest.fixture
@@ -86,7 +87,19 @@ def portfolio_units_operator():
             forecaster=ff,
         )
         units[f"pp_{i}"] = unit
-    return MockUnitsOperator(id="test_portfolio_operator", units=units)
+
+    # operator-level forecaster carrying the same market-wide price and residual
+    # load the units see, so portfolio strategies can read them from the operator
+    operator_forecaster = UnitsOperatorForecaster(
+        index,
+        residual_load={MARKET_ID: res_load_forecast},
+        market_prices={MARKET_ID: market_price_forecast},
+    )
+    return MockUnitsOperator(
+        id="test_portfolio_operator",
+        units=units,
+        forecaster=operator_forecaster,
+    )
 
 
 @pytest.fixture
@@ -133,6 +146,31 @@ def test_portfolio_observation_dimensions(portfolio_units_operator, portfolio_st
         strategy.unique_obs_dim + strategy.foresight * strategy.num_timeseries_obs_dim
         == EXPECTED_OBS_DIM
     )
+
+
+@pytest.mark.require_learning
+def test_portfolio_observation_uses_operator_forecaster(
+    portfolio_units_operator, portfolio_strategy
+):
+    """prepare_observations reads the operator-level forecaster: the price /
+    residual load scaling bounds reflect the operator forecaster's values, not
+    those of any individual unit (which here hold different forecasts)."""
+    strategy, _ = portfolio_strategy
+
+    # Give the operator forecaster distinct, known values so the bounds below can
+    # only come from it (the units' forecasters span 50..150 / 500..1000).
+    portfolio_units_operator.forecaster = UnitsOperatorForecaster(
+        portfolio_units_operator.forecaster.index,
+        market_prices={MARKET_ID: np.linspace(20, 80, 48)},
+        residual_load={MARKET_ID: np.linspace(100, 400, 48)},
+    )
+
+    strategy.prepare_observations(portfolio_units_operator, MARKET_ID)
+
+    assert strategy.min_price == pytest.approx(20)
+    assert strategy.max_price == pytest.approx(80)
+    assert strategy.min_res_load == pytest.approx(100)
+    assert strategy.max_res_load == pytest.approx(400)
 
 
 @pytest.mark.require_learning


### PR DESCRIPTION
### **User description**
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #783 

## Description
Adds a specific forecaster for unit operators that uses the generic forecaster interface and behaves like the existing unit forecasters (same forecast switching via config or csv. 
Incorporates the new forecaster in the portfolio learning strategy. 

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- [x] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add `UnitsOperatorForecaster` for operators

- Wire operator forecasters into world loading

- Portfolio learning reads operator forecasts

- Add tests and update docs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSV scenario loader (loader_csv.py)"] 
  B["UnitsOperatorForecaster (forecaster.py)"]
  C["UnitsOperator (units_operator.py)"]
  D["World forecast init (world.py)"]
  E["PortfolioLearningStrategy (portfolio_learning_strategies.py)"]
  F["Tests + docs"]
  A -- "build per-operator forecaster" --> B
  A -- "pass forecaster to operator" --> C
  C -- "store `forecaster`" --> E
  D -- "initialize operator forecasts" --> B
  B -- "provide `price`/`residual_load`" --> E
  F -- "validate + document behavior" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>forecaster.py</strong><dd><code>Add `UnitsOperatorForecaster` extending `UnitForecaster`</code>&nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-9e3d450a0ad0d08812b308dcbbf1e232b784fc92ab699c3b5e75dba23e1de7f8">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>units_operator.py</strong><dd><code>Store operator-level forecaster on `UnitsOperator`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-9a14867c55f7a7c764c2f32b538a8f7a614d0328364bf56a7397b11a340aa11a">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>loader_csv.py</strong><dd><code>Create and inject per-operator forecasters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-0dfddc944404e0303344c49eccf4b01cc2c44a07837d1b7a02de13097e408ca2">+37/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>world.py</strong><dd><code>Plumb operator forecasters and initialize them</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-945b2a919be66427224a36b62e63d439a5752b48d8d72e13a34f40d18a93fb8f">+31/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>portfolio_learning_strategies.py</strong><dd><code>Use operator forecasts for observations/reward</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-99fb132f4f3d01e5dcd96242b84d9cf05158edcfd3f887633330a4dfd6d19792">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>test_forecast_interface.py</strong><dd><code>Add operator-forecaster tests and cache assertions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-4df491c4e16c87531d4031e471547ab0f4881303dab531c7c201092de3246753">+66/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>test_portfolio_learning_strategy.py</strong><dd><code>Provide operator forecaster and assert usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-f687dc35b81f57e74b0864c9d57f8aa57411659daeaa7ca1d663488c00050e7f">+40/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>release_notes.rst</strong><dd><code>Note new operator-level forecaster feature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-eb36f1b6f2ee2691f609c07d32a8d977e4052a9e47d0ec94a241c6fc001a5d5c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unit_forecasts.rst</strong><dd><code>Document operator forecast algorithm configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-d521dad11610d6ed384d6fda8d03aa92bcfc1ac8741b5b95189a711fbabba6ae">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unit_operator.rst</strong><dd><code>Document `units_operator.forecaster` behavior and lifecycle</code></dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/818/files#diff-67e2bbbdc2d2d8440a68f37d7b410a5fe74444a4470f27c28ba3b49f28dbce26">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

