### PR TITLE
grafana: add button for setting time range to simulation horizon

### DIFF
--- a/docker_configs/dashboard-definitions/ASSUME Comparison.json
+++ b/docker_configs/dashboard-definitions/ASSUME Comparison.json
@@ -25,7 +25,20 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 1,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Set time filter to full simulation horizon",
+      "tooltip": "Clicking on the button will update the time range filter. The first and last timestamps of the selected simulation are used. Other filter items are preserved. The dashboard will reload: make sure to save your changes beforehand.",
+      "type": "link",
+      "url": "/d/vP8U8-q4k?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc"
+    }
+  ],
   "panels": [
     {
       "description": "",
@@ -2393,6 +2406,47 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 1,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation start, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_start",
+        "options": [],
+        "query": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation end, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_end",
+        "options": [],
+        "query": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
         "type": "query"
       }
     ]

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -29,14 +29,14 @@
     {
       "asDropdown": false,
       "icon": "dashboard",
-      "includeVars": false,
+      "includeVars": true,
       "keepTime": false,
       "tags": [],
       "targetBlank": false,
-      "title": "Set time filter to full simulation extent",
+      "title": "Set time filter to full simulation horizon",
       "tooltip": "Clicking on the button will update the time range filter. The first and last timestamps of the selected simulation are used. Other filter items are preserved. The dashboard will reload: make sure to save your changes beforehand.",
       "type": "link",
-      "url": "/d/aemnxld4ukgsga?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc&var-simulation=${simulation}&var-market=${market}&var-Gen_Units=${Gen_Units}&var-Demand_Units=${Demand_Units}&var-Storage_Units=${Storage_Units}"
+      "url": "/d/aemnxld4ukgsga?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc"
     }
   ],
   "panels": [

--- a/docker_configs/dashboard-definitions/ASSUME.json
+++ b/docker_configs/dashboard-definitions/ASSUME.json
@@ -25,7 +25,20 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 2,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Set time filter to full simulation extent",
+      "tooltip": "Clicking on the button will update the time range filter. The first and last timestamps of the selected simulation are used. Other filter items are preserved. The dashboard will reload: make sure to save your changes beforehand.",
+      "type": "link",
+      "url": "/d/aemnxld4ukgsga?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc&var-simulation=${simulation}&var-market=${market}&var-Gen_Units=${Gen_Units}&var-Demand_Units=${Demand_Units}&var-Storage_Units=${Storage_Units}"
+    }
+  ],
   "panels": [
     {
       "description": "",
@@ -5439,6 +5452,47 @@
         "regex": "",
         "skipUrlSync": false,
         "sort": 0,
+        "type": "query"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation start, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_start",
+        "options": [],
+        "query": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation end, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_end",
+        "options": [],
+        "query": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
         "type": "query"
       }
     ]

--- a/docker_configs/dashboard-definitions/ASSUME_Learning.json
+++ b/docker_configs/dashboard-definitions/ASSUME_Learning.json
@@ -2677,7 +2677,7 @@
         "refresh": 2,
         "regex": "",
         "type": "query"
-            },
+      },
       {
         "current": {
           "selected": false,

--- a/docker_configs/dashboard-definitions/ASSUME_Learning.json
+++ b/docker_configs/dashboard-definitions/ASSUME_Learning.json
@@ -26,7 +26,20 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 3,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Set time filter to full simulation horizon",
+      "tooltip": "Clicking on the button will update the time range filter. The first and last timestamps of the selected simulation are used. Other filter items are preserved. The dashboard will reload: make sure to save your changes beforehand.",
+      "type": "link",
+      "url": "/d/JKQzx0q4k?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc"
+    }
+  ],
   "panels": [
     {
       "description": "",
@@ -2662,6 +2675,47 @@
         "options": [],
         "query": "SELECT DISTINCT unit \nFROM rl_params\nWHERE simulation = '$simulation'\nAND episode = 1\nAND evaluation_mode = False;",
         "refresh": 2,
+        "regex": "",
+        "type": "query"
+            },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation start, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_start",
+        "options": [],
+        "query": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation end, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_end",
+        "options": [],
+        "query": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
         "regex": "",
         "type": "query"
       }

--- a/docker_configs/dashboard-definitions/ASSUME_nodal.json
+++ b/docker_configs/dashboard-definitions/ASSUME_nodal.json
@@ -1037,7 +1037,7 @@
         "regex": "",
         "sort": 1,
         "type": "query"
