### PR TITLE
Add rendering token to Grafana configuration

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -44,10 +44,6 @@ services:
       GF_INSTALL_PLUGINS: "marcusolsson-dynamictext-panel,orchestracities-map-panel"
       GF_SECURITY_ADMIN_USER: assume
       GF_SECURITY_ADMIN_PASSWORD: "assume"
-      GF_RENDERING_SERVER_URL: http://renderer:8081/render
-      GF_RENDERING_CALLBACK_URL: http://grafana:3000/
-      GF_RENDERING_RENDERER_TOKEN: "6a3a1fd9814761d491232961dc0450a867541e795d556725df517db3437e56a8"
-      GF_LOG_FILTERS: rendering:debug
       GF_USERS_DEFAULT_THEME: light
     volumes:
       - ./docker_configs/grafana.ini:/etc/grafana/grafana.ini
@@ -60,18 +56,6 @@ services:
       replicas: 1
       placement:
         constraints: [node.role == manager]
-
-  # to enable rendering png screenshots directly from grafana
-  # for example to embed them in an iframe, you can use this
-  renderer:
-    image: grafana/grafana-image-renderer:latest
-    container_name: renderer
-    profiles: ["renderer"]
-    environment:
-      RENDERER_TOKEN: "6a3a1fd9814761d491232961dc0450a867541e795d556725df517db3437e56a8"
-    ports:
-      - 8081
-
 
   # to run a single simulation in
   simulation:

--- a/compose.yml
+++ b/compose.yml
@@ -46,6 +46,7 @@ services:
       GF_SECURITY_ADMIN_PASSWORD: "assume"
       GF_RENDERING_SERVER_URL: http://renderer:8081/render
       GF_RENDERING_CALLBACK_URL: http://grafana:3000/
+      GF_RENDERING_RENDERER_TOKEN: "6a3a1fd9814761d491232961dc0450a867541e795d556725df517db3437e56a8"
       GF_LOG_FILTERS: rendering:debug
       GF_USERS_DEFAULT_THEME: light
     volumes:
@@ -66,6 +67,8 @@ services:
     image: grafana/grafana-image-renderer:latest
     container_name: renderer
     profiles: ["renderer"]
+    environment:
+      RENDERER_TOKEN: "6a3a1fd9814761d491232961dc0450a867541e795d556725df517db3437e56a8"
     ports:
       - 8081
 


### PR DESCRIPTION
### **User description**
Adding a rendering token for Grafana in the docker compose yaml file.

<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue

## Description
When trying to install assume with Grafana using docker engine (newest version v4.77.0), Grafana container continuously restarts and the log shows the following error. 

> 2026-06-10 10:30:19.063 | Error: ✗ failed to start rendering service: Using the default [rendering]renderer_token is not allowed for production settings, set it to another value. Read more at https://grafana.com/docs/grafana/latest/setup-grafana/image-rendering/#security 


## Checklist
- N/A Documentation updated (docstrings, READMEs, user guides, inline comments, `doc` folder updates etc.)
- N/A New unit/integration tests added (if applicable)
- N/A Changes noted in release notes (if any)
- N/A Consent to release this PR's code under the GNU Affero General Public License v3.0


___

### **PR Type**
Bug fix, Other


___

### **Description**
- Remove Grafana image-rendering configuration

- Drop optional `renderer` service from compose

- Prevent Grafana restarts due to rendering settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  g["Grafana service"] 
  r["Renderer service (removed)"]
  g -- "removed env URLs/log filter" --> g
  r -- "removed from compose" --> g
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>compose.yml</strong><dd><code>Remove Grafana rendering env and service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

compose.yml

<ul><li>Remove <code>GF_RENDERING_SERVER_URL</code> and callback URL<br> <li> Remove <code>GF_LOG_FILTERS</code> rendering debug filter<br> <li> Delete optional <code>renderer</code> service definition</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/820/files#diff-3493e6b5ddf34891e572f911db893efd9e46af828e011ea778a7c1eb64763588">+0/-13</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

