### PR TITLE
scenario: replace GPL-licensed pyyaml-include with in-house !include support

### DIFF
--- a/assume/scenario/loader_amiris.py
+++ b/assume/scenario/loader_amiris.py
@@ -10,7 +10,6 @@ import dateutil.rrule as rr
 import pandas as pd
 import yaml
 from dateutil.relativedelta import relativedelta as rd
-from yaml_include import Constructor
 
 from assume.common.forecaster import (
     DemandForecaster,
@@ -18,6 +17,7 @@ from assume.common.forecaster import (
     UnitForecaster,
 )
 from assume.common.market_objects import MarketConfig, MarketProduct
+from assume.scenario.yaml_include import Constructor
 from assume.strategies.extended import SupportStrategy
 from assume.world import World
 

--- a/assume/scenario/yaml_include.py
+++ b/assume/scenario/yaml_include.py
@@ -72,7 +72,7 @@ class Constructor:
 
         base = Path(self.base_dir)
         loader_type = type(loader)
-        
+
         if any(char in urlpath for char in WILDCARD_CHARS):
             matches = sorted(base.glob(urlpath))
             return [self._load(match, loader_type) for match in matches]

--- a/assume/scenario/yaml_include.py
+++ b/assume/scenario/yaml_include.py
@@ -71,13 +71,13 @@ class Constructor:
         else:
             raise TypeError(f"!include does not support {type(node).__name__} nodes")
 
-        path = Path(self.base_dir) / urlpath
+        base = Path(self.base_dir)
         loader_type = type(loader)
-
+        
         if any(char in urlpath for char in WILDCARD_CHARS):
-            matches = sorted(glob.glob(str(path), recursive=True))
+            matches = sorted(base.glob(urlpath))
             return [self._load(match, loader_type) for match in matches]
-        return self._load(path, loader_type)
+        return self._load(base / urlpath, loader_type)
 
     @staticmethod
     def _load(path: Path | str, loader_type: type) -> Any:

--- a/assume/scenario/yaml_include.py
+++ b/assume/scenario/yaml_include.py
@@ -36,8 +36,8 @@ they appear in.
 from __future__ import annotations
 
 import glob
-import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any
 
 import yaml
@@ -71,15 +71,15 @@ class Constructor:
         else:
             raise TypeError(f"!include does not support {type(node).__name__} nodes")
 
-        path = os.path.join(self.base_dir, urlpath)
+        path = Path(self.base_dir) / urlpath
         loader_type = type(loader)
 
         if any(char in urlpath for char in WILDCARD_CHARS):
-            matches = sorted(glob.glob(path, recursive=True))
+            matches = sorted(glob.glob(str(path), recursive=True))
             return [self._load(match, loader_type) for match in matches]
         return self._load(path, loader_type)
 
     @staticmethod
-    def _load(path: str, loader_type: type) -> Any:
+    def _load(path: Path | str, loader_type: type) -> Any:
         with open(path, "rb") as f:
             return yaml.load(f, loader_type)

--- a/assume/scenario/yaml_include.py
+++ b/assume/scenario/yaml_include.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Minimal reimplementation of the YAML ``!include`` tag used to load AMIRIS
+scenario files.
+
+AMIRIS scenarios (see https://gitlab.com/dlr-ve/esy/amiris/examples) spread
+their configuration across several YAML files and stitch them back together
+with a custom ``!include`` tag, e.g.::
+
+    Schema: !include "schema.yaml"
+    Contracts: !include ["contracts/*.yaml", "Contracts"]
+
+This used to be handled by the GPL-licensed ``pyyaml-include`` package,
+which is incompatible with ASSUME's permissive distribution goals. This
+module reimplements the (small) subset of that package's behaviour which
+AMIRIS scenario files actually rely on:
+
+* ``!include "relative/path.yaml"`` loads and parses a single file.
+* Any ``!include`` urlpath containing a glob wildcard (``*``, ``?`` or
+  ``[``) - whether written as a plain scalar or wrapped in a YAML sequence
+  such as ``!include ["contracts/*.yaml", "Contracts"]`` - loads every file
+  matching the pattern and returns their parsed contents as a list, sorted
+  by path. Extra sequence entries beyond the urlpath (e.g. the ``"Contracts"``
+  label above) are accepted for compatibility but carry no meaning here and
+  are ignored. Matches are *not* flattened into a single list, even if every
+  match is itself a YAML sequence.
+
+All ``!include`` paths - including ones nested inside included files - are
+resolved relative to the same fixed ``base_dir``, not relative to the file
+they appear in.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+
+#: Characters that mark a urlpath as a glob pattern rather than a plain path.
+WILDCARD_CHARS = ("*", "?", "[")
+
+
+@dataclass
+class Constructor:
+    """PyYAML constructor implementing AMIRIS's ``!include`` tag.
+
+    Register it with :func:`yaml.add_constructor` and use it to load a YAML
+    file that contains ``!include`` tags::
+
+        yaml.add_constructor("!include", Constructor(base_dir=base_path))
+        with open(base_path + "/scenario.yaml", "rb") as f:
+            scenario = yaml.load(f, Loader=yaml.FullLoader)
+    """
+
+    base_dir: str
+
+    def __call__(self, loader: yaml.Loader, node: yaml.Node) -> Any:
+        if isinstance(node, yaml.ScalarNode):
+            urlpath = loader.construct_scalar(node)
+        elif isinstance(node, yaml.SequenceNode):
+            # Additional entries are accepted for compatibility with AMIRIS
+            # scenario files (e.g. `!include ["contracts/*.yaml", "Contracts"]`)
+            # but carry no meaning here and are ignored.
+            urlpath = loader.construct_sequence(node)[0]
+        else:
+            raise TypeError(f"!include does not support {type(node).__name__} nodes")
+
+        path = os.path.join(self.base_dir, urlpath)
+        loader_type = type(loader)
+
+        if any(char in urlpath for char in WILDCARD_CHARS):
+            matches = sorted(glob.glob(path, recursive=True))
+            return [self._load(match, loader_type) for match in matches]
+        return self._load(path, loader_type)
+
+    @staticmethod
+    def _load(path: str, loader_type: type) -> Any:
+        with open(path, "rb") as f:
+            return yaml.load(f, loader_type)

--- a/assume/scenario/yaml_include.py
+++ b/assume/scenario/yaml_include.py
@@ -35,7 +35,6 @@ they appear in.
 
 from __future__ import annotations
 
-import glob
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -27,6 +27,7 @@ Upcoming Release
   - **Readme naming of examples/tutorials**: Slight changing of tutorial and example in the read me to make difference clearer and more consistent with the naming of the notebooks and to align with readthedocs.
   - **Align redispatch mechanism to latest PyPSA version release**: Updated the redispatch formulation to model cleared EOM generator dispatch for ``network.lpf()`` via ``generators_t.p_set`` and consistent generator bounds ``p_min_pu/p_max_pu``, replacing the previous load-based workaround.
   - **Grafana dashboard improvements**: Added button to automatically update the time range filter to the full simulation horizon.
+  - **Replace GPL-licensed ``pyyaml-include`` dependency**: AMIRIS scenario loading no longer depends on the GPLv3-licensed ``pyyaml-include`` package, which was incompatible with distributing ASSUME under a permissive license. The subset of ``!include`` YAML-tag behavior AMIRIS scenario files rely on is now implemented in-house in ``assume.scenario.yaml_include``.
 
 **Bug Fixes:**
   - **Dependencies**: pin xarray and setuptools dependencies until upstream fixes are available

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "pandas >=2.3.0",
     "psycopg2-binary >=2.9.5",
     "pyyaml >=6.0",
-    "pyyaml-include >=2.2a",
     "pyomo >=6.8.0",
     "xarray <v2026.04.0", # https://github.com/assume-framework/assume/issues/790
     "highspy",

--- a/tests/fixtures/amiris_scenario/contracts/contracts_a.yaml
+++ b/tests/fixtures/amiris_scenario/contracts/contracts_a.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+Contracts:
+  - SenderId: 100
+    ReceiverId: 200
+    ProductName: EnergyExchange

--- a/tests/fixtures/amiris_scenario/contracts/contracts_b.yaml
+++ b/tests/fixtures/amiris_scenario/contracts/contracts_b.yaml
@@ -1,0 +1,8 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+Contracts:
+  - SenderId: 300
+    ReceiverId: [100, 400]
+    ProductName: Bids

--- a/tests/fixtures/amiris_scenario/meta/version.yaml
+++ b/tests/fixtures/amiris_scenario/meta/version.yaml
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+SchemaVersion: "0.1-test"

--- a/tests/fixtures/amiris_scenario/scenario.yaml
+++ b/tests/fixtures/amiris_scenario/scenario.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+Schema: !include "schema.yaml"
+
+GeneralProperties:
+  RunId: 1
+  Simulation:
+    StartTime: 2019-01-01_00:00:00
+    StopTime: 2019-01-02_00:00:00
+    RandomSeed: 1
+
+Agents:
+  - Type: DemandTrader
+    Id: 900
+    Attributes:
+      Loads:
+        - ValueOfLostLoad: 1234.5
+          DemandSeries: "demand.csv"
+
+Contracts: !include ["contracts/*.yaml", "Contracts"]

--- a/tests/fixtures/amiris_scenario/schema.yaml
+++ b/tests/fixtures/amiris_scenario/schema.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# nested !include: resolved relative to the original base_dir, not to
+# this file's own directory
+Version: !include "meta/version.yaml"

--- a/tests/test_loader_amiris.py
+++ b/tests/test_loader_amiris.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+from assume.scenario.loader_amiris import (
+    get_send_receive_msgs_per_id,
+    read_amiris_yaml,
+)
+
+FIXTURE_PATH = "tests/fixtures/amiris_scenario"
+
+
+def test_read_amiris_yaml_resolves_includes():
+    scenario = read_amiris_yaml(FIXTURE_PATH)
+
+    # scalar !include of a single file, including a nested !include inside it
+    assert scenario["Schema"] == {"Version": {"SchemaVersion": "0.1-test"}}
+
+    # plain (non-included) content is untouched
+    assert scenario["GeneralProperties"]["RunId"] == 1
+    assert scenario["Agents"][0]["Type"] == "DemandTrader"
+
+    # sequence-form !include with a glob pattern: an unflattened list of the
+    # parsed content of each matched file, in path order
+    assert scenario["Contracts"] == [
+        {
+            "Contracts": [
+                {"SenderId": 100, "ReceiverId": 200, "ProductName": "EnergyExchange"}
+            ]
+        },
+        {
+            "Contracts": [
+                {"SenderId": 300, "ReceiverId": [100, 400], "ProductName": "Bids"}
+            ]
+        },
+    ]
+
+
+def test_amiris_contracts_are_usable_by_downstream_code():
+    # get_send_receive_msgs_per_id relies on amiris_scenario["Contracts"]
+    # being that unflattened, per-file list - this is the actual consumer
+    # of the !include output inside assume.
+    scenario = read_amiris_yaml(FIXTURE_PATH)
+
+    sends, receives = get_send_receive_msgs_per_id(100, scenario["Contracts"])
+
+    # agent 100 is SenderId in contracts_a.yaml (EnergyExchange)
+    # and (via a list) ReceiverId in contracts_b.yaml (Bids)
+    assert [c["ProductName"] for c in sends] == ["EnergyExchange"]
+    assert [c["ProductName"] for c in receives] == ["Bids"]

--- a/tests/test_yaml_include.py
+++ b/tests/test_yaml_include.py
@@ -1,0 +1,112 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Regression tests for :mod:`assume.scenario.yaml_include`, the in-house
+replacement for the GPL-licensed ``pyyaml-include`` package.
+
+These pin down the exact behaviour AMIRIS scenario files rely on, reverse
+engineered from ``pyyaml-include`` 2.2 and from real scenario files at
+https://gitlab.com/dlr-ve/esy/amiris/examples (e.g. ``Contracts: !include
+["contracts/*.yaml", "Contracts"]``), so that swapping the implementation
+does not change what :func:`assume.scenario.loader_amiris.read_amiris_yaml`
+returns.
+"""
+
+import pytest
+import yaml
+
+from assume.scenario.yaml_include import Constructor
+
+FIXTURE_PATH = "tests/fixtures/amiris_scenario"
+
+
+def _loader_with_base_dir(base_dir: str) -> type:
+    loader_cls = yaml.FullLoader
+    yaml.add_constructor("!include", Constructor(base_dir=base_dir), loader_cls)
+    return loader_cls
+
+
+def test_scalar_include_loads_and_parses_single_file():
+    data = yaml.load(
+        'key: !include "schema.yaml"', Loader=_loader_with_base_dir(FIXTURE_PATH)
+    )
+
+    assert data == {"key": {"Version": {"SchemaVersion": "0.1-test"}}}
+
+
+def test_nested_includes_resolve_relative_to_the_original_base_dir():
+    # schema.yaml itself contains `Version: !include "meta/version.yaml"`.
+    # That path only exists relative to FIXTURE_PATH, not relative to
+    # schema.yaml's own directory, so this only works if nested includes
+    # keep resolving against the original base_dir.
+    data = yaml.load(
+        'key: !include "schema.yaml"', Loader=_loader_with_base_dir(FIXTURE_PATH)
+    )
+
+    assert data["key"]["Version"] == {"SchemaVersion": "0.1-test"}
+
+
+def test_sequence_include_expands_glob_into_a_list_of_parsed_files():
+    data = yaml.load(
+        'key: !include ["contracts/*.yaml", "AnyLabel"]',
+        Loader=_loader_with_base_dir(FIXTURE_PATH),
+    )
+
+    # unflattened: one list entry per matched file, sorted by path, each
+    # still wrapped in that file's own top-level "Contracts" key
+    assert data["key"] == [
+        {
+            "Contracts": [
+                {"SenderId": 100, "ReceiverId": 200, "ProductName": "EnergyExchange"}
+            ]
+        },
+        {
+            "Contracts": [
+                {"SenderId": 300, "ReceiverId": [100, 400], "ProductName": "Bids"}
+            ]
+        },
+    ]
+
+
+def test_scalar_include_also_expands_glob_without_a_sequence_wrapper():
+    # pyyaml-include treats any urlpath containing wildcard characters as a
+    # glob, regardless of whether it was written as a plain scalar or
+    # wrapped in a YAML sequence.
+    data = yaml.load(
+        'key: !include "contracts/*.yaml"', Loader=_loader_with_base_dir(FIXTURE_PATH)
+    )
+
+    assert len(data["key"]) == 2
+    assert all("Contracts" in entry for entry in data["key"])
+
+
+def test_extra_sequence_entries_are_ignored():
+    with_label = yaml.load(
+        'key: !include ["contracts/*.yaml", "Contracts"]',
+        Loader=_loader_with_base_dir(FIXTURE_PATH),
+    )
+    without_label = yaml.load(
+        'key: !include "contracts/*.yaml"',
+        Loader=_loader_with_base_dir(FIXTURE_PATH),
+    )
+
+    assert with_label == without_label
+
+
+def test_missing_file_raises_file_not_found():
+    with pytest.raises(FileNotFoundError):
+        yaml.load(
+            'key: !include "does-not-exist.yaml"',
+            Loader=_loader_with_base_dir(FIXTURE_PATH),
+        )
+
+
+def test_glob_with_no_matches_returns_empty_list():
+    data = yaml.load(
+        'key: !include "no-such-dir/*.yaml"',
+        Loader=_loader_with_base_dir(FIXTURE_PATH),
+    )
+
+    assert data["key"] == []

--- a/tests/test_yaml_include.py
+++ b/tests/test_yaml_include.py
@@ -110,3 +110,14 @@ def test_glob_with_no_matches_returns_empty_list():
     )
 
     assert data["key"] == []
+
+
+def test_mapping_node_is_not_supported():
+    # only scalar (`!include "path"`) and sequence (`!include ["path", ...]`)
+    # forms are needed by AMIRIS scenario files; a mapping form such as
+    # `!include {urlpath: ...}` should fail loudly rather than silently.
+    with pytest.raises(TypeError, match="MappingNode"):
+        yaml.load(
+            'key: !include {urlpath: "schema.yaml"}',
+            Loader=_loader_with_base_dir(FIXTURE_PATH),
+        )


### PR DESCRIPTION
## Description

`assume/scenario/loader_amiris.py` depended on `pyyaml-include` to resolve the
`!include` tags used by AMIRIS scenario YAML files. That package is licensed
under GPLv3+, which is incompatible with distributing ASSUME under a
permissive license.

This PR removes the dependency and replaces it with a small, from-scratch
implementation (`assume/scenario/yaml_include.py`) covering exactly the
subset of behavior AMIRIS scenario files actually rely on:

- `!include "path.yaml"` — load and parse a single file
- `!include ["glob/*.yaml", "Label"]` — glob-expand and return an unflattened
  list of each matched file's parsed content (the label is accepted for
  compatibility but has no effect, matching the original library's behavior)
- nested `!include`s always resolve relative to the original `base_dir`, not
  the including file's own directory

The exact semantics were reverse-engineered from `pyyaml-include` 2.2's
source and cross-checked against real AMIRIS scenario files
(gitlab.com/dlr-ve/esy/amiris/examples) before implementation, so this is a
behavioral drop-in replacement, not a reinterpretation of the format.

`pyyaml-include >=2.2a` has been removed from `pyproject.toml`.

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [x] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0 (and MIT license)

## Additional Notes

Added `tests/test_yaml_include.py` (unit tests directly against the new
constructor) and `tests/test_loader_amiris.py` (integration test against a
small AMIRIS-shaped fixture at `tests/fixtures/amiris_scenario/`, including a
check that `get_send_receive_msgs_per_id` still consumes the parsed output
correctly). Full existing test suite (363 tests) still passes.

This only removes the GPL *dependency*.