-            },
+      },
       {
         "current": {
           "selected": false,

--- a/docker_configs/dashboard-definitions/ASSUME_nodal.json
+++ b/docker_configs/dashboard-definitions/ASSUME_nodal.json
@@ -25,7 +25,20 @@
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
   "id": 4,
-  "links": [],
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "dashboard",
+      "includeVars": true,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": false,
+      "title": "Set time filter to full simulation horizon",
+      "tooltip": "Clicking on the button will update the time range filter. The first and last timestamps of the selected simulation are used. Other filter items are preserved. The dashboard will reload: make sure to save your changes beforehand.",
+      "type": "link",
+      "url": "/d/nodalview?orgId=1&from=${simulation_start}&to=${simulation_end}&timezone=utc"
+    }
+  ],
   "panels": [
     {
       "description": "",
@@ -1023,6 +1036,47 @@
         "refresh": 2,
         "regex": "",
         "sort": 1,
+        "type": "query"
+            },
+      {
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation start, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_start",
+        "options": [],
+        "query": "SELECT  min(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
+        "type": "query"
+      },
+      {
+        "current": {
+          "text": "",
+          "value": ""
+        },
+        "datasource": {
+          "type": "postgres",
+          "uid": "P7B13B9DF907EC40C"
+        },
+        "definition": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "description": "Epoch ms of the simulation end, used for the full range link",
+        "hide": 2,
+        "includeAll": false,
+        "name": "simulation_end",
+        "options": [],
+        "query": "SELECT  max(start_time) FROM market_orders WHERE simulation = '$simulation' ",
+        "refresh": 1,
+        "regex": "",
         "type": "query"
       }
     ]

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -26,6 +26,7 @@ Upcoming Release
   - **Add test for portfolio learning strategy and ``min_max_scale`` function**: Added a test for the portfolio learning strategy and ``min_max_rescale`` function to ensure its functionality and stability.
   - **Readme naming of examples/tutorials**: Slight changing of tutorial and example in the read me to make difference clearer and more consistent with the naming of the notebooks and to align with readthedocs.
   - **Align redispatch mechanism to latest PyPSA version release**: Updated the redispatch formulation to model cleared EOM generator dispatch for ``network.lpf()`` via ``generators_t.p_set`` and consistent generator bounds ``p_min_pu/p_max_pu``, replacing the previous load-based workaround.
+  - **Grafana dashboard improvements**: Added button to automatically update the time range filter to the full simulation horizon.
 
 **Bug Fixes:**
   - **Dependencies**: pin xarray and setuptools dependencies until upstream fixes are available


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
/ 

## Description
Until now, the time range filter could not automatically detect the horizon of the selected simulation. This leads to "no data" in most of the panels for the default simulation horizon, pointed out by @paragpatil39.

Because it should not reset the time range on every filter change (you might want to compare a shorter interval between simulations or units), it should be triggered manually. 

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
The button is implemented as a link, this means:
- clicking it reloads the dashboard
- dashboard changes need to be saved beforehand

<img width="1920" height="1032" alt="20260706-1320-40 7675392" src="https://github.com/user-attachments/assets/b308f74f-438c-4d8f-9812-7e6f15e07e62" />


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add full-horizon dashboard time links

- Preserve filters through Grafana variables

- Add hidden simulation boundary queries

- Document dashboard release note


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Selected simulation"] -- "queries" --> B["simulation_start and simulation_end"]
  B -- "populate" --> C["Dashboard link URL"]
  C -- "click" --> D["Full simulation horizon time range"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ASSUME Comparison.json</strong><dd><code>Add horizon link to comparison dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker_configs/dashboard-definitions/ASSUME Comparison.json

<ul><li>Adds a dashboard link for full simulation horizon.<br> <li> Preserves dashboard variables using <code>includeVars</code>.<br> <li> Adds hidden <code>simulation_start</code> and <code>simulation_end</code> query variables.<br> <li> Uses <code>market_orders</code> min/max <code>start_time</code> values.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/830/files#diff-50b9dbd9d4b3dd2adde16eaccdef0b7702e8a616935a322508a0141850e9a4be">+55/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ASSUME.json</strong><dd><code>Add horizon link to main dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker_configs/dashboard-definitions/ASSUME.json

<ul><li>Adds a full simulation horizon dashboard link.<br> <li> Builds link from <code>${simulation_start}</code> and <code>${simulation_end}</code>.<br> <li> Adds hidden query variables for simulation boundaries.<br> <li> Uses selected <code>simulation</code> to calculate time range.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/830/files#diff-00da6ebd4386ddd44ecc96a023447ced7581a0751e53cbef77e5ffdb3d178f19">+55/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ASSUME_Learning.json</strong><dd><code>Add horizon link to learning dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker_configs/dashboard-definitions/ASSUME_Learning.json

<ul><li>Adds full-horizon time range link to learning dashboard.<br> <li> Preserves other selected dashboard variables.<br> <li> Adds hidden start and end timestamp variables.<br> <li> Queries simulation bounds from <code>market_orders</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/830/files#diff-f5f055cf9bee7d7c95a9c28b2e66186690fd51f8572ecca2414e88c402f27d8a">+55/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ASSUME_nodal.json</strong><dd><code>Add horizon link to nodal dashboard</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker_configs/dashboard-definitions/ASSUME_nodal.json

<ul><li>Adds full simulation horizon link to nodal dashboard.<br> <li> Uses hidden variables for start and end timestamps.<br> <li> Preserves existing filters when applying time range.<br> <li> Points link to the <code>nodalview</code> dashboard route.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/830/files#diff-996f90b6f652fdebac7eadf6ca0ff58ad5be9d1499de949ea09a1224e037ffd8">+55/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>release_notes.rst</strong><dd><code>Document Grafana dashboard horizon button</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/source/release_notes.rst

<ul><li>Adds an upcoming release note entry.<br> <li> Documents Grafana dashboard time-range button improvement.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/830/files#diff-eb36f1b6f2ee2691f609c07d32a8d977e4052a9e47d0ec94a241c6fc001a5d5c">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

