### PR TITLE
fix: do not remove empty bids for storage strategies, until #562 is f…

### DIFF
--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -175,7 +175,8 @@ class StorageEnergyHeuristicFlexableStrategy(MinMaxChargeStrategy):
             theoretic_SOC += delta_soc
             previous_power = bid_quantity + current_power
 
-        bids = self.remove_empty_bids(bids)
+        # issue #562 needs to be fixed first to enable this again
+        # bids = self.remove_empty_bids(bids)
 
         return bids
 
@@ -353,7 +354,8 @@ class StorageCapacityHeuristicBalancingPosStrategy(MinMaxChargeStrategy):
                     f"Product {market_config.product_type} is not supported by this strategy."
                 )
 
-        bids = self.remove_empty_bids(bids)
+        # issue #562 needs to be fixed first to enable this again
+        # bids = self.remove_empty_bids(bids)
 
         return bids
 
@@ -460,7 +462,8 @@ class StorageCapacityHeuristicBalancingNegStrategy(MinMaxChargeStrategy):
                     f"Product {market_config.product_type} is not supported by this strategy."
                 )
 
-        bids = self.remove_empty_bids(bids)
+        # issue #562 needs to be fixed first to enable this again
+        # bids = self.remove_empty_bids(bids)
 
         return bids
 


### PR DESCRIPTION
### **User description**
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #837 

## Description
Empty bids were not removed in #557 although initially intended. This led to inconsistent SoC values after periods without market participation. In this PR, we fix the SoC issues and no longer remove empty bids for flexable storage strategies. 

Performance-wise we want to revert to removing empty bids, but not until a fix for #562 is proposed.  
--> We can also discuss to fix it here already? See proposition [here](https://github.com/assume-framework/assume/tree/correct_soc_with_empty_bid_removal).

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
<!-- Anything the reviewer should pay special attention to, known limitations, rollout plan, etc. -->


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve storage empty bids

- Avoid SOC gaps during idle periods

- Defer bid filtering until issue fixed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Storage bid calculation"] 
  B["Keep empty bids"]
  C["Dispatch covers idle intervals"]
  D["SOC carries forward"]
  A -- "does not filter" --> B
  B -- "retains time coverage" --> C
  C -- "prevents reset" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>flexable_storage.py</strong><dd><code>Preserve empty storage bids for SOC continuity</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

assume/strategies/flexable_storage.py

<ul><li>Disables <code>remove_empty_bids(bids)</code> in storage strategies.<br> <li> Adds comments referencing issue <code>#562</code>.<br> <li> Keeps empty bids to preserve SOC time coverage.</ul>


</details>


  </td>
  <td><a href="https://github.com/assume-framework/assume/pull/840/files#diff-c04d33a51cdba7617f5f02c63674746e63cdcd5bb68fd120993451b4985305bb">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

