### PR TITLE
ci: run pre-commit once and do not run on docs change

### DIFF
--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -14,7 +14,26 @@ on:
     branches: [ "main" ]
 
 jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - name: Set up Python
+      uses: actions/setup-python@v6.3.0
+      with:
+        python-version: "3.14"
+    - name: Cache pre-commit environments
+      uses: actions/cache@v6.1.0
+      with:
+        path: ~/.cache/pre-commit
+        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v3.0.1
+      with:
+        extra_args: --all-files --show-diff-on-failure
+
   jupyter:
+    needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -22,9 +41,9 @@ jobs:
         python-version: ["3.10", "3.12", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
@@ -38,8 +57,9 @@ jobs:
         jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output output.ipynb 02_automated_run_example.ipynb
         jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output output.ipynb 03_custom_unit_example.ipynb
         jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output output.ipynb 10_DSU_and_flexibility.ipynb
-  test:
 
+  test:
+    needs: pre-commit
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -47,31 +67,20 @@ jobs:
         python-version: ["3.10", "3.12", "3.14"]
 
     steps:
-    - uses: actions/checkout@v6.0.2
+    - uses: actions/checkout@v7.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v6.2.0
+      uses: actions/setup-python@v6.3.0
       with:
         python-version: ${{ matrix.python-version }}
         cache: 'pip'
         cache-dependency-path: '**/pyproject.toml'
-
-    - name: Cache pre-commit environments
-      uses: actions/cache@v5.0.4
-      with:
-        path: ~/.cache/pre-commit
-        key: ${{ runner.os }}-pre-commit-${{ hashFiles('.pre-commit-config.yaml') }}
 
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         python -m pip install -e .[test]
-
-    - name: Run pre-commit hooks
-      uses: pre-commit/action@v3.0.1
-      with:
-        extra_args: --all-files --show-diff-on-failure
 
     - name: Test with pytest & integration tests
       run: |
@@ -94,7 +103,7 @@ jobs:
         pytest --cov --cov-report=xml --junitxml="result.xml"
 
     - name: Upload tests results
-      uses: actions/upload-artifact@v7.0.0
+      uses: actions/upload-artifact@v7.0.1
       if: always()
       with:
         name: test-results-${{ matrix.python-version }}
@@ -103,7 +112,7 @@ jobs:
           result.xml
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
+      uses: codecov/codecov-action@v7.0.0
       env:
         CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       with:

--- a/.github/workflows/lint-pytest.yaml
+++ b/.github/workflows/lint-pytest.yaml
@@ -14,7 +14,30 @@ on:
     branches: [ "main" ]
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+    - uses: actions/checkout@v7.0.0
+    - uses: dorny/paths-filter@v4.0.2
+      id: filter
+      with:
+        filters: |
+          code:
+            - '**'
+            - '!docs/**'
+            - '!**/*.md'
+            - '!.gitignore'
+            - '!.dockerignore'
+            - '!.readthedocs.yaml'
+            - '!LICENSE.txt'
+            - '!LICENSES/**'
+            - '!REUSE.toml'
+
   pre-commit:
+    needs: changes
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v7.0.0
@@ -33,7 +56,8 @@ jobs:
         extra_args: --all-files --show-diff-on-failure
 
   jupyter:
-    needs: pre-commit
+    needs: [changes, pre-commit]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -59,7 +83,8 @@ jobs:
         jupyter nbconvert --to notebook --execute --ExecutePreprocessor.timeout=60 --output output.ipynb 10_DSU_and_flexibility.ipynb
 
   test:
-    needs: pre-commit
+    needs: [changes, pre-commit]
+    if: ${{ needs.changes.outputs.code == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
### **User description**
## Description
This reduces failing pipelines by not creating them if the pre-commit did not succeed.
Also disables the pytest if a change does only touch the docs/md and nothing else.

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0


___

### **PR Type**
Enhancement


___

### **Description**
- Skip CI for non-code changes

- Run pre-commit as prerequisite job

- Gate tests on successful linting

- Update GitHub Actions versions


___

### Diagram Walkthrough


```mermaid
flowchart LR
  changes["Detect changed paths"]
  precommit["Run pre-commit once"]
  tests["Run pytest matrix"]
  notebooks["Execute notebook matrix"]
  changes -- "code changed" --> precommit
  precommit -- "success required" --> tests
  precommit -- "success required" --> notebooks
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lint-pytest.yaml</strong><dd><code>Add CI path filtering and lint gating</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/lint-pytest.yaml

<ul><li>Adds a <code>changes</code> job using <code>dorny/paths-filter</code>.<br> <li> Skips downstream jobs for docs-only and metadata changes.<br> <li> Moves pre-commit into a dedicated prerequisite job.<br> <li> Updates checkout, setup-python, cache, artifact, and Codecov actions.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/835/files#diff-569eb23e1cd2feec716f8166b91e4758857f821052cfb83076f0d090f5848ac6">+52/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

