### PR TITLE
Cement plant and associated technologies

### DIFF
--- a/assume/common/forecaster.py
+++ b/assume/common/forecaster.py
@@ -781,6 +781,132 @@ class SteelplantForecaster(DsmUnitForecaster):
         initializing_unit.setup_model()
 
 
+class CementForecaster(DsmUnitForecaster):
+    """Forecaster for cement plant units.
+
+    Provides all DSM forecasts (see :class:`DsmUnitForecaster`) plus fuel prices, clinker
+    demand and the optional profiles that shape clinker production. After initialization,
+    DSM signals are copied to the unit and ``setup_model()`` is called.
+
+    Supports the same three operational strategies as :class:`SteelplantForecaster`:
+    1. **Profile-guided**: If ``normalized_load_profile`` is provided, production follows the profile shape.
+    2. **Min-demand**: If hourly minimum demand (``clinker_demand``) is provided, meets per-hour minimums.
+    3. **Cost-optimized**: If neither is provided, minimizes cost without shape constraints.
+
+    Attributes:
+        fuel_prices (dict[str, ForecastSeries]): Map of fuel type to forecasted fuel prices
+            (``natural_gas``, ``coal``, ``hydrogen``, ``co2``).
+        clinker_demand (ForecastSeries): Per-timestep clinker production demand in tonnes (optional).
+        normalized_load_profile (ForecastSeries): Normalized profile to guide production shape (optional).
+        thermal_storage_schedule (ForecastSeries): Binary charge/discharge schedule of a
+            long-term thermal storage (optional).
+        electricity_price_flex (ForecastSeries): Alternative price signal used by the
+            ``electricity_price_signal`` flexibility measure. Falls back to ``electricity_price``.
+        availability_profiles (dict[str, ForecastSeries]): Per-component availability
+            profiles (1 available, 0 unavailable), keyed by technology name.
+    """
+
+    def __init__(
+        self,
+        index: ForecastIndex,
+        fuel_prices: dict[str, ForecastSeries],
+        market_prices: dict[str, ForecastSeries] = None,
+        residual_load: dict[str, ForecastSeries] = None,
+        availability: ForecastSeries = 1,
+        forecast_algorithms: dict[str, str] = {},
+        forecast_registries: dict[str, dict] = None,
+        congestion_signal: ForecastSeries = 0.0,
+        renewable_utilisation_signal: ForecastSeries = 0.0,
+        electricity_price: ForecastSeries = None,
+        electricity_price_flex: ForecastSeries = None,
+        clinker_demand: ForecastSeries = None,
+        normalized_load_profile: ForecastSeries = None,
+        thermal_storage_schedule: ForecastSeries = 0,
+        availability_profiles: dict[str, ForecastSeries] = None,
+    ):
+        super().__init__(
+            index=index,
+            availability=availability,
+            forecast_algorithms=forecast_algorithms,
+            forecast_registries=forecast_registries,
+            market_prices=market_prices,
+            residual_load=residual_load,
+            congestion_signal=congestion_signal,
+            renewable_utilisation_signal=renewable_utilisation_signal,
+            electricity_price=electricity_price,
+        )
+        self.fuel_prices = self._dict_to_series(fuel_prices)
+        self.clinker_demand = (
+            self._to_series(clinker_demand) if clinker_demand is not None else None
+        )
+        self.normalized_load_profile = (
+            self._to_series(normalized_load_profile)
+            if normalized_load_profile is not None
+            else None
+        )
+        self.thermal_storage_schedule = self._to_series(thermal_storage_schedule)
+        self._electricity_price_flex = (
+            self._to_series(electricity_price_flex)
+            if electricity_price_flex is not None
+            else None
+        )
+        self.availability_profiles = {
+            tech: self._to_series(profile)
+            for tech, profile in (availability_profiles or {}).items()
+            if profile is not None
+        }
+
+    @property
+    def electricity_price_flex(self) -> FastSeries:
+        """Price signal for the ``electricity_price_signal`` measure.
+
+        Falls back to the current ``electricity_price`` when no dedicated flex price
+        was provided, so the fallback also tracks the price initialized later on.
+        """
+        if self._electricity_price_flex is None:
+            return self.electricity_price
+        return self._electricity_price_flex
+
+    @electricity_price_flex.setter
+    def electricity_price_flex(self, value: ForecastSeries) -> None:
+        self._electricity_price_flex = (
+            self._to_series(value) if value is not None else None
+        )
+
+    def get_price(self, fuel: str) -> FastSeries:
+        if fuel not in self.fuel_prices:
+            return self._to_series(0)
+        return self.fuel_prices[fuel]
+
+    def initialize(
+        self,
+        units: list[BaseUnit],
+        market_configs: list[MarketConfig],
+        forecast_df: ForecastSeries = None,
+        initializing_unit: BaseUnit = None,
+    ):
+        super().initialize(
+            units,
+            market_configs,
+            forecast_df,
+            initializing_unit,
+        )
+
+        # Always set standard DSM signals
+        initializing_unit.congestion_signal = self.congestion_signal
+        initializing_unit.renewable_utilisation_signal = (
+            self.renewable_utilisation_signal
+        )
+
+        if self.clinker_demand is not None:
+            initializing_unit.clinker_demand_per_timestep = self.clinker_demand
+
+        if self.normalized_load_profile is not None:
+            initializing_unit.normalized_load_profile = self.normalized_load_profile
+
+        initializing_unit.setup_model()
+
+
 class SteamgenerationForecaster(DsmUnitForecaster):
     """Forecaster for steam generation units.
 

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -20,6 +20,7 @@ from assume.common.exceptions import AssumeException
 from assume.common.fast_pandas import FastIndex
 from assume.common.forecaster import (
     BuildingForecaster,
+    CementForecaster,
     CustomUnitForecaster,
     DemandForecaster,
     DsmUnitForecaster,
@@ -813,6 +814,42 @@ def load_config_and_create_forecaster(
                         fuel_prices=fuel_prices_df,
                         normalized_load_profile=normalized_profile,
                         steel_demand=steel_demand,
+                    )
+                if type == "cement_plant":
+                    storage_schedule = get_unit_forecast_column(
+                        forecasts_df, id, "thermal_storage_schedule"
+                    )
+                    unit_forecasts[id] = CementForecaster(
+                        index=shared_unit_index,
+                        availability=availability.get(
+                            id, pd.Series(1.0, index, name=id)
+                        ),
+                        market_prices=unit.get("market_prices"),
+                        forecast_algorithms=unit_forecast_algorithms,
+                        forecast_registries=None,
+                        fuel_prices=fuel_prices_df,
+                        normalized_load_profile=get_unit_forecast_column(
+                            forecasts_df, id, "normalized_load_profile"
+                        ),
+                        clinker_demand=get_unit_forecast_column(
+                            forecasts_df, id, "clinker_demand"
+                        ),
+                        electricity_price_flex=get_unit_forecast_column(
+                            forecasts_df, id, "electricity_price_flex"
+                        ),
+                        thermal_storage_schedule=(
+                            storage_schedule if storage_schedule is not None else 0
+                        ),
+                        availability_profiles={
+                            tech: get_unit_forecast_column(
+                                forecasts_df, id, f"{tech}_availability"
+                            )
+                            for tech in (
+                                "preheater",
+                                "calciner",
+                                "kiln",
+                            )
+                        },
                     )
                 if type == "hydrogen_plant":
                     unit_forecasts[id] = HydrogenForecaster(

--- a/assume/units/__init__.py
+++ b/assume/units/__init__.py
@@ -8,6 +8,7 @@ from assume.units.exchange import Exchange
 from assume.units.powerplant import PowerPlant
 from assume.units.storage import Storage
 from assume.units.steel_plant import SteelPlant
+from assume.units.cement_plant import CementPlant
 from assume.units.steam_generation_plant import SteamPlant
 from assume.units.hydrogen_plant import HydrogenPlant
 from assume.units.building import Building
@@ -19,6 +20,7 @@ unit_types: dict[str, type[BaseUnit]] = {
     "exchange": Exchange,
     "storage": Storage,
     "steel_plant": SteelPlant,
+    "cement_plant": CementPlant,
     "hydrogen_plant": HydrogenPlant,
     "steam_plant": SteamPlant,
     "building": Building,

--- a/assume/units/cement_plant.py
+++ b/assume/units/cement_plant.py
@@ -1,0 +1,670 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+import logging
+
+import pyomo.environ as pyo
+
+from assume.common.base import SupportsMinMax
+from assume.common.forecaster import CementForecaster
+from assume.units.dsm_load_shift import DSMFlex
+
+logger = logging.getLogger(__name__)
+
+# Set the log level to ERROR
+logging.getLogger("pyomo").setLevel(logging.WARNING)
+
+# Components whose availability may be shaped by a forecast profile
+AVAILABILITY_COMPONENTS = ("preheater", "calciner", "kiln")
+
+
+class CementPlant(DSMFlex, SupportsMinMax):
+    """
+    The CementPlant class represents a cement plant unit within an energy system.
+
+    The plant is modelled as the kiln line of a cement works: a **preheater** heats the
+    raw meal, a **calciner** drives the calcination reaction that releases the process
+    CO2, and a **kiln** finishes the clinker at high temperature. Each stage is
+    fuel-switchable between electricity, a natural gas / coal mix and hydrogen, so the
+    same plant description covers a conventional and an electrified configuration.
+
+    Optional components extend the line:
+
+    - an **electrolyser** producing hydrogen on site for the calciner and kiln burners,
+    - a **thermal storage** which, in its electric-heater mode, buys power when it is
+      cheap and later displaces calciner burner heat (an E-TES),
+    - a **raw material mill** and a **cement mill** - electric grinding steps that
+      convert raw materials to raw meal and clinker to cement respectively.
+
+    Waste heat from the kiln is recovered into the preheater, which reduces the fuel the
+    preheater needs for a given raw meal throughput.
+
+    The two mills are not connected into the kiln line automatically. A cement mill
+    alongside a kiln line still grinds that line's clinker output (as it always has),
+    but a plant made of only a raw material mill and/or only a cement mill - with no
+    preheater/calciner/kiln at all - runs as a **standalone grinding operation**: the
+    declared demand then targets that mill's own ground tonnage directly (cement for a
+    lone cement mill, raw meal for a lone raw material mill) instead of clinker.
+
+    Both full-horizon and rolling-horizon optimisation are supported. In rolling-horizon
+    mode the plant re-optimises a look-ahead window at each market round, carrying
+    thermal storage fill levels and on/off states from the previously committed period
+    and tracking the clinker (or, for a standalone mill, the ground tonnage) still to be
+    produced.
+
+    Args:
+        id (str): A unique identifier for the cement plant unit.
+        unit_operator (str): The operator responsible for the cement plant.
+        bidding_strategies (dict): A dictionary of bidding strategies, which define how the unit participates in energy markets.
+        forecaster (CementForecaster): A forecaster used to get key variables such as fuel or electricity prices.
+        components (dict, optional): A dictionary describing the components of the cement plant. Default is an empty dictionary.
+        technology (str, optional): The technology of the cement plant. Default is "cement_plant".
+        objective (str, optional): The objective function of the plant. Default is "min_variable_cost".
+        flexibility_measure (str, optional): The flexibility measure for the cement plant, such as "cost_based_load_shift". Default is "cost_based_load_shift".
+        demand (float, optional): The production demand in tonnes over the simulation horizon - clinker when a preheater/calciner/kiln is configured, otherwise the ground tonnage of a standalone mill. Default is 0.
+        cost_tolerance (float, optional): The maximum allowable cost increase (in %) when shifting the load. Default is 10.
+        congestion_threshold (float, optional): The threshold above which the congestion signal counts as congestion. Default is 0.
+        peak_load_cap (float, optional): The peak load cap (in % of the peak load) used by the peak load shifting measure. Default is 0.
+        load_profile_deviation (float, optional): Allowed deviation (±) from the normalized load profile, as a fraction (e.g. 0.05 for ±5%). Default is 1.0 (no constraint).
+        raw_meal_to_clinker_ratio (float, optional): Tonnes of raw meal per tonne of clinker. Default is 1.55.
+        waste_heat_per_t_clinker (float, optional): Kiln waste heat available per tonne of clinker (MWh_th/t). Default is 0.22.
+        waste_heat_utilisation (float, optional): Share of the available waste heat the preheater can use. Default is 0.90.
+        node (str, optional): The network node where the cement plant is located. Default is "node0".
+        location (tuple[float, float], optional): The geographical coordinates (latitude, longitude) of the cement plant. Default is (0.0, 0.0).
+        **kwargs: Additional keyword arguments that may be passed to support more specific configurations.
+
+    Attributes:
+        required_technologies (list): Technologies the plant cannot operate without (none: any subset of the kiln line may be modelled).
+        optional_technologies (list): Technologies the plant may consist of.
+    """
+
+    # Required and optional technologies for the cement plant
+    required_technologies = []
+    optional_technologies = [
+        "preheater",
+        "calciner",
+        "kiln",
+        "raw_material_mill",
+        "cement_mill",
+        "electrolyser",
+        "thermal_storage",
+    ]
+
+    # Stages that produce clinker, in the order in which they may terminate the line
+    clinker_stages = ("kiln", "calciner")
+
+    # Rolling-horizon extensibility hooks (DSMFlex)
+    _demand_attr_suffix = "clinker_demand"
+    _extra_price_attrs = [
+        "natural_gas_price",
+        "coal_price",
+        "hydrogen_price",
+        "co2_price",
+    ]
+    _component_schema = {
+        "preheater": (
+            "power_in",
+            "raw_meal_out",
+            "preheater_power_input",
+            "raw_meal_output",
+        ),
+        "calciner": (
+            "power_in",
+            "clinker_out",
+            "calciner_power_input",
+            "calciner_clinker_output",
+        ),
+        "kiln": ("power_in", "clinker_out", "kiln_power_input", "kiln_clinker_output"),
+        "raw_material_mill": (
+            "power_in",
+            "material_output",
+            "raw_material_mill_power_input",
+            "raw_meal_output",
+        ),
+        "cement_mill": (
+            "power_in",
+            "material_output",
+            "cement_mill_power_input",
+            "cement_output",
+        ),
+        "electrolyser": (
+            "power_in",
+            "hydrogen_out",
+            "electrolyser_power",
+            "hydrogen_prod",
+        ),
+        "thermal_storage": (
+            "power_in",
+            "discharge",
+            "thermal_storage_power_input",
+            "thermal_storage_discharge",
+        ),
+    }
+
+    def _primary_output_expr(self, m, t):
+        """The plant's tracked output (tonnes): clinker, or a standalone mill's own
+        ground tonnage when there is no kiln line at all."""
+        return m.clinker_rate[t]
+
+    def _component_power_expr(self, m, t):
+        """Plant load: electric heating, auxiliaries and the electric components."""
+        return pyo.quicksum(
+            m.dsm_blocks[block].power_in[t]
+            for block in m.dsm_blocks
+            if hasattr(m.dsm_blocks[block], "power_in")
+        ) + pyo.quicksum(
+            m.dsm_blocks[block].aux_power[t]
+            for block in m.dsm_blocks
+            if hasattr(m.dsm_blocks[block], "aux_power")
+        )
+
+    def __init__(
+        self,
+        id: str,
+        unit_operator: str,
+        bidding_strategies: dict,
+        forecaster: CementForecaster,
+        components: dict[str, dict] = None,
+        technology: str = "cement_plant",
+        objective: str = "min_variable_cost",
+        flexibility_measure: str = "cost_based_load_shift",
+        demand: float = 0,
+        cost_tolerance: float = 10,
+        congestion_threshold: float = 0,
+        peak_load_cap: float = 0,
+        load_profile_deviation: float = 1.0,
+        raw_meal_to_clinker_ratio: float = 1.55,
+        waste_heat_per_t_clinker: float = 0.22,
+        waste_heat_utilisation: float = 0.90,
+        node: str = "node0",
+        location: tuple[float, float] = (0.0, 0.0),
+        **kwargs,
+    ):
+        super().__init__(
+            id=id,
+            unit_operator=unit_operator,
+            technology=technology,
+            components=components,
+            bidding_strategies=bidding_strategies,
+            forecaster=forecaster,
+            node=node,
+            location=location,
+            **kwargs,
+        )
+        if not isinstance(forecaster, CementForecaster):
+            raise TypeError(f"forecaster must be of type {CementForecaster.__name__}")
+
+        # check if the required components are present in the components dictionary
+        for component in self.required_technologies:
+            if component not in components.keys():
+                raise ValueError(
+                    f"Component {component} is required for the cement plant unit."
+                )
+
+        # check if the provided components are valid and do not contain any unknown components
+        for component in components.keys():
+            if (
+                component not in self.required_technologies
+                and component not in self.optional_technologies
+            ):
+                raise ValueError(
+                    f"Components {component} is not a valid component for the cement plant unit."
+                )
+
+        # FIXME assuming only one market
+        self.market_id = list(bidding_strategies.keys())[0]
+
+        # Global demand (total clinker production by the end of the horizon)
+        self.clinker_demand = demand
+        # Per-timestep minimum clinker production (optional, from the forecaster)
+        self.clinker_demand_per_timestep = getattr(forecaster, "clinker_demand", None)
+
+        self.natural_gas_price = self.forecaster.get_price("natural_gas")
+        self.coal_price = self.forecaster.get_price("coal")
+        self.hydrogen_price = self.forecaster.get_price("hydrogen")
+        self.co2_price = self.forecaster.get_price("co2")
+
+        # DSM signals used by the flexibility measures
+        self.congestion_signal = forecaster.congestion_signal
+        self.renewable_utilisation_signal = forecaster.renewable_utilisation_signal
+
+        self.objective = objective
+        self.flexibility_measure = flexibility_measure
+        self.cost_tolerance = cost_tolerance
+        self.congestion_threshold = congestion_threshold
+        self.peak_load_cap = peak_load_cap
+        self.load_profile_deviation = load_profile_deviation
+
+        self.raw_meal_to_clinker_ratio = raw_meal_to_clinker_ratio
+        self.waste_heat_per_t_clinker = waste_heat_per_t_clinker
+        self.waste_heat_utilisation = waste_heat_utilisation
+
+        # Optional profile guiding production in rolling-horizon mode
+        self.normalized_load_profile = getattr(
+            forecaster, "normalized_load_profile", None
+        )
+
+        # Component flags
+        self.has_preheater = "preheater" in self.components.keys()
+        self.has_calciner = "calciner" in self.components.keys()
+        self.has_kiln = "kiln" in self.components.keys()
+        self.has_raw_material_mill = "raw_material_mill" in self.components.keys()
+        self.has_cement_mill = "cement_mill" in self.components.keys()
+        self.has_electrolyser = "electrolyser" in self.components.keys()
+        self.has_thermal_storage = "thermal_storage" in self.components.keys()
+
+        # The stage whose clinker output is the plant output
+        self.final_clinker_stage = next(
+            (stage for stage in self.clinker_stages if stage in self.components), None
+        )
+        # The stage that receives the preheated raw meal: the calciner if present,
+        # otherwise the kiln directly (a single-stage line without a separate
+        # precalciner, where the kiln itself performs the calcination reaction).
+        self.raw_meal_receiving_stage = (
+            "calciner" if self.has_calciner else ("kiln" if self.has_kiln else None)
+        )
+        # When there is no kiln line at all, a lone mill becomes the plant's own
+        # standalone output (cement mill takes priority over the raw material mill,
+        # mirroring how final_clinker_stage prefers the kiln over the calciner).
+        self._standalone_output_stage = None
+        if self.final_clinker_stage is None:
+            if self.has_cement_mill:
+                self._standalone_output_stage = "cement_mill"
+            elif self.has_raw_material_mill:
+                self._standalone_output_stage = "raw_material_mill"
+
+        if self.has_electrolyser and not (self.has_calciner or self.has_kiln):
+            raise ValueError(
+                "An electrolyser needs a calciner or a kiln to supply with hydrogen."
+            )
+        if self.has_thermal_storage and not self.has_calciner:
+            raise ValueError(
+                "The thermal storage of a cement plant buffers the calciner, so a "
+                "calciner is required."
+            )
+        if (
+            self.final_clinker_stage is None
+            and self._standalone_output_stage is None
+            and (self.clinker_demand or self.clinker_demand_per_timestep is not None)
+        ):
+            raise ValueError(
+                "A production demand requires a calciner, a kiln, or a standalone "
+                "raw material mill / cement mill in the cement plant."
+            )
+
+        # Inject the schedule of a long-term thermal storage, and hand per-component
+        # availability profiles down to the component configs, so both are sliced along
+        # with the components in rolling-horizon windows.
+        storage_cfg = self.components.get("thermal_storage")
+        if (
+            storage_cfg is not None
+            and storage_cfg.get("storage_type", "short-term") == "long-term"
+        ):
+            storage_cfg["storage_schedule_profile"] = (
+                forecaster.thermal_storage_schedule
+            )
+
+        availability_profiles = getattr(forecaster, "availability_profiles", None) or {}
+        for tech in AVAILABILITY_COMPONENTS:
+            profile = availability_profiles.get(tech)
+            if tech in self.components and profile is not None:
+                self.components[tech]["availability_profile"] = profile
+
+        # Initialize the model
+        # self.setup_model()  # NOTE: called in forecaster initialization again!!!
+
+    def define_parameters(self):
+        """
+        Defines the parameters for the Pyomo model.
+
+        All price and profile series are aligned to the current model index, so the same
+        code path serves the full-horizon model and the shorter rolling-horizon windows.
+        """
+        self.model.electricity_price = pyo.Param(
+            self.model.time_steps,
+            initialize={
+                t: value
+                for t, value in enumerate(
+                    self._values_for_model(self.forecaster.electricity_price)
+                )
+            },
+        )
+        self.model.natural_gas_price = pyo.Param(
+            self.model.time_steps,
+            initialize={
+                t: value
+                for t, value in enumerate(
+                    self._values_for_model(self.natural_gas_price)
+                )
+            },
+        )
+        self.model.coal_price = pyo.Param(
+            self.model.time_steps,
+            initialize={
+                t: value
+                for t, value in enumerate(self._values_for_model(self.coal_price))
+            },
+        )
+        # Hydrogen produced on site is paid for through the electrolyser's electricity
+        # bill, so charging the hydrogen price on top would double count it.
+        if self.has_electrolyser:
+            self.model.hydrogen_price = pyo.Param(
+                self.model.time_steps,
+                initialize={t: 0 for t in self.model.time_steps},
+            )
+        else:
+            self.model.hydrogen_price = pyo.Param(
+                self.model.time_steps,
+                initialize={
+                    t: value
+                    for t, value in enumerate(
+                        self._values_for_model(self.hydrogen_price)
+                    )
+                },
+            )
+        self.model.co2_price = pyo.Param(
+            self.model.time_steps,
+            initialize={
+                t: value
+                for t, value in enumerate(self._values_for_model(self.co2_price))
+            },
+            within=pyo.NonNegativeReals,
+        )
+
+        self.model.raw_meal_to_clinker_ratio = pyo.Param(
+            initialize=self.raw_meal_to_clinker_ratio
+        )
+        self.model.waste_heat_per_t_clinker = pyo.Param(
+            initialize=self.waste_heat_per_t_clinker
+        )
+        self.model.waste_heat_utilisation = pyo.Param(
+            initialize=self.waste_heat_utilisation
+        )
+
+        # Use the remaining demand in rolling-horizon mode, otherwise the global demand
+        demand_value = self.clinker_demand
+        if self._rh_window_remaining_demand is not None:
+            demand_value = self._rh_window_remaining_demand
+            logger.info(f"Using rolling-horizon remaining_demand: {demand_value}")
+
+        self.model.clinker_demand = pyo.Param(initialize=demand_value)
+
+        # Optional: per-timestep minimum clinker production
+        if self.clinker_demand_per_timestep is not None:
+            self.model.clinker_demand_per_timestep = pyo.Param(
+                self.model.time_steps,
+                initialize={
+                    t: value
+                    for t, value in enumerate(
+                        self._values_for_model(self.clinker_demand_per_timestep)
+                    )
+                },
+            )
+
+        # Optional: normalized load profile used to shape production
+        if self.normalized_load_profile is not None:
+            self.model.normalized_load_profile = pyo.Param(
+                self.model.time_steps,
+                initialize={
+                    t: value
+                    for t, value in enumerate(
+                        self._values_for_model(self.normalized_load_profile)
+                    )
+                },
+            )
+            self.model.load_profile_deviation = pyo.Param(
+                initialize=self.load_profile_deviation
+            )
+
+    def define_variables(self):
+        """
+        Defines the variables for the Pyomo model.
+        """
+        self.model.total_power_input = pyo.Var(
+            self.model.time_steps, within=pyo.NonNegativeReals
+        )
+        self.model.variable_cost = pyo.Var(
+            self.model.time_steps, within=pyo.NonNegativeReals
+        )
+        self.model.clinker_rate = pyo.Var(
+            self.model.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="The plant's tracked production at each time step (tonnes): clinker "
+            "leaving the kiln line, or a standalone mill's own ground tonnage",
+        )
+        self.model.cumulative_thermal_output = pyo.Var(
+            self.model.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Process heat generated by the last thermal stage (MWh_th)",
+        )
+
+        if self.has_electrolyser:
+            self.model.h2_to_calciner = pyo.Var(
+                self.model.time_steps, within=pyo.NonNegativeReals
+            )
+            self.model.h2_to_kiln = pyo.Var(
+                self.model.time_steps, within=pyo.NonNegativeReals
+            )
+            self.model.h2_unutilised = pyo.Var(
+                self.model.time_steps, within=pyo.NonNegativeReals
+            )
+
+    def initialize_process_sequence(self):
+        """
+        Establishes the material and energy flows between the components of the cement plant.
+
+        The following links are added, each only if the components involved are configured:
+
+        1. **Raw meal flow**: the preheated raw meal covers what the first clinker-forming
+           stage needs - the calciner if present, otherwise the kiln directly - scaled by
+           ``raw_meal_to_clinker_ratio``.
+        2. **Clinker flow**: the kiln finishes the calcined material of the calciner, and
+           the clinker of the last stage of the line becomes the plant's tracked output.
+           If there is no kiln line at all, a lone raw material mill or cement mill
+           becomes the plant's tracked output instead (see 6.).
+        3. **Waste heat recovery**: heat recovered from the kiln reduces the fuel the
+           preheater needs. Without a kiln the preheater's waste heat port is closed.
+        4. **Calciner heat**: the heat driving calcination is the burner output plus the
+           thermal storage discharge, minus what a heat-charged storage takes away.
+        5. **Hydrogen flow**: hydrogen from the electrolyser is routed to the calciner and
+           kiln burners.
+        6. **Cement grinding**: when a kiln line is configured, the cement mill grinds
+           the clinker it produces. A cement mill with no kiln line is not connected to
+           anything and instead becomes the plant's own standalone output (see 2.).
+        """
+
+        if self.has_preheater and self.raw_meal_receiving_stage is not None:
+
+            @self.model.Constraint(self.model.time_steps)
+            def raw_meal_flow_constraint(m, t):
+                """
+                Links the preheated raw meal to the material calcined downstream.
+                """
+                return (
+                    m.dsm_blocks["preheater"].raw_meal_out[t]
+                    == m.dsm_blocks[self.raw_meal_receiving_stage].clinker_out[t]
+                    * m.raw_meal_to_clinker_ratio
+                )
+
+        if self.has_calciner and self.has_kiln:
+
+            @self.model.Constraint(self.model.time_steps)
+            def calciner_to_kiln_flow_constraint(m, t):
+                """
+                Links the calcined material of the calciner to the kiln throughput.
+                """
+                return (
+                    m.dsm_blocks["kiln"].clinker_out[t]
+                    == m.dsm_blocks["calciner"].clinker_out[t]
+                )
+
+        @self.model.Constraint(self.model.time_steps)
+        def clinker_rate_constraint(m, t):
+            """
+            Sets the plant's tracked output to the last stage of the kiln line, or, for
+            a standalone mill with no kiln line at all, to that mill's own ground
+            tonnage.
+            """
+            if self.final_clinker_stage is not None:
+                return (
+                    m.clinker_rate[t]
+                    == m.dsm_blocks[self.final_clinker_stage].clinker_out[t]
+                )
+            if self._standalone_output_stage is not None:
+                return (
+                    m.clinker_rate[t]
+                    == m.dsm_blocks[self._standalone_output_stage].material_output[t]
+                )
+            return m.clinker_rate[t] == 0
+
+        if self.has_preheater:
+
+            @self.model.Constraint(self.model.time_steps)
+            def waste_heat_recovery_constraint(m, t):
+                """
+                Recovers kiln waste heat into the preheater.
+                """
+                if not self.has_kiln:
+                    return m.dsm_blocks["preheater"].external_heat_in[t] == 0
+                return (
+                    m.dsm_blocks["preheater"].external_heat_in[t]
+                    == m.dsm_blocks["kiln"].clinker_out[t]
+                    * m.waste_heat_per_t_clinker
+                    * m.waste_heat_utilisation
+                )
+
+        if self.has_calciner:
+
+            @self.model.Constraint(self.model.time_steps)
+            def calciner_heat_constraint(m, t):
+                """
+                Determines the heat available for calcination, buffered by the thermal
+                storage where present.
+                """
+                effective_heat = m.dsm_blocks["calciner"].heat_out[t]
+                if self.has_thermal_storage:
+                    storage = m.dsm_blocks["thermal_storage"]
+                    effective_heat += storage.discharge[t]
+                    # A storage without an electric heater is charged with burner heat,
+                    # which is therefore not available to the calciner.
+                    if self.components["thermal_storage"].storage_type != (
+                        "short-term_with_generator"
+                    ):
+                        effective_heat -= storage.charge[t]
+                return m.dsm_blocks["calciner"].effective_heat_in[t] == effective_heat
+
+        if self.has_electrolyser:
+
+            @self.model.Constraint(self.model.time_steps)
+            def electrolyser_supply_constraint(m, t):
+                """
+                Splits the hydrogen production between the burners it can supply.
+                """
+                return m.dsm_blocks["electrolyser"].hydrogen_out[t] == (
+                    m.h2_to_calciner[t] + m.h2_to_kiln[t] + m.h2_unutilised[t]
+                )
+
+            @self.model.Constraint(self.model.time_steps)
+            def calciner_hydrogen_constraint(m, t):
+                """
+                Routes hydrogen to the calciner burner.
+                """
+                if not self.has_calciner:
+                    return m.h2_to_calciner[t] == 0
+                return m.dsm_blocks["calciner"].hydrogen_in[t] == m.h2_to_calciner[t]
+
+            @self.model.Constraint(self.model.time_steps)
+            def kiln_hydrogen_constraint(m, t):
+                """
+                Routes hydrogen to the kiln burner.
+                """
+                if not self.has_kiln:
+                    return m.h2_to_kiln[t] == 0
+                return m.dsm_blocks["kiln"].hydrogen_in[t] == m.h2_to_kiln[t]
+
+        if self.has_cement_mill and self.final_clinker_stage is not None:
+
+            @self.model.Constraint(self.model.time_steps)
+            def cement_grinding_constraint(m, t):
+                """
+                Grinds the clinker the kiln line produces into cement.
+                """
+                return (
+                    m.dsm_blocks["cement_mill"].material_input[t] == m.clinker_rate[t]
+                )
+
+        @self.model.Constraint(self.model.time_steps)
+        def cumulative_thermal_output_constraint(m, t):
+            """
+            Reports the process heat of the last thermal stage of the line.
+            """
+            for stage in ("kiln", "calciner", "preheater"):
+                if stage in self.components:
+                    return (
+                        m.cumulative_thermal_output[t]
+                        == m.dsm_blocks[stage].heat_out[t]
+                    )
+            return m.cumulative_thermal_output[t] == 0
+
+    def define_constraints(self):
+        """
+        Defines the plant-level optimization constraints of the cement plant.
+
+        1. **Demand constraint**: the plant's tracked production (clinker, or a standalone
+           mill's own ground tonnage) over the horizon meets the declared demand. It is
+           skipped when per-timestep minimums are supplied instead, since the optimizer
+           is then free to produce more than the sum of the minimums.
+        2. **Per-timestep demand constraint**: production per time step covers the
+           declared hourly minimum (full-horizon mode only; in rolling-horizon mode the
+           per-window equivalent is added by ``_add_window_demand_constraints``).
+        3. **Total power input constraint**: the plant load is the sum of the electric
+           heating, auxiliary and electric-component loads.
+        4. **Variable cost constraint**: the cost per time step is the sum of the component
+           operating costs, which already include fuel, auxiliary electricity and CO2.
+        """
+
+        # With per-hour minimums the global equality would conflict with them, since
+        # producing more than the sum of the minimums must stay feasible.
+        _min_demand_strategy = (
+            self.normalized_load_profile is None
+            and self.clinker_demand_per_timestep is not None
+        )
+        if not _min_demand_strategy:
+
+            @self.model.Constraint()
+            def clinker_output_association_constraint(m):
+                """
+                Global constraint: total tracked production meets the declared demand.
+                """
+                return (
+                    pyo.quicksum(m.clinker_rate[t] for t in m.time_steps)
+                    == m.clinker_demand
+                )
+
+        if (
+            self.clinker_demand_per_timestep is not None
+            and self.horizon_mode != "rolling_horizon"
+        ):
+
+            @self.model.Constraint(self.model.time_steps)
+            def clinker_demand_per_timestep_constraint(m, t):
+                return m.clinker_rate[t] >= m.clinker_demand_per_timestep[t]
+
+        @self.model.Constraint(self.model.time_steps)
+        def total_power_input_constraint(m, t):
+            """
+            Ensures the total power input is the sum of power inputs of all components.
+            """
+            return m.total_power_input[t] == self._component_power_expr(m, t)
+
+        @self.model.Constraint(self.model.time_steps)
+        def cost_per_time_step(m, t):
+            """
+            Calculates the variable cost per time step.
+            """
+            return m.variable_cost[t] == pyo.quicksum(
+                m.dsm_blocks[block].operating_cost[t]
+                for block in m.dsm_blocks
+                if hasattr(m.dsm_blocks[block], "operating_cost")
+            )

--- a/assume/units/dsm_load_shift.py
+++ b/assume/units/dsm_load_shift.py
@@ -117,6 +117,20 @@ class DSMFlex:
                     "commit_horizon, and rolling_step to be specified."
                 )
 
+    def _component_power_expr(self, m, t):
+        """Electric load of all component blocks at step *t*.
+
+        Used by the flexibility measures as the technology-agnostic counterpart of
+        ``total_power_input``: every block that draws power contributes its ``power_in``.
+        Units whose load also contains generation or bidirectional terms (e.g. PV or
+        batteries in a building) handle that in their own branch of the measure.
+        """
+        return pyo.quicksum(
+            m.dsm_blocks[block].power_in[t]
+            for block in m.dsm_blocks
+            if hasattr(m.dsm_blocks[block], "power_in")
+        )
+
     def initialize_components(self):
         """
         Initializes the DSM components by creating and adding blocks to the model.
@@ -406,6 +420,12 @@ class DSMFlex:
                     == total_power
                 )
 
+            else:
+                # Any other DSM unit: the plant load is the sum of its component loads
+                return m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[
+                    t
+                ] == self._component_power_expr(m, t)
+
         @self.model.Objective(sense=pyo.maximize)
         def obj_rule_flex(m):
             """
@@ -589,6 +609,12 @@ class DSMFlex:
                     == total_power
                 )
 
+            else:
+                # Any other DSM unit: the plant load is the sum of its component loads
+                return m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[
+                    t
+                ] == self._component_power_expr(m, t)
+
         @self.model.Objective(sense=pyo.maximize)
         def obj_rule_flex(m):
             """
@@ -653,38 +679,16 @@ class DSMFlex:
         # Power input constraint with flexibility based on congestion
         @model.Constraint(model.time_steps)
         def total_power_input_constraint_with_peak_shift(m, t):
-            if self.has_electrolyser:
-                return (
-                    m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[t]
-                    == m.dsm_blocks["electrolyser"].power_in[t]
-                    + m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                )
-            else:
-                return (
-                    m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[t]
-                    == m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                )
+            return m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[
+                t
+            ] == self._component_power_expr(m, t)
 
         @model.Constraint(model.time_steps)
         def peak_threshold_constraint(m, t):
             """
             Ensures that the power input during peak periods does not exceed the peak threshold value.
             """
-            if self.has_electrolyser:
-                return (
-                    m.dsm_blocks["electrolyser"].power_in[t]
-                    + m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                    <= peak_load_cap_value
-                )
-            else:
-                return (
-                    m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                    <= peak_load_cap_value
-                )
+            return self._component_power_expr(m, t) <= peak_load_cap_value
 
         @self.model.Objective(sense=pyo.maximize)
         def obj_rule_flex(m):
@@ -747,19 +751,9 @@ class DSMFlex:
         # Power input constraint integrating flexibility
         @model.Constraint(model.time_steps)
         def total_power_input_constraint_flex(m, t):
-            if self.has_electrolyser:
-                return (
-                    m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[t]
-                    == m.dsm_blocks["electrolyser"].power_in[t]
-                    + m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                )
-            else:
-                return (
-                    m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[t]
-                    == m.dsm_blocks["eaf"].power_in[t]
-                    + m.dsm_blocks["dri_plant"].power_in[t]
-                )
+            return m.total_power_input[t] + m.load_shift_pos[t] - m.load_shift_neg[
+                t
+            ] == self._component_power_expr(m, t)
 
         @self.model.Objective(sense=pyo.maximize)
         def obj_rule_flex(m):
@@ -959,7 +953,11 @@ class DSMFlex:
         def _fit_to_horizon(attr_name: str, pad_value=None):
             if not (attr_name and hasattr(self, attr_name)):
                 return None
-            val = getattr(self, attr_name)
+            # Prefer the saved full-horizon series: the attribute itself may already
+            # have been sliced down to the current window by
+            # _collect_series_attrs_for_window, and window offsets are applied to the
+            # returned sequence later on.
+            val = saved_attrs.get(attr_name, getattr(self, attr_name))
             if val is None:
                 return None
             try:
@@ -982,7 +980,9 @@ class DSMFlex:
         if profile is not None:
             return "profile_guided", profile, None
 
-        demand = _fit_to_horizon("steel_demand_per_timestep", pad_value=0.0)
+        demand = _fit_to_horizon(
+            f"{self._demand_attr_suffix}_per_timestep", pad_value=0.0
+        )
         if demand is not None:
             return "min_demand", None, demand
 
@@ -1156,7 +1156,11 @@ class DSMFlex:
     ):
         """Create instance and solve; retry without profile penalty if infeasible.
 
-        Returns ``(instance, results)``.
+        Returns ``(instance, results)``, or ``(None, None)`` when the window has no
+        feasible solution at all. Some solver interfaces (e.g. appsi HiGHS) raise
+        instead of reporting an infeasible termination condition, so an unsolvable
+        window must be reported back rather than crashing the caller: the window is
+        then left uncommitted and the simulation continues.
         """
         _profile_comps = [
             "profile_deviation_con",
@@ -1180,7 +1184,14 @@ class DSMFlex:
             results = self.solver.solve(instance, options={})
         except RuntimeError as e:
             if not load_profile_added:
-                raise
+                logger.warning(
+                    "Window [%d:%d] has no feasible solution (%.80s); "
+                    "leaving it uncommitted.",
+                    window_start,
+                    window_end,
+                    str(e),
+                )
+                return None, None
             logger.warning(
                 "[LOAD-PROFILE-RH] Solver error in window [%d:%d] with profile: %.80s. "
                 "Re-solving without.",
@@ -1190,7 +1201,17 @@ class DSMFlex:
             )
             _strip_profile_and_plain_obj()
             instance = self.model.create_instance()
-            results = self.solver.solve(instance, options={})
+            try:
+                results = self.solver.solve(instance, options={})
+            except RuntimeError as retry_error:
+                logger.warning(
+                    "Window [%d:%d] has no feasible solution without the profile "
+                    "either (%.80s); leaving it uncommitted.",
+                    window_start,
+                    window_end,
+                    str(retry_error),
+                )
+                return None, None
             load_profile_added = False
 
         if (
@@ -1205,7 +1226,17 @@ class DSMFlex:
             )
             _strip_profile_and_plain_obj()
             instance = self.model.create_instance()
-            results = self.solver.solve(instance, options={})
+            try:
+                results = self.solver.solve(instance, options={})
+            except RuntimeError as retry_error:
+                logger.warning(
+                    "Window [%d:%d] has no feasible solution without the profile "
+                    "either (%.80s); leaving it uncommitted.",
+                    window_start,
+                    window_end,
+                    str(retry_error),
+                )
+                return None, None
 
         return instance, results
 
@@ -1442,6 +1473,10 @@ class DSMFlex:
             instance, results = self._solve_with_profile_fallback(
                 load_profile_added, window_start, window_end
             )
+            if instance is None:
+                # Unsolvable window: keep the schedule as it is and move on, so the
+                # simulation continues with the previously committed values.
+                return
             self._log_solver_status(results, window_start, window_end)
 
             n_commit = commit_end - window_start

--- a/assume/units/dst_components.py
+++ b/assume/units/dst_components.py
@@ -354,7 +354,9 @@ class Boiler:
                     == b.hydrogen_gas_in[t] * model.hydrogen_gas_price[t]
                 )
 
-        # Ramp-up constraint and ramp-down constraints
+        # Ramp-up constraint and ramp-down constraints. The first step has no
+        # predecessor to decrease from, so ramp_down is skipped there rather than
+        # also capping it (ramp_up already limits the rise from a standing start).
         if self.fuel_type == "natural_gas":
 
             @model_block.Constraint(self.time_steps)
@@ -366,7 +368,7 @@ class Boiler:
             @model_block.Constraint(self.time_steps)
             def ramp_down_constraint(b, t):
                 if t == self.time_steps.at(1):
-                    return b.natural_gas_in[t] <= b.ramp_down
+                    return pyo.Constraint.Skip
                 return b.natural_gas_in[t - 1] - b.natural_gas_in[t] <= b.ramp_down
 
         elif self.fuel_type == "hydrogen_gas":
@@ -380,7 +382,7 @@ class Boiler:
             @model_block.Constraint(self.time_steps)
             def ramp_down_constraint(b, t):
                 if t == self.time_steps.at(1):
-                    return b.hydrogen_gas_in[t] <= b.ramp_down
+                    return pyo.Constraint.Skip
                 return b.hydrogen_gas_in[t - 1] - b.hydrogen_gas_in[t] <= b.ramp_down
 
         elif self.fuel_type == "electricity":
@@ -578,17 +580,20 @@ class GenericStorage:
                 return b.discharge[t] <= b.ramp_up
             return b.discharge[t] - b.discharge[t - 1] <= b.ramp_up
 
-        # Apply ramp-down constraints if ramp_down is specified
+        # Apply ramp-down constraints if ramp_down is specified. The first step has no
+        # predecessor to decrease from, so it is left uncapped here rather than also
+        # bounding it by ramp_down (ramp_up above already caps how fast it can rise
+        # from a standing start).
         @model_block.Constraint(self.time_steps)
         def charge_ramp_down_constraint(b, t):
             if t == self.time_steps.at(1):
-                return b.charge[t] <= b.ramp_down
+                return pyo.Constraint.Skip
             return b.charge[t - 1] - b.charge[t] <= b.ramp_down
 
         @model_block.Constraint(self.time_steps)
         def discharge_ramp_down_constraint(b, t):
             if t == self.time_steps.at(1):
-                return b.discharge[t] <= b.ramp_down
+                return pyo.Constraint.Skip
             return b.discharge[t - 1] - b.discharge[t] <= b.ramp_down
 
         return model_block
@@ -603,17 +608,30 @@ class ThermalStorage(GenericStorage):
 
     - For 'short-term': behaves like GenericStorage without behavioral restrictions.
     - For 'long-term': follows a storage schedule (0: charge-only, 1: discharge-only).
+    - For 'short-term_with_generator': an electric heater charges the storage, making it
+      a power-to-heat unit (E-TES). ``charge`` is then produced from ``power_in`` at
+      ``eta_electric`` and priced at the electricity price.
 
     Args:
-        storage_type (str): Type of storage behavior: 'short-term' or 'long-term'.
+        storage_type (str): Type of storage behavior: 'short-term', 'long-term' or 'short-term_with_generator'.
         storage_schedule_profile (pd.Series, optional): Binary schedule for discharge availability (only required for 'long-term').
+        eta_electric (float, optional): Efficiency of the electric heater (only used with a generator). Defaults to 0.97.
+        max_power (float, optional): Cap on the electric heater power (MW). Defaults to ``max_power_charge / eta_electric``.
         **kwargs: All other parameters are inherited from GenericStorage.
     """
+
+    supported_storage_types = (
+        "short-term",
+        "long-term",
+        "short-term_with_generator",
+    )
 
     def __init__(
         self,
         storage_type: str = "short-term",
         storage_schedule_profile: pd.Series | None = None,
+        eta_electric: float = 0.97,
+        max_power: float | None = None,
         **kwargs,
     ):
         """
@@ -621,7 +639,7 @@ class ThermalStorage(GenericStorage):
 
         Raises:
             ValueError: If `storage_type` is 'long-term' and no schedule is provided.
-            ValueError: If `storage_type` is not one of ['short-term', 'long-term'].
+            ValueError: If `storage_type` is not a supported storage type.
         """
         super().__init__(**kwargs)
 
@@ -633,8 +651,22 @@ class ThermalStorage(GenericStorage):
                 "storage_schedule_profile is required for 'long-term' storage_type."
             )
 
-        if self.storage_type not in ["short-term", "long-term"]:
-            raise ValueError("storage_type must be either 'short-term' or 'long-term'.")
+        if self.storage_type not in self.supported_storage_types:
+            raise ValueError(
+                "storage_type must be one of: "
+                f"{', '.join(self.supported_storage_types)}."
+            )
+
+        self.eta_electric = eta_electric
+        if self.storage_type == "short-term_with_generator":
+            self.max_power = (
+                self.max_power_charge / max(eta_electric, 1e-6)
+                if max_power is None
+                else max_power
+            )
+        else:
+            # No electric heater: the power port exists but is fixed to zero
+            self.max_power = 0.0
 
     def add_to_model(
         self, model: pyo.ConcreteModel, model_block: pyo.Block
@@ -643,6 +675,7 @@ class ThermalStorage(GenericStorage):
         Adds thermal storage constraints to the model based on storage type.
 
         - If 'long-term', restrict charge/discharge based on the binary schedule profile.
+        - If 'short-term_with_generator', charge the storage with an electric heater.
         - Otherwise, behaves identically to GenericStorage.
 
         Args:
@@ -653,6 +686,45 @@ class ThermalStorage(GenericStorage):
             pyo.Block: Updated model block with thermal storage constraints.
         """
         model_block = super().add_to_model(model, model_block)
+
+        # The power port is always defined so plant-level load aggregation and
+        # reporting can treat every thermal storage alike; without a generator it is
+        # fixed to zero.
+        model_block.eta_electric = pyo.Param(initialize=self.eta_electric)
+        model_block.max_power = pyo.Param(initialize=self.max_power)
+        model_block.power_in = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            bounds=(0, model_block.max_power),
+        )
+        model_block.operating_cost = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+
+        if self.storage_type == "short-term_with_generator":
+            if not hasattr(model, "electricity_price"):
+                raise ValueError(
+                    "ThermalStorage with an electric heater requires an electricity "
+                    "price profile in the model."
+                )
+
+            @model_block.Constraint(self.time_steps)
+            def electric_heater_charge(b, t):
+                return b.charge[t] == b.power_in[t] * b.eta_electric
+
+            @model_block.Constraint(self.time_steps)
+            def storage_operating_cost_constraint(b, t):
+                return b.operating_cost[t] == b.power_in[t] * model.electricity_price[t]
+
+        else:
+
+            @model_block.Constraint(self.time_steps)
+            def no_electric_heater(b, t):
+                return b.power_in[t] == 0
+
+            @model_block.Constraint(self.time_steps)
+            def storage_operating_cost_constraint(b, t):
+                return b.operating_cost[t] == 0
 
         if self.storage_type == "long-term":
 
@@ -1780,10 +1852,13 @@ class ChargingStation:
                 return b.charge[t] <= b.ramp_up
             return b.charge[t] - b.charge[t - 1] <= b.ramp_up
 
+        # The first step has no predecessor to decrease from, so ramp_down is skipped
+        # there rather than also capping it (ramp_up above already limits how fast it
+        # can rise from a standing start).
         @model_block.Constraint(self.time_steps)
         def charge_ramp_down_constraint(b, t):
             if t == self.time_steps.at(1):
-                return b.charge[t] <= b.ramp_down
+                return pyo.Constraint.Skip
             return b.charge[t - 1] - b.charge[t] <= b.ramp_down
 
         # Ramping: discharge
@@ -1796,7 +1871,7 @@ class ChargingStation:
         @model_block.Constraint(self.time_steps)
         def discharge_ramp_down_constraint(b, t):
             if t == self.time_steps.at(1):
-                return b.discharge[t] <= b.ramp_down
+                return pyo.Constraint.Skip
             return b.discharge[t - 1] - b.discharge[t] <= b.ramp_down
 
         return model_block
@@ -2037,6 +2112,628 @@ class DRIStorage(GenericStorage):
         return model_block
 
 
+class GrindingMill:
+    """
+    A class to represent a generic grinding mill in a cement plant model.
+
+    The same class covers raw material milling (limestone and additives to raw meal)
+    and cement grinding (clinker and additives to cement), since both are purely
+    electric grinding steps that differ only in their parameterisation.
+
+    Args:
+        max_power (float): Maximum allowable power input to the mill (MW).
+        specific_electricity_consumption (float): Electricity consumption per tonne of
+            material output (MWh/t).
+        time_steps (list[int]): A list of time steps over which the mill operates.
+        min_power (float, optional): Minimum allowable power input to the mill. Defaults to 0.0.
+        efficiency (float, optional): Mass ratio of material output to material input.
+            Defaults to 1.0 (no mass losses).
+        ramp_up (float, optional): Maximum allowed increase in power input per time step.
+            Defaults to `max_power`.
+        ramp_down (float, optional): Maximum allowed decrease in power input per time step.
+            Defaults to `max_power`.
+        min_operating_steps (int, optional): Minimum number of consecutive time steps the
+            mill must operate once started. Defaults to 0.
+        min_down_steps (int, optional): Minimum number of consecutive time steps the mill
+            must remain off after shutdown. Defaults to 0.
+        initial_operational_status (int, optional): Operational status before the first
+            time step (0 for off, 1 for on). Defaults to 1.
+    """
+
+    def __init__(
+        self,
+        max_power: float,
+        specific_electricity_consumption: float,
+        time_steps: list[int],
+        min_power: float = 0.0,
+        efficiency: float = 1.0,
+        ramp_up: float | None = None,
+        ramp_down: float | None = None,
+        min_operating_steps: int = 0,
+        min_down_steps: int = 0,
+        initial_operational_status: int = 1,
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.max_power = max_power
+        self.min_power = min_power
+        self.efficiency = efficiency
+        self.specific_electricity_consumption = specific_electricity_consumption
+        self.time_steps = time_steps
+        self.ramp_up = max_power if ramp_up is None else ramp_up
+        self.ramp_down = max_power if ramp_down is None else ramp_down
+        self.min_operating_steps = int(min_operating_steps)
+        self.min_down_steps = int(min_down_steps)
+        self.initial_operational_status = initial_operational_status
+        self.kwargs = kwargs
+
+        if specific_electricity_consumption <= 0:
+            raise ValueError(
+                "GrindingMill requires a positive specific_electricity_consumption."
+            )
+        if efficiency <= 0:
+            raise ValueError("GrindingMill requires a positive efficiency.")
+
+    def add_to_model(
+        self, model: pyo.ConcreteModel, model_block: pyo.Block
+    ) -> pyo.Block:
+        """
+        Adds a grinding mill block to the Pyomo model, defining parameters, variables and constraints.
+
+        Pyomo Components:
+            - **Parameters**: `max_power`, `min_power`, `efficiency`,
+              `specific_electricity_consumption`, `ramp_up`, `ramp_down`,
+              `min_operating_steps`, `min_down_steps`, `initial_operational_status`.
+            - **Variables**: `power_in[t]`, `material_input[t]`, `material_output[t]`,
+              `operating_cost[t]`, and optionally `operational_status[t]` (binary).
+            - **Constraints**: material input/output relation, electricity demand of the
+              grinding step, operating cost, ramping, and minimum up/down times.
+
+        Args:
+            model (pyo.ConcreteModel): The optimisation model the block belongs to.
+            model_block (pyo.Block): The block the mill is added to.
+
+        Returns:
+            pyo.Block: The block representing the grinding mill.
+        """
+
+        # Define parameters
+        model_block.max_power = pyo.Param(initialize=self.max_power)
+        model_block.min_power = pyo.Param(initialize=self.min_power)
+        model_block.efficiency = pyo.Param(initialize=self.efficiency)
+        model_block.specific_electricity_consumption = pyo.Param(
+            initialize=self.specific_electricity_consumption
+        )
+        model_block.ramp_up = pyo.Param(initialize=self.ramp_up)
+        model_block.ramp_down = pyo.Param(initialize=self.ramp_down)
+        model_block.min_operating_steps = pyo.Param(
+            initialize=self.min_operating_steps, within=pyo.NonNegativeIntegers
+        )
+        model_block.min_down_steps = pyo.Param(
+            initialize=self.min_down_steps, within=pyo.NonNegativeIntegers
+        )
+        model_block.initial_operational_status = pyo.Param(
+            initialize=self.initial_operational_status
+        )
+
+        # Define variables
+        model_block.power_in = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            bounds=(0, model_block.max_power),
+        )
+        model_block.material_input = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+        model_block.material_output = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+        model_block.operating_cost = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+
+        # Mass balance over the mill
+        @model_block.Constraint(self.time_steps)
+        def material_input_output_relation(b, t):
+            return b.material_input[t] == b.material_output[t] / b.efficiency
+
+        # Electricity demand of the grinding step
+        @model_block.Constraint(self.time_steps)
+        def material_flow_constraint(b, t):
+            return (
+                b.power_in[t]
+                == b.material_output[t] * b.specific_electricity_consumption
+            )
+
+        # Operating costs
+        @model_block.Constraint(self.time_steps)
+        def operating_cost_constraint_rule(b, t):
+            return b.operating_cost[t] == b.power_in[t] * model.electricity_price[t]
+
+        # Ramp-up and ramp-down constraints
+        add_ramping_constraints(
+            model_block=model_block,
+            time_steps=self.time_steps,
+        )
+
+        # Define additional variables and constraints for startup/shutdown and operational status
+        if (
+            self.min_operating_steps > 1
+            or self.min_down_steps > 1
+            or self.min_power > 0
+        ):
+            add_min_up_down_time_constraints(
+                model_block=model_block,
+                time_steps=self.time_steps,
+            )
+
+        return model_block
+
+
+class ThermalProcessStage:
+    """
+    Base class for the fuel-switchable thermal stages of a cement kiln line.
+
+    A stage converts an energy carrier into process heat, and its heat throughput sets
+    the material throughput of the stage. Four firing modes are supported:
+
+    - ``"electricity"``: ``heat_out = eta_electric × power_in``
+    - ``"fossil"``: ``heat_out = eta_fossil × (natural_gas_in + coal_in)``, split by ``fossil_ng_share``
+    - ``"both"``: the sum of the electric and the fossil contribution
+    - ``"hydrogen"``: ``heat_out = eta_fossil × hydrogen_in`` (``eta_fossil`` acts as the burner efficiency)
+
+    Auxiliary electricity (fans, drives, transport) is modelled separately from the
+    electric heating path in ``aux_power``, so it is part of the plant load in every
+    firing mode - not only when the stage is heated electrically.
+
+    Args:
+        max_heat_out (float): Maximum thermal output of the stage (MW_th).
+        specific_heat_demand (float): Thermal energy per tonne of throughput (MWh_th/t).
+        time_steps (list[int]): A list of time steps over which the stage operates.
+        min_heat_out (float, optional): Minimum thermal output while the stage is on (MW_th). Defaults to 0.0.
+        specific_electricity_aux (float, optional): Auxiliary electricity per tonne of throughput (MWh_el/t). Defaults to 0.0.
+        fuel_type (str, optional): Firing mode, see above. Defaults to ``"electricity"``.
+        eta_electric (float, optional): Efficiency of the electric heating path. Defaults to 0.95.
+        eta_fossil (float, optional): Efficiency of the burner (fossil or hydrogen). Defaults to 0.90.
+        fossil_ng_share (float, optional): Share of natural gas in the fossil fuel mix (1.0 = only gas, 0.0 = only coal). Defaults to 1.0.
+        max_power (float, optional): Cap on the electric heating power (MW_el). Defaults to ``max_heat_out / eta_electric``.
+        ramp_up (float, optional): Maximum increase in thermal output per time step. Defaults to `max_heat_out`.
+        ramp_down (float, optional): Maximum decrease in thermal output per time step. Defaults to `max_heat_out`.
+        ng_co2_factor (float, optional): Emissions of natural gas (t CO2/MWh_th). Defaults to 0.202.
+        coal_co2_factor (float, optional): Emissions of coal (t CO2/MWh_th). Defaults to 0.341.
+        min_operating_steps (int, optional): Minimum number of consecutive operating steps. Defaults to 0.
+        min_down_steps (int, optional): Minimum number of consecutive down steps. Defaults to 0.
+        initial_operational_status (int, optional): Status before the first time step (0 for off, 1 for on). Defaults to 1.
+        availability_profile (pd.Series | FastSeries | None, optional): Per-time-step
+            availability of the stage (1 available, 0 unavailable). Defaults to None.
+    """
+
+    supported_fuel_types = ("electricity", "fossil", "both", "hydrogen")
+    #: Name of the block variable holding the material throughput of the stage.
+    throughput_name = "throughput"
+
+    def __init__(
+        self,
+        max_heat_out: float,
+        specific_heat_demand: float,
+        time_steps: list[int],
+        min_heat_out: float = 0.0,
+        specific_electricity_aux: float = 0.0,
+        fuel_type: str = "electricity",
+        eta_electric: float = 0.95,
+        eta_fossil: float = 0.90,
+        fossil_ng_share: float = 1.0,
+        max_power: float | None = None,
+        ramp_up: float | None = None,
+        ramp_down: float | None = None,
+        ng_co2_factor: float = 0.202,
+        coal_co2_factor: float = 0.341,
+        min_operating_steps: int = 0,
+        min_down_steps: int = 0,
+        initial_operational_status: int = 1,
+        availability_profile=None,
+        **kwargs,
+    ):
+        super().__init__()
+
+        self.fuel_type = str(fuel_type).lower()
+        if self.fuel_type not in self.supported_fuel_types:
+            raise ValueError(
+                f"Unsupported fuel_type '{fuel_type}' for {type(self).__name__}. "
+                f"Choose one of {', '.join(self.supported_fuel_types)}."
+            )
+        if specific_heat_demand <= 0:
+            raise ValueError(
+                f"{type(self).__name__} requires a positive specific_heat_demand."
+            )
+        if not 0 <= fossil_ng_share <= 1:
+            raise ValueError("fossil_ng_share must be between 0 and 1.")
+
+        self.time_steps = time_steps
+        self.max_heat_out = max_heat_out
+        self.min_heat_out = min_heat_out
+        self.specific_heat_demand = specific_heat_demand
+        self.specific_electricity_aux = specific_electricity_aux
+
+        self.eta_electric = eta_electric
+        self.eta_fossil = eta_fossil
+        self.fossil_ng_share = fossil_ng_share
+
+        self.max_power = (
+            max_heat_out / max(eta_electric, 1e-6) if max_power is None else max_power
+        )
+        self.ramp_up = max_heat_out if ramp_up is None else ramp_up
+        self.ramp_down = max_heat_out if ramp_down is None else ramp_down
+
+        self.ng_co2_factor = ng_co2_factor
+        self.coal_co2_factor = coal_co2_factor
+
+        self.min_operating_steps = int(min_operating_steps)
+        self.min_down_steps = int(min_down_steps)
+        self.initial_operational_status = initial_operational_status
+        self.availability_profile = sanitize_availability_profile(
+            availability_profile, type(self).__name__
+        )
+        self.kwargs = kwargs
+
+    @property
+    def uses_electricity(self) -> bool:
+        return self.fuel_type in ("electricity", "both")
+
+    @property
+    def uses_fossil(self) -> bool:
+        return self.fuel_type in ("fossil", "both")
+
+    def _check_prices(self, model: pyo.ConcreteModel) -> None:
+        """Verify the plant model provides every price series this stage needs."""
+        required = ["electricity_price"]  # auxiliaries are always electric
+        if self.uses_fossil:
+            required += ["natural_gas_price", "coal_price"]
+        if self.fuel_type == "hydrogen":
+            required += ["hydrogen_price"]
+        for attr in required:
+            if not hasattr(model, attr):
+                raise ValueError(
+                    f"{type(self).__name__} with fuel_type '{self.fuel_type}' requires "
+                    f"a '{attr}' profile in the model."
+                )
+
+    def _add_common_parameters(self, model_block: pyo.Block) -> None:
+        model_block.max_heat_out = pyo.Param(initialize=self.max_heat_out)
+        model_block.min_heat_out = pyo.Param(initialize=self.min_heat_out)
+        model_block.specific_heat_demand = pyo.Param(
+            initialize=self.specific_heat_demand
+        )
+        model_block.specific_electricity_aux = pyo.Param(
+            initialize=self.specific_electricity_aux
+        )
+        model_block.eta_electric = pyo.Param(initialize=self.eta_electric)
+        model_block.eta_fossil = pyo.Param(initialize=self.eta_fossil)
+        model_block.fossil_ng_share = pyo.Param(
+            initialize=self.fossil_ng_share, within=pyo.UnitInterval
+        )
+        model_block.max_power = pyo.Param(initialize=self.max_power)
+        model_block.ramp_up = pyo.Param(initialize=self.ramp_up)
+        model_block.ramp_down = pyo.Param(initialize=self.ramp_down)
+        model_block.ng_co2_factor = pyo.Param(initialize=self.ng_co2_factor)
+        model_block.coal_co2_factor = pyo.Param(initialize=self.coal_co2_factor)
+        model_block.min_operating_steps = pyo.Param(
+            initialize=self.min_operating_steps, within=pyo.NonNegativeIntegers
+        )
+        model_block.min_down_steps = pyo.Param(
+            initialize=self.min_down_steps, within=pyo.NonNegativeIntegers
+        )
+        model_block.initial_operational_status = pyo.Param(
+            initialize=self.initial_operational_status
+        )
+
+    def _add_common_variables(self, model_block: pyo.Block) -> None:
+        model_block.heat_out = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            bounds=(0, model_block.max_heat_out),
+            doc="Useful process heat generated by the stage",
+        )
+        model_block.power_in = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            bounds=(0, model_block.max_power),
+            doc="Electric heating power",
+        )
+        model_block.aux_power = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Auxiliary electricity of fans, drives and transport",
+        )
+        model_block.natural_gas_in = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+        model_block.coal_in = pyo.Var(self.time_steps, within=pyo.NonNegativeReals)
+        model_block.fossil_in = pyo.Var(self.time_steps, within=pyo.NonNegativeReals)
+        model_block.hydrogen_in = pyo.Var(self.time_steps, within=pyo.NonNegativeReals)
+        model_block.co2_energy = pyo.Var(self.time_steps, within=pyo.NonNegativeReals)
+        model_block.operating_cost = pyo.Var(
+            self.time_steps, within=pyo.NonNegativeReals
+        )
+
+    def _add_firing_constraints(self, model_block: pyo.Block) -> None:
+        """Heat balance, fossil fuel split and zeroing of the unused carriers."""
+
+        @model_block.Constraint(self.time_steps)
+        def heat_balance(b, t):
+            generated = 0
+            if self.uses_electricity:
+                generated += b.power_in[t] * b.eta_electric
+            if self.uses_fossil:
+                generated += b.fossil_in[t] * b.eta_fossil
+            if self.fuel_type == "hydrogen":
+                generated += b.hydrogen_in[t] * b.eta_fossil
+            return b.heat_out[t] == generated + self._external_heat_expr(b, t)
+
+        if self.uses_fossil:
+
+            @model_block.Constraint(self.time_steps)
+            def fossil_sum(b, t):
+                return b.fossil_in[t] == b.natural_gas_in[t] + b.coal_in[t]
+
+            @model_block.Constraint(self.time_steps)
+            def fossil_split_ng(b, t):
+                return b.natural_gas_in[t] == b.fossil_ng_share * b.fossil_in[t]
+
+        else:
+
+            @model_block.Constraint(self.time_steps)
+            def no_fossil_input(b, t):
+                return b.natural_gas_in[t] + b.coal_in[t] + b.fossil_in[t] == 0
+
+        if not self.uses_electricity:
+
+            @model_block.Constraint(self.time_steps)
+            def no_electric_heating(b, t):
+                return b.power_in[t] == 0
+
+        if self.fuel_type != "hydrogen":
+
+            @model_block.Constraint(self.time_steps)
+            def no_hydrogen_input(b, t):
+                return b.hydrogen_in[t] == 0
+
+    def _external_heat_expr(self, model_block: pyo.Block, t: int):
+        """Heat supplied from outside the stage (overridden where applicable)."""
+        return 0
+
+    def _add_aux_and_cost_constraints(self, model_block: pyo.Block, model) -> None:
+        throughput = getattr(model_block, self.throughput_name)
+
+        @model_block.Constraint(self.time_steps)
+        def aux_power_constraint(b, t):
+            return b.aux_power[t] == throughput[t] * b.specific_electricity_aux
+
+        @model_block.Constraint(self.time_steps)
+        def energy_co2_constraint(b, t):
+            return (
+                b.co2_energy[t]
+                == b.natural_gas_in[t] * b.ng_co2_factor
+                + b.coal_in[t] * b.coal_co2_factor
+            )
+
+        @model_block.Constraint(self.time_steps)
+        def operating_cost_constraint(b, t):
+            cost = (b.power_in[t] + b.aux_power[t]) * model.electricity_price[t]
+            if self.uses_fossil:
+                cost += (
+                    b.natural_gas_in[t] * model.natural_gas_price[t]
+                    + b.coal_in[t] * model.coal_price[t]
+                )
+            if self.fuel_type == "hydrogen":
+                cost += b.hydrogen_in[t] * model.hydrogen_price[t]
+            cost += self._emission_cost_expr(b, t, model)
+            return b.operating_cost[t] == cost
+
+    def _emission_cost_expr(self, model_block: pyo.Block, t: int, model):
+        """CO2 cost of the stage; extended by stages with process emissions."""
+        return model_block.co2_energy[t] * model.co2_price[t]
+
+    def _add_operational_constraints(self, model_block: pyo.Block) -> None:
+        """Availability, ramping and, where configured, unit commitment on the heat output."""
+        if self.availability_profile is not None:
+
+            @model_block.Constraint(self.time_steps)
+            def availability_constraint(b, t):
+                return (
+                    b.heat_out[t]
+                    <= availability_at(self.availability_profile, t) * b.max_heat_out
+                )
+
+        add_ramping_constraints(
+            model_block=model_block,
+            time_steps=self.time_steps,
+            quantity="heat_out",
+        )
+
+        if (
+            self.min_operating_steps > 1
+            or self.min_down_steps > 1
+            or self.min_heat_out > 0
+        ):
+            add_min_up_down_time_constraints(
+                model_block=model_block,
+                time_steps=self.time_steps,
+                quantity="heat_out",
+                min_quantity="min_heat_out",
+                max_quantity="max_heat_out",
+            )
+
+    def add_to_model(
+        self, model: pyo.ConcreteModel, model_block: pyo.Block
+    ) -> pyo.Block:
+        """
+        Adds the thermal stage to the Pyomo model, defining parameters, variables and constraints.
+
+        Pyomo Components:
+            - **Parameters**: `max_heat_out`, `min_heat_out`, `specific_heat_demand`,
+              `specific_electricity_aux`, `eta_electric`, `eta_fossil`, `fossil_ng_share`,
+              `max_power`, `ramp_up`, `ramp_down`, `ng_co2_factor`, `coal_co2_factor`,
+              `min_operating_steps`, `min_down_steps`, `initial_operational_status`.
+            - **Variables**: `heat_out[t]`, `power_in[t]`, `aux_power[t]`,
+              `natural_gas_in[t]`, `coal_in[t]`, `fossil_in[t]`, `hydrogen_in[t]`,
+              `co2_energy[t]`, `operating_cost[t]`, the stage throughput, and optionally
+              `operational_status[t]` / `start_up[t]` / `shut_down[t]` (binary).
+            - **Constraints**: heat balance for the configured firing mode, fossil fuel
+              split, zeroing of unused carriers, throughput from heat, auxiliary
+              electricity, energy emissions, operating cost, ramping and minimum
+              up/down times.
+
+        Args:
+            model (pyo.ConcreteModel): The optimisation model the block belongs to.
+            model_block (pyo.Block): The block the stage is added to.
+
+        Returns:
+            pyo.Block: The block representing the thermal stage.
+        """
+        self._check_prices(model)
+        self._add_common_parameters(model_block)
+        self._add_stage_parameters(model_block)
+        self._add_common_variables(model_block)
+        self._add_stage_variables(model_block)
+        self._add_firing_constraints(model_block)
+        self._add_stage_constraints(model_block, model)
+        self._add_aux_and_cost_constraints(model_block, model)
+        self._add_operational_constraints(model_block)
+        return model_block
+
+    # Stage-specific hooks
+    def _add_stage_parameters(self, model_block: pyo.Block) -> None:
+        pass
+
+    def _add_stage_variables(self, model_block: pyo.Block) -> None:
+        pass
+
+    def _add_stage_constraints(self, model_block: pyo.Block, model) -> None:
+        pass
+
+
+class Preheater(ThermalProcessStage):
+    """
+    A fuel-switchable preheater for cement raw meal (medium temperature, ~300-800 °C).
+
+    The stage heats raw meal with electricity, natural gas, coal or hydrogen, and can
+    additionally use waste heat recovered elsewhere in the plant. The recovered heat
+    enters through ``external_heat_in``, which the plant unit links to its waste heat
+    source (and fixes to zero when there is none).
+
+    Args:
+        See :class:`ThermalProcessStage`; ``specific_heat_demand`` is given per tonne of
+        raw meal (MWh_th/t) and the throughput variable is ``raw_meal_out``.
+    """
+
+    throughput_name = "raw_meal_out"
+
+    def _add_stage_variables(self, model_block: pyo.Block) -> None:
+        model_block.raw_meal_out = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Preheated raw meal leaving the stage (t)",
+        )
+        model_block.external_heat_in = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Waste heat supplied from elsewhere in the plant (MWh_th)",
+        )
+
+    def _external_heat_expr(self, model_block: pyo.Block, t: int):
+        return model_block.external_heat_in[t]
+
+    def _add_stage_constraints(self, model_block: pyo.Block, model) -> None:
+        @model_block.Constraint(self.time_steps)
+        def throughput_from_heat(b, t):
+            return b.raw_meal_out[t] == b.heat_out[t] / b.specific_heat_demand
+
+
+class Calciner(ThermalProcessStage):
+    """
+    A fuel-switchable calciner for cement raw meal (high temperature, ~920-930 °C).
+
+    Calcination releases process CO2 in proportion to the clinker produced, on top of
+    the energy emissions of the fuel. The heat that actually drives calcination is
+    ``effective_heat_in``, which the plant unit links to the burner output plus any
+    thermal storage discharge - this is what lets an electric thermal storage displace
+    burner heat in expensive hours.
+
+    Args:
+        calcination_emission_factor (float, optional): Process emissions per tonne of clinker (t CO2/t). Defaults to 0.525.
+        Other arguments: see :class:`ThermalProcessStage`; ``specific_heat_demand`` is
+        given per tonne of clinker (MWh_th/t) and the throughput variable is ``clinker_out``.
+    """
+
+    throughput_name = "clinker_out"
+
+    def __init__(self, *args, calcination_emission_factor: float = 0.525, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.calcination_emission_factor = calcination_emission_factor
+
+    def _add_stage_parameters(self, model_block: pyo.Block) -> None:
+        model_block.calcination_emission_factor = pyo.Param(
+            initialize=self.calcination_emission_factor
+        )
+
+    def _add_stage_variables(self, model_block: pyo.Block) -> None:
+        model_block.clinker_out = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Calcined material leaving the stage (t)",
+        )
+        model_block.effective_heat_in = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Heat driving calcination, incl. thermal storage discharge (MWh_th)",
+        )
+        model_block.co2_process = pyo.Var(self.time_steps, within=pyo.NonNegativeReals)
+
+    def _add_stage_constraints(self, model_block: pyo.Block, model) -> None:
+        @model_block.Constraint(self.time_steps)
+        def throughput_from_heat(b, t):
+            return b.clinker_out[t] == b.effective_heat_in[t] / b.specific_heat_demand
+
+        @model_block.Constraint(self.time_steps)
+        def process_co2_constraint(b, t):
+            return b.co2_process[t] == b.clinker_out[t] * b.calcination_emission_factor
+
+    def _emission_cost_expr(self, model_block: pyo.Block, t: int, model):
+        return (
+            model_block.co2_energy[t] + model_block.co2_process[t]
+        ) * model.co2_price[t]
+
+
+class Kiln(ThermalProcessStage):
+    """
+    A fuel-switchable rotary kiln for final clinkerisation (~1450 °C).
+
+    Unlike the calciner the kiln has no process emissions - the calcination CO2 has
+    already been released upstream - so only the energy emissions of its fuel are
+    accounted for. Its thermal demand per tonne of clinker is correspondingly higher.
+
+    Args:
+        See :class:`ThermalProcessStage`; ``specific_heat_demand`` is given per tonne of
+        clinker (MWh_th/t) and the throughput variable is ``clinker_out``.
+    """
+
+    throughput_name = "clinker_out"
+
+    def _add_stage_variables(self, model_block: pyo.Block) -> None:
+        model_block.clinker_out = pyo.Var(
+            self.time_steps,
+            within=pyo.NonNegativeReals,
+            doc="Clinker leaving the kiln (t)",
+        )
+
+    def _add_stage_constraints(self, model_block: pyo.Block, model) -> None:
+        @model_block.Constraint(self.time_steps)
+        def throughput_from_heat(b, t):
+            return b.clinker_out[t] == b.heat_out[t] / b.specific_heat_demand
+
+
 # Mapping of component type identifiers to their respective classes
 demand_side_technologies: dict = {
     "electrolyser": Electrolyser,
@@ -2052,38 +2749,102 @@ demand_side_technologies: dict = {
     "generic_storage": GenericStorage,
     "pv_plant": PVPlant,
     "thermal_storage": ThermalStorage,
+    "raw_material_mill": GrindingMill,
+    "cement_mill": GrindingMill,
+    "preheater": Preheater,
+    "calciner": Calciner,
+    "kiln": Kiln,
 }
 
 
-def add_ramping_constraints(model_block, time_steps):
+def sanitize_availability_profile(availability_profile, component_name: str):
+    """Return *availability_profile* if it can be indexed per time step, else ``None``.
+
+    Availability is expected as a per-time-step series. Scalar flags (such as the
+    ``"yes"``/``"no"`` strings sometimes present in DSM input files) carry no temporal
+    information and are dropped with a warning rather than failing the run.
+    """
+    if availability_profile is None:
+        return None
+    if isinstance(availability_profile, str) or not hasattr(
+        availability_profile, "__getitem__"
+    ):
+        logger.warning(
+            "%s received a non-series availability_profile (%r); "
+            "the availability constraint is skipped.",
+            component_name,
+            availability_profile,
+        )
+        return None
+    return availability_profile
+
+
+def availability_at(availability_profile, t: int) -> float:
+    """Positional lookup of an availability value for local time step *t*."""
+    if hasattr(availability_profile, "iat"):
+        return float(availability_profile.iat[t])
+    return float(availability_profile[t])
+
+
+def add_ramping_constraints(model_block, time_steps, quantity: str = "power_in"):
+    """Limit the change of *quantity* between consecutive time steps.
+
+    *quantity* names the block variable the ramp limits apply to - ``power_in`` for
+    electric components, ``heat_out`` for thermally driven ones.
+
+    The first time step has no predecessor, so it is only capped by ``ramp_up`` (how
+    fast the component can rise from an assumed standing start of zero). ``ramp_down``
+    is skipped there rather than also capping the first value: there is no preceding
+    value to decrease *from*, so a low ``ramp_down`` must not choke off a legitimately
+    high first-step value the way it would if it were treated as a second, tighter
+    absolute cap alongside ``ramp_up``.
+    """
+    ramped = getattr(model_block, quantity)
+
     # Ramp-up constraint
     @model_block.Constraint(time_steps)
     def ramp_up_constraint(b, t):
         if t == time_steps.at(1):
-            return b.power_in[t] <= b.ramp_up
-        return b.power_in[t] - b.power_in[t - 1] <= b.ramp_up
+            return ramped[t] <= b.ramp_up
+        return ramped[t] - ramped[t - 1] <= b.ramp_up
 
     # Ramp-down constraint
     @model_block.Constraint(time_steps)
     def ramp_down_constraint(b, t):
         if t == time_steps.at(1):
-            return b.power_in[t] <= b.ramp_down
-        return b.power_in[t - 1] - b.power_in[t] <= b.ramp_down
+            return pyo.Constraint.Skip
+        return ramped[t - 1] - ramped[t] <= b.ramp_down
 
     return model_block
 
 
-def add_min_up_down_time_constraints(model_block, time_steps):
+def add_min_up_down_time_constraints(
+    model_block,
+    time_steps,
+    quantity: str = "power_in",
+    min_quantity: str = "min_power",
+    max_quantity: str = "max_power",
+):
+    """Add an on/off status with minimum up- and down-time to a component block.
+
+    *quantity* names the block variable the status switches (``power_in`` for electric
+    components, ``heat_out`` for thermally driven ones), bounded by the *min_quantity*
+    and *max_quantity* parameters while the component is on.
+    """
     model_block.operational_status = pyo.Var(time_steps, within=pyo.Binary)
 
-    # Power constraints based on operational status
+    switched = getattr(model_block, quantity)
+    min_level = getattr(model_block, min_quantity)
+    max_level = getattr(model_block, max_quantity)
+
+    # Output constraints based on operational status
     @model_block.Constraint(time_steps)
     def min_power_constraint(b, t):
-        return b.power_in[t] >= b.min_power * b.operational_status[t]
+        return switched[t] >= min_level * b.operational_status[t]
 
     @model_block.Constraint(time_steps)
     def max_power_constraint(b, t):
-        return b.power_in[t] <= b.max_power * b.operational_status[t]
+        return switched[t] <= max_level * b.operational_status[t]
 
     if model_block.min_operating_steps > 0 or model_block.min_down_steps > 0:
         model_block.start_up = pyo.Var(time_steps, within=pyo.Binary)

--- a/docs/source/demand_side_agent.rst
+++ b/docs/source/demand_side_agent.rst
@@ -189,6 +189,7 @@ Example Workflow
 .. note::
 
    DSM units (e.g. :class:`~assume.units.steel_plant.SteelPlant`,
+   :class:`~assume.units.cement_plant.CementPlant`,
    :class:`~assume.units.building.Building`,
    :class:`~assume.units.hydrogen_plant.HydrogenPlant`,
    :class:`~assume.units.steam_generation_plant.SteamGenerationPlant`) build their internal
@@ -198,6 +199,82 @@ Example Workflow
    :meth:`~assume.common.forecaster.UnitForecaster.initialize` (or
    :func:`~assume.world.World.init_forecasts`), you must call
    ``unit.setup_model()`` explicitly before running optimisation on the unit.
+
+Industrial Agent: Cement Plant
+------------------------------
+
+The **Cement Plant** agent models the kiln line of a cement works: a preheater heats the
+raw meal, a calciner drives the calcination reaction that releases the process CO2, and a
+kiln finishes the clinker at high temperature. Every stage is fuel-switchable between
+electricity, a natural gas / coal mix and hydrogen, so one plant description covers both
+a conventional and an electrified configuration. Demand is expressed in tonnes to be
+produced over the horizon - clinker when a kiln line is configured, or a standalone
+mill's own ground tonnage when it isn't (see *Grinding mills* below).
+
+Waste heat recovered from the kiln reduces the fuel the preheater needs, and an optional
+electric thermal storage lets the plant buy power when it is cheap and displace calciner
+burner heat later - which is where most of the plant's demand-side flexibility comes from.
+
+Attributes
+^^^^^^^^^^^
+
+- **Technology**: Represents components such as Preheater, Calciner, Kiln, Thermal Storage, Electrolyser, Raw Material Mill, and Cement Mill.
+- **Node**: Connection point in the energy system.
+- **Bidding Strategy**: Defines how the cement plant bids in electricity markets. Example: `DsmEnergyOptimizationStrategy`.
+- **Objective**: Minimising variable cost (``min_variable_cost``).
+- **Flexibility Measure**: Any measure provided by :class:`~assume.units.dsm_load_shift.DSMFlex`, e.g. load shifting, peak load shifting, congestion management, or renewable utilisation.
+
+Components
+^^^^^^^^^^^
+
+- **Preheater**: Heats the raw meal (:class:`~assume.units.dst_components.Preheater`) and can additionally use waste heat recovered from the kiln.
+- **Calciner**: Drives calcination (:class:`~assume.units.dst_components.Calciner`), releasing process CO2 in proportion to the calcined material. The heat that reaches the reaction includes any thermal storage discharge.
+- **Kiln**: Finishes the clinker (:class:`~assume.units.dst_components.Kiln`) at a correspondingly higher specific heat demand, with energy emissions only.
+- **Thermal Storage**: In its ``short-term_with_generator`` mode (:class:`~assume.units.dst_components.ThermalStorage`) an electric heater charges the storage, making it a power-to-heat buffer for the calciner.
+- **Electrolyser**: Produces hydrogen on site for the calciner and kiln burners; the plant routes the production between them.
+- **Raw Material Mill** and **Cement Mill**: Electric grinding steps (:class:`~assume.units.dst_components.GrindingMill`) that convert raw materials to raw meal and clinker to cement respectively.
+
+All three thermal stages account for auxiliary electricity (fans, drives, transport) per
+tonne of throughput in ``aux_power``, separately from the electric heating path, so the
+auxiliaries are part of the plant load in every firing mode.
+
+Grinding mills
+^^^^^^^^^^^^^^^
+
+The raw material mill and cement mill are **not** automatically wired into the kiln
+line. A cement mill alongside a kiln line grinds that line's clinker output as before;
+a plant made of only a raw material mill and/or only a cement mill - with no
+preheater/calciner/kiln at all - runs as a **standalone grinding operation**, and the
+declared demand then targets that mill's own ground tonnage directly (cement for a lone
+cement mill, raw meal for a lone raw material mill). If both mills are present with no
+kiln line, the cement mill takes priority as the demand target and the raw material mill
+stays idle. A mill left present but unconnected alongside a kiln line (e.g. a raw
+material mill next to a full kiln line) likewise stays idle, since nothing requires or
+rewards running it.
+
+Rolling horizon
+^^^^^^^^^^^^^^^^
+
+The cement plant supports the same production guidance modes as the steel plant. The
+forecaster accepts generic or unit-specific forecast columns:
+
+- ``clinker_demand`` or ``<unit_id>_clinker_demand`` - per-timestep minimum production (clinker, or a standalone mill's ground tonnage)
+- ``normalized_load_profile`` or ``<unit_id>_normalized_load_profile`` - profile-guided production
+- ``electricity_price_flex`` or ``<unit_id>_electricity_price_flex`` - price signal for the ``electricity_price_signal`` measure
+- ``thermal_storage_schedule`` or ``<unit_id>_thermal_storage_schedule`` - schedule of a long-term thermal storage
+- ``<component>_availability`` or ``<unit_id>_<component>_availability`` - availability of the preheater, calciner or kiln (the mills do not take an availability profile)
+
+Across rolling-horizon windows the plant carries thermal storage fill levels and
+component on/off states, and tracks the clinker (or standalone mill output) still to be
+produced.
+
+Example Workflow
+^^^^^^^^^^^^^^^^^^
+
+1. Instantiate the CementPlant agent with the stages of the kiln line it should contain
+   (or just a mill, for a standalone grinding operation).
+2. Define the production demand, the firing mode of each stage and the flexibility measure.
+3. Run the optimization to generate bids for the electricity market.
 
 Residential Agent: Building
 ----------------------------

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -38,6 +38,17 @@ Upcoming Release
   - **Skip torch seeding when torch is installed but not used**: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
   - **Fix bug in redispatch mechanism**: Fixed the bug in redispatch evaluation due to PyPSA's version upgrade. In ``PyPSA >= 0.35.2`` (released in February 2025) the sign of load was not taken into account correctly & since the fixed EOM dispatch was modelled as a load with positive sign which was resulting in incorrect redispatch amounts.
 
+0.6.2 - (5th August 2026)
+=========================
+
+**New Features:**
+  - **Cement Plant DSM unit**: Added a ``CementPlant`` unit modelling a fuel-switchable kiln line, each stage independently switchable between electricity, a natural-gas/coal mix, or hydrogen. Optional components include an electrolyser supplying the burners with on-site hydrogen, an electric-heater thermal storage (E-TES) that buffers calciner heat, and a raw material mill / cement mill. Either mill can also run standalone with no kiln line at all, in which case the declared demand targets that mill's own ground tonnage directly. Supports both full-horizon and rolling-horizon optimisation, and all of the existing ``DSMFlex`` flexibility measures. See the Demand Side Agent documentation for details.
+  - **New demand-side technology components in** ``dst_components.py``: Added ``ThermalProcessStage``, a shared base class for fuel-switchable thermal stages, with ``Preheater``, ``Calciner``, and ``Kiln`` subclasses used by the new cement plant. ``Calciner`` tracks process (calcination) CO2 emissions separately from energy emissions; ``Preheater`` accepts recovered waste heat from the kiln. Also added ``GrindingMill``, a generic electric grinding component used for both raw material milling and cement grinding, and a new ``short-term_with_generator`` mode for ``ThermalStorage`` where an electric heater charges the storage from grid power.
+
+**Bug Fixes:**
+  - **Fix ramp constraint at the first time step**: For every ramp-limited DSM component, the first time step was incorrectly capped by ``min(ramp_up, ramp_down)`` instead of just ``ramp_up``, since the ramp-down constraint also applied an absolute cap on the first step even though there is no previous value to decrease from. This could artificially choke off a legitimately high first-step value whenever ``ramp_down`` was tighter than ``ramp_up``. Fixed across all affected components (``GenericStorage``, ``ChargingStation``, ``Boiler``, and the shared ``add_ramping_constraints`` helper used by most other DSM components).
+  - **Fix rolling-horizon min-demand strategy for non-steel-plant units**: The rolling-horizon function's per-timestep demand-strategy detection hard-coded the steel plant's own ``steel_demand_per_timestep`` attribute name, so any other DSM unit using the ``min_demand`` strategy in rolling-horizon mode silently read the wrong (already window-sliced) series. Generalized to use each unit's own demand attribute.
+
 0.6.1 - (25th March 2026)
 =========================
 

--- a/docs/source/unit_forecasts.rst
+++ b/docs/source/unit_forecasts.rst
@@ -29,6 +29,7 @@ Demand Units                  ``DemandForecaster``                      ``demand
 Exchange Units                ``ExchangeForecaster``                    ``volume_import``, ``volume_export``
 DSM Units                     ``DsmUnitForecaster``                     ``congestion_signal``, ``renewable_utilisation_signal``, ``electricity_price``
 Steelplant Units              ``SteelplantForecaster``                  DSM attrs + ``fuel_prices``
+Cement Plant Units            ``CementForecaster``                      DSM attrs + ``fuel_prices``, ``clinker_demand``, ``normalized_load_profile``, ``electricity_price_flex``, ``thermal_storage_schedule``, ``availability_profiles``
 Steam Generation Units        ``SteamgenerationForecaster``             DSM attrs + ``fuel_prices``, ``demand``, ``thermal_demand``, ``thermal_storage_schedule``, ``electricity_price_flex``
 Building Units                ``BuildingForecaster``                    DSM attrs + ``fuel_prices``, ``heat_demand``, ``ev_load_profile``, ``battery_load_profile``, ``pv_profile``, ``load_profile``
 Hydrogen Units                ``HydrogenForecaster``                    DSM attrs + ``hydrogen_demand``, ``seasonal_storage_schedule``

--- a/tests/test_cement_plant.py
+++ b/tests/test_cement_plant.py
@@ -1,0 +1,1634 @@
+# SPDX-FileCopyrightText: ASSUME Developers
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+"""
+Tests for the cement plant DSM unit.
+
+Covers the kiln line (preheater → calciner → kiln), the firing modes, waste heat
+recovery, the optional components (electrolyser, electric thermal storage, cement mill),
+the flexibility measures and rolling-horizon operation.
+"""
+
+import copy
+
+import pandas as pd
+import pyomo.environ as pyo
+import pytest
+
+from assume.common.fast_pandas import FastSeries
+from assume.common.forecaster import CementForecaster
+from assume.strategies.naive_strategies import (
+    DsmEnergyNaiveRedispatchStrategy,
+    DsmEnergyOptimizationStrategy,
+)
+from assume.units.cement_plant import CementPlant
+
+# Base configuration of the kiln line used throughout the tests. Thermal demands are
+# given per tonne of throughput, auxiliary electricity per tonne as well.
+RAW_MEAL_RATIO = 1.55
+PREHEATER_HEAT = 0.3  # MWh_th per t raw meal
+CALCINER_HEAT = 0.7  # MWh_th per t clinker
+KILN_HEAT = 1.7  # MWh_th per t clinker
+AUX_ELECTRICITY = 0.0015  # MWh_el per t throughput
+WASTE_HEAT = 0.22  # MWh_th per t clinker
+WASTE_HEAT_UTILISATION = 0.9
+
+# Auxiliary electricity per tonne of clinker across the three stages
+AUX_PER_TONNE_CLINKER = AUX_ELECTRICITY * (2 + RAW_MEAL_RATIO)
+
+
+@pytest.fixture
+def cement_components():
+    return {
+        "preheater": {
+            "max_heat_out": 10,
+            "specific_heat_demand": PREHEATER_HEAT,
+            "specific_electricity_aux": AUX_ELECTRICITY,
+            "fuel_type": "fossil",
+            "eta_fossil": 0.9,
+            "fossil_ng_share": 1,
+            "ramp_up": 10,
+            "ramp_down": 10,
+        },
+        "calciner": {
+            "max_heat_out": 5,
+            "specific_heat_demand": CALCINER_HEAT,
+            "specific_electricity_aux": AUX_ELECTRICITY,
+            "fuel_type": "fossil",
+            "eta_fossil": 0.9,
+            "fossil_ng_share": 0.7,
+            "calcination_emission_factor": 0.525,
+            "ramp_up": 5,
+            "ramp_down": 5,
+        },
+        "kiln": {
+            "max_heat_out": 20,
+            "specific_heat_demand": KILN_HEAT,
+            "specific_electricity_aux": AUX_ELECTRICITY,
+            "fuel_type": "fossil",
+            "eta_fossil": 0.9,
+            "fossil_ng_share": 1,
+            "ramp_up": 20,
+            "ramp_down": 20,
+        },
+    }
+
+
+def make_forecaster(n=24, prices=None, **kwargs):
+    index = pd.date_range("2023-01-01", periods=n, freq="h")
+    return CementForecaster(
+        index,
+        electricity_price=prices if prices is not None else [50] * n,
+        fuel_prices={
+            "natural_gas": [30] * n,
+            "coal": [15] * n,
+            "hydrogen": [80] * n,
+            "co2": [90] * n,
+        },
+        renewable_utilisation_signal=[0.1 * i for i in range(n)],
+        **kwargs,
+    )
+
+
+def make_plant(
+    components,
+    forecaster,
+    flexibility_measure="cost_based_load_shift",
+    demand=100,
+    setup=True,
+    plant_id=None,
+    **kwargs,
+):
+    plant = CementPlant(
+        id=plant_id or f"test_cement_plant_{flexibility_measure}",
+        unit_operator="test_operator",
+        objective="min_variable_cost",
+        flexibility_measure=flexibility_measure,
+        bidding_strategies={
+            "EOM": DsmEnergyOptimizationStrategy(),
+            "RD": DsmEnergyNaiveRedispatchStrategy(),
+        },
+        node="south",
+        components=components,
+        forecaster=forecaster,
+        demand=demand,
+        technology="cement_plant",
+        cost_tolerance=10,
+        congestion_threshold=0.8,
+        peak_load_cap=95,
+        **kwargs,
+    )
+    if setup:
+        plant.setup_model()
+    return plant
+
+
+def solved_instance(plant):
+    """Solve the cost-optimal model and return the solved instance."""
+    instance = plant.model.create_instance()
+    instance = plant.switch_to_opt(instance)
+    plant.solver.solve(instance, tee=False)
+    return instance
+
+
+def interior_runs(status_values):
+    """Maximal runs of equal consecutive values, excluding runs touching either edge.
+
+    Used to check minimum up/down time: a run touching index 0 may have started before
+    the horizon with no ``start_up`` event to anchor it, and a run touching the last
+    index may simply be cut off by the end of the horizon rather than genuinely
+    violating a minimum length. Both are legitimate exclusions, not enforcement gaps -
+    excluding them keeps the check meaningful for the interior of the horizon, where a
+    run is unambiguously bounded by real transitions on both sides.
+    """
+    values = list(status_values)
+    n = len(values)
+    runs = []
+    i = 0
+    while i < n:
+        j = i
+        while j + 1 < n and values[j + 1] == values[i]:
+            j += 1
+        if i > 0 and j < n - 1:
+            runs.append((values[i], i, j))
+        i = j + 1
+    return runs
+
+
+# ---------------------------------------------------------------------------
+# 1. Model structure
+# ---------------------------------------------------------------------------
+
+
+def test_initialize_components(cement_components):
+    plant = make_plant(cement_components, make_forecaster())
+    for block in ("preheater", "calciner", "kiln"):
+        assert block in plant.model.dsm_blocks.keys()
+
+
+def test_unknown_component_is_rejected(cement_components):
+    components = copy.deepcopy(cement_components)
+    components["eaf"] = {"max_power": 10}
+    with pytest.raises(ValueError, match="not a valid component"):
+        make_plant(components, make_forecaster(), setup=False)
+
+
+def test_electrolyser_requires_a_burner():
+    with pytest.raises(ValueError, match="needs a calciner or a kiln"):
+        make_plant(
+            {"electrolyser": {"max_power": 10, "efficiency": 0.7}},
+            make_forecaster(),
+            demand=0,
+            setup=False,
+        )
+
+
+def test_thermal_storage_requires_a_calciner(cement_components):
+    components = copy.deepcopy(cement_components)
+    components.pop("calciner")
+    components["thermal_storage"] = {
+        "capacity": 20,
+        "max_power_charge": 10,
+        "max_power_discharge": 20,
+        "ramp_up": 10,
+        "ramp_down": 10,
+        "initial_soc": 0,
+        "storage_type": "short-term_with_generator",
+    }
+    with pytest.raises(ValueError, match="calciner is required"):
+        make_plant(components, make_forecaster(), setup=False)
+
+
+def test_demand_without_any_output_stage_still_raises():
+    """A demand with no kiln line and no mill at all has nothing to produce it."""
+    with pytest.raises(ValueError, match="requires a calciner"):
+        make_plant(
+            {
+                "preheater": {
+                    "max_heat_out": 10,
+                    "specific_heat_demand": PREHEATER_HEAT,
+                    "fuel_type": "fossil",
+                }
+            },
+            make_forecaster(),
+            demand=100,
+            setup=False,
+        )
+
+
+def test_unsupported_fuel_type_is_rejected(cement_components):
+    components = copy.deepcopy(cement_components)
+    components["kiln"]["fuel_type"] = "biomass"
+    with pytest.raises(ValueError, match="Unsupported fuel_type"):
+        make_plant(components, make_forecaster())
+
+
+# ---------------------------------------------------------------------------
+# 2. Process chain and cost-optimal operation
+# ---------------------------------------------------------------------------
+
+
+def test_process_chain_mass_and_energy_balances(cement_components):
+    """Raw meal, clinker, waste heat and fuel demands are consistent per time step."""
+    demand = 20
+    plant = make_plant(
+        cement_components, make_forecaster(n=8), demand=demand, plant_id="test_chain"
+    )
+    instance = solved_instance(plant)
+
+    total_clinker = 0.0
+    for t in instance.time_steps:
+        preheater = instance.dsm_blocks["preheater"]
+        calciner = instance.dsm_blocks["calciner"]
+        kiln = instance.dsm_blocks["kiln"]
+
+        clinker = pyo.value(kiln.clinker_out[t])
+        total_clinker += clinker
+
+        # Kiln finishes exactly what the calciner calcined
+        assert clinker == pytest.approx(pyo.value(calciner.clinker_out[t]), abs=1e-6)
+        # Raw meal follows the clinker rate through the raw meal ratio
+        assert pyo.value(preheater.raw_meal_out[t]) == pytest.approx(
+            clinker * RAW_MEAL_RATIO, abs=1e-6
+        )
+        # Heat demands of the stages
+        assert pyo.value(kiln.heat_out[t]) == pytest.approx(
+            clinker * KILN_HEAT, abs=1e-6
+        )
+        assert pyo.value(calciner.effective_heat_in[t]) == pytest.approx(
+            clinker * CALCINER_HEAT, abs=1e-6
+        )
+        # Waste heat recovered from the kiln lowers the preheater's own firing
+        recovered = clinker * WASTE_HEAT * WASTE_HEAT_UTILISATION
+        assert pyo.value(preheater.external_heat_in[t]) == pytest.approx(
+            recovered, abs=1e-6
+        )
+        assert pyo.value(preheater.heat_out[t]) == pytest.approx(
+            clinker * RAW_MEAL_RATIO * PREHEATER_HEAT, abs=1e-6
+        )
+        # Fossil fuel covers the heat the stage generates itself
+        assert pyo.value(preheater.fossil_in[t]) * 0.9 == pytest.approx(
+            pyo.value(preheater.heat_out[t]) - recovered, abs=1e-6
+        )
+        # Fossil mix split of the calciner
+        fossil = pyo.value(calciner.fossil_in[t])
+        assert pyo.value(calciner.natural_gas_in[t]) == pytest.approx(
+            0.7 * fossil, abs=1e-6
+        )
+        assert pyo.value(calciner.coal_in[t]) == pytest.approx(0.3 * fossil, abs=1e-6)
+
+    assert total_clinker == pytest.approx(demand, rel=1e-4)
+
+
+def test_preheater_feeds_kiln_directly_without_a_calciner(cement_components):
+    """A single-stage line (preheater + kiln, no calciner) still links raw meal to clinker.
+
+    Without a dedicated precalciner the kiln itself performs the calcination reaction,
+    so the preheater must feed the kiln's raw meal demand directly rather than being
+    left as an unconstrained (and therefore idle) stage.
+    """
+    demand = 20
+    components = {
+        "preheater": copy.deepcopy(cement_components["preheater"]),
+        "kiln": copy.deepcopy(cement_components["kiln"]),
+    }
+    plant = make_plant(
+        components, make_forecaster(n=6), demand=demand, plant_id="test_two_stage"
+    )
+    instance = solved_instance(plant)
+
+    total_clinker = 0.0
+    for t in instance.time_steps:
+        preheater = instance.dsm_blocks["preheater"]
+        kiln = instance.dsm_blocks["kiln"]
+        clinker = pyo.value(kiln.clinker_out[t])
+        total_clinker += clinker
+
+        assert pyo.value(preheater.raw_meal_out[t]) == pytest.approx(
+            clinker * RAW_MEAL_RATIO, abs=1e-6
+        )
+        # The kiln is present here too, so waste heat recovery still applies.
+        recovered = clinker * WASTE_HEAT * WASTE_HEAT_UTILISATION
+        assert pyo.value(preheater.external_heat_in[t]) == pytest.approx(
+            recovered, abs=1e-6
+        )
+
+    assert total_clinker == pytest.approx(demand, rel=1e-4)
+
+
+def test_fossil_line_load_is_auxiliary_electricity_only(cement_components):
+    """With fossil firing the plant load is the auxiliary electricity of the stages."""
+    demand = 20
+    plant = make_plant(
+        cement_components, make_forecaster(n=8), demand=demand, plant_id="test_aux_load"
+    )
+    plant.determine_optimal_operation_without_flex()
+
+    assert isinstance(plant.opt_power_requirement, FastSeries)
+    assert sum(plant.opt_power_requirement.data) == pytest.approx(
+        demand * AUX_PER_TONNE_CLINKER, rel=1e-4
+    )
+
+
+def test_process_emissions_are_priced(cement_components):
+    """Calcination CO2 is charged on top of the energy emissions."""
+    demand = 20
+    plant = make_plant(
+        cement_components, make_forecaster(n=4), demand=demand, plant_id="test_co2"
+    )
+    instance = solved_instance(plant)
+
+    process_co2 = sum(
+        pyo.value(instance.dsm_blocks["calciner"].co2_process[t])
+        for t in instance.time_steps
+    )
+    assert process_co2 == pytest.approx(demand * 0.525, rel=1e-4)
+
+
+def test_electric_calciner_shifts_load_to_cheap_hours(cement_components):
+    """An electrically heated calciner concentrates its load in the cheap hours."""
+    n = 8
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    components["calciner"]["eta_electric"] = 0.95
+    prices = [200.0] * 4 + [10.0] * 4
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=prices),
+        demand=20,
+        plant_id="test_electric_calciner",
+    )
+    plant.determine_optimal_operation_without_flex()
+
+    opt_power = plant.opt_power_requirement
+    assert sum(opt_power.data[4:]) > sum(opt_power.data[:4])
+
+    instance = solved_instance(plant)
+    for t in instance.time_steps:
+        calciner = instance.dsm_blocks["calciner"]
+        # The electric heating path covers the whole calciner heat demand
+        assert pyo.value(calciner.power_in[t]) * 0.95 == pytest.approx(
+            pyo.value(calciner.heat_out[t]), abs=1e-6
+        )
+        assert pyo.value(calciner.fossil_in[t]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_hydrogen_fired_kiln_with_electrolyser(cement_components):
+    """Hydrogen from the electrolyser covers the burner demand it is routed to."""
+    n = 4
+    components = copy.deepcopy(cement_components)
+    components["kiln"]["fuel_type"] = "hydrogen"
+    components["electrolyser"] = {
+        "max_power": 200,
+        "min_power": 0,
+        "efficiency": 0.7,
+        "ramp_up": 200,
+        "ramp_down": 200,
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=10, plant_id="test_h2_kiln"
+    )
+    instance = solved_instance(plant)
+
+    for t in instance.time_steps:
+        kiln = instance.dsm_blocks["kiln"]
+        electrolyser = instance.dsm_blocks["electrolyser"]
+        assert pyo.value(kiln.hydrogen_in[t]) == pytest.approx(
+            pyo.value(instance.h2_to_calciner[t] * 0 + instance.h2_to_kiln[t]), abs=1e-6
+        )
+        # All hydrogen produced is either routed to a burner or explicitly unused
+        assert pyo.value(electrolyser.hydrogen_out[t]) == pytest.approx(
+            pyo.value(
+                instance.h2_to_calciner[t]
+                + instance.h2_to_kiln[t]
+                + instance.h2_unutilised[t]
+            ),
+            abs=1e-6,
+        )
+        # Hydrogen fires the kiln, so it draws no fossil fuel
+        assert pyo.value(kiln.fossil_in[t]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_electric_thermal_storage_displaces_burner_heat(cement_components):
+    """The E-TES charges in cheap hours and covers calciner heat in expensive ones."""
+    n = 6
+    components = copy.deepcopy(cement_components)
+    components["thermal_storage"] = {
+        "capacity": 20,
+        "max_power_charge": 10,
+        "max_power_discharge": 20,
+        "ramp_up": 10,
+        "ramp_down": 10,
+        "initial_soc": 0,
+        "storage_type": "short-term_with_generator",
+        "eta_electric": 0.97,
+    }
+    # Cheap power in the first half, very expensive gas throughout
+    prices = [1.0, 1.0, 1.0, 300.0, 300.0, 300.0]
+    forecaster = CementForecaster(
+        pd.date_range("2023-01-01", periods=n, freq="h"),
+        electricity_price=prices,
+        fuel_prices={
+            "natural_gas": [500] * n,
+            "coal": [500] * n,
+            "hydrogen": [500] * n,
+            "co2": [10] * n,
+        },
+    )
+    plant = make_plant(
+        components, forecaster, demand=6, plant_id="test_etes", setup=True
+    )
+    instance = solved_instance(plant)
+
+    storage = instance.dsm_blocks["thermal_storage"]
+    charge_power = [pyo.value(storage.power_in[t]) for t in instance.time_steps]
+    discharge = [pyo.value(storage.discharge[t]) for t in instance.time_steps]
+
+    # The heater ran, and it ran in the cheap hours
+    assert sum(charge_power) > 0
+    assert sum(charge_power[:3]) > sum(charge_power[3:])
+    # Discharged heat reached the calciner
+    for t in instance.time_steps:
+        assert pyo.value(
+            instance.dsm_blocks["calciner"].effective_heat_in[t]
+        ) == pytest.approx(
+            pyo.value(instance.dsm_blocks["calciner"].heat_out[t]) + discharge[t],
+            abs=1e-6,
+        )
+    # Charging is the electric heat the power draw produced
+    for t in instance.time_steps:
+        assert pyo.value(storage.charge[t]) == pytest.approx(
+            charge_power[t] * 0.97, abs=1e-6
+        )
+
+
+def test_cement_mill_grinds_the_clinker(cement_components):
+    """The cement mill load follows the clinker the line produces."""
+    n = 4
+    demand = 20
+    components = copy.deepcopy(cement_components)
+    components["cement_mill"] = {
+        "max_power": 25,
+        "min_power": 0,
+        "efficiency": 1.0,
+        "specific_electricity_consumption": 0.04,
+        "ramp_up": 25,
+        "ramp_down": 25,
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=demand, plant_id="test_cement_mill"
+    )
+    instance = solved_instance(plant)
+
+    for t in instance.time_steps:
+        assert pyo.value(
+            instance.dsm_blocks["cement_mill"].material_input[t]
+        ) == pytest.approx(pyo.value(instance.clinker_rate[t]), abs=1e-6)
+
+    total_power = sum(
+        pyo.value(instance.total_power_input[t]) for t in instance.time_steps
+    )
+    expected = demand * (AUX_PER_TONNE_CLINKER + 0.04)
+    assert total_power == pytest.approx(expected, rel=1e-4)
+
+
+def test_per_timestep_demand_constraint_is_enforced(cement_components):
+    """Hourly minimum clinker production from the forecaster is respected."""
+    n = 4
+    per_hour_min = [2.0, 4.0, 6.0, 1.0]
+    forecaster = make_forecaster(
+        n=n, prices=[500.0, 500.0, 10.0, 10.0], clinker_demand=per_hour_min
+    )
+    plant = make_plant(
+        cement_components, forecaster, demand=0, plant_id="test_per_timestep"
+    )
+
+    # The global equality constraint must give way to the per-hour minimums
+    assert not hasattr(plant.model, "clinker_output_association_constraint")
+    assert hasattr(plant.model, "clinker_demand_per_timestep_constraint")
+
+    instance = solved_instance(plant)
+    for t, minimum in enumerate(per_hour_min):
+        assert pyo.value(instance.clinker_rate[t]) >= minimum - 1e-6
+
+
+def test_availability_profile_blocks_a_stage(cement_components):
+    """A zero availability of the kiln forbids clinker burning in those hours."""
+    n = 8
+    availability = [1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0]
+    forecaster = make_forecaster(n=n, availability_profiles={"kiln": availability})
+    plant = make_plant(
+        cement_components, forecaster, demand=20, plant_id="test_availability"
+    )
+    instance = solved_instance(plant)
+
+    for t, available in enumerate(availability):
+        if available == 0:
+            assert pyo.value(instance.dsm_blocks["kiln"].heat_out[t]) == pytest.approx(
+                0.0, abs=1e-6
+            )
+
+
+def test_minimum_heat_output_adds_unit_commitment(cement_components):
+    """A minimum thermal output turns a stage into a unit-commitment block."""
+    components = copy.deepcopy(cement_components)
+    components["kiln"]["min_heat_out"] = 4
+    plant = make_plant(
+        components, make_forecaster(n=6), demand=20, plant_id="test_min_heat"
+    )
+    assert hasattr(plant.model.dsm_blocks["kiln"], "operational_status")
+
+    instance = solved_instance(plant)
+    for t in instance.time_steps:
+        heat = pyo.value(instance.dsm_blocks["kiln"].heat_out[t])
+        assert heat <= 1e-6 or heat >= 4 - 1e-6
+
+
+# ---------------------------------------------------------------------------
+# 2b. Standalone grinding mill operation
+# ---------------------------------------------------------------------------
+
+
+def test_raw_material_mill_is_a_valid_component(cement_components):
+    """raw_material_mill is accepted as a component, not rejected as unknown."""
+    components = copy.deepcopy(cement_components)
+    components["raw_material_mill"] = {
+        "max_power": 15,
+        "min_power": 0,
+        "efficiency": 1.0,
+        "specific_electricity_consumption": 0.02,
+        "ramp_up": 15,
+        "ramp_down": 15,
+    }
+    plant = make_plant(
+        components, make_forecaster(n=4), demand=20, plant_id="test_raw_mill_valid"
+    )
+    assert "raw_material_mill" in plant.model.dsm_blocks.keys()
+
+
+def test_standalone_cement_mill_meets_its_own_demand():
+    """A cement mill with no kiln line grinds directly to meet the declared demand."""
+    n = 4
+    demand = 20
+    components = {
+        "cement_mill": {
+            "max_power": 25,
+            "min_power": 0,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 0.04,
+            "ramp_up": 25,
+            "ramp_down": 25,
+        }
+    }
+    plant = make_plant(
+        components,
+        make_forecaster(n=n),
+        demand=demand,
+        plant_id="test_standalone_cement_mill",
+    )
+    instance = solved_instance(plant)
+
+    total_output = sum(
+        pyo.value(instance.dsm_blocks["cement_mill"].material_output[t])
+        for t in instance.time_steps
+    )
+    assert total_output == pytest.approx(demand, rel=1e-4)
+    for t in instance.time_steps:
+        assert pyo.value(instance.clinker_rate[t]) == pytest.approx(
+            pyo.value(instance.dsm_blocks["cement_mill"].material_output[t]), abs=1e-6
+        )
+
+
+def test_standalone_raw_material_mill_meets_its_own_demand():
+    """A raw material mill with no kiln line grinds directly to meet the declared demand."""
+    n = 4
+    demand = 30
+    components = {
+        "raw_material_mill": {
+            "max_power": 15,
+            "min_power": 0,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 0.02,
+            "ramp_up": 15,
+            "ramp_down": 15,
+        }
+    }
+    plant = make_plant(
+        components,
+        make_forecaster(n=n),
+        demand=demand,
+        plant_id="test_standalone_raw_mill",
+    )
+    instance = solved_instance(plant)
+
+    total_output = sum(
+        pyo.value(instance.dsm_blocks["raw_material_mill"].material_output[t])
+        for t in instance.time_steps
+    )
+    assert total_output == pytest.approx(demand, rel=1e-4)
+
+
+def test_kiln_line_demand_ignores_a_present_but_unconnected_mill(cement_components):
+    """Demand still targets clinker when a kiln line exists, even with a mill present.
+
+    The mill is not wired into the process chain, so it stays idle - nothing requires
+    or rewards running it.
+    """
+    n = 4
+    demand = 20
+    components = copy.deepcopy(cement_components)
+    components["raw_material_mill"] = {
+        "max_power": 15,
+        "min_power": 0,
+        "efficiency": 1.0,
+        "specific_electricity_consumption": 0.02,
+        "ramp_up": 15,
+        "ramp_down": 15,
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=demand, plant_id="test_kiln_plus_mill"
+    )
+    instance = solved_instance(plant)
+
+    for t in instance.time_steps:
+        assert pyo.value(instance.clinker_rate[t]) == pytest.approx(
+            pyo.value(instance.dsm_blocks["kiln"].clinker_out[t]), abs=1e-6
+        )
+        assert pyo.value(
+            instance.dsm_blocks["raw_material_mill"].material_output[t]
+        ) == pytest.approx(0.0, abs=1e-6)
+
+    total_clinker = sum(
+        pyo.value(instance.clinker_rate[t]) for t in instance.time_steps
+    )
+    assert total_clinker == pytest.approx(demand, rel=1e-4)
+
+
+def test_cement_mill_takes_priority_over_raw_material_mill_when_standalone():
+    """With both mills and no kiln line, demand targets the cement mill."""
+    n = 4
+    demand = 20
+    components = {
+        "cement_mill": {
+            "max_power": 25,
+            "min_power": 0,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 0.04,
+            "ramp_up": 25,
+            "ramp_down": 25,
+        },
+        "raw_material_mill": {
+            "max_power": 15,
+            "min_power": 0,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 0.02,
+            "ramp_up": 15,
+            "ramp_down": 15,
+        },
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=demand, plant_id="test_mill_priority"
+    )
+    assert plant._standalone_output_stage == "cement_mill"
+    instance = solved_instance(plant)
+
+    total_cement = sum(
+        pyo.value(instance.dsm_blocks["cement_mill"].material_output[t])
+        for t in instance.time_steps
+    )
+    assert total_cement == pytest.approx(demand, rel=1e-4)
+    for t in instance.time_steps:
+        assert pyo.value(
+            instance.dsm_blocks["raw_material_mill"].material_output[t]
+        ) == pytest.approx(0.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 2c. Exact / rigorous verification
+#
+# These tests avoid loose aggregate checks in favour of two stricter techniques:
+#   (a) forcing a *unique* optimum by construction (e.g. demand exactly equal to the
+#       maximum output achievable under a binding ramp limit), so the solved schedule
+#       can be compared to a hand-computed value at every time step, not just in total;
+#   (b) reconstructing a constraint's right-hand side from the solved values of its own
+#       inputs (efficiencies, prices, ratios) and checking it against the solved
+#       left-hand side exactly, which catches wiring bugs (wrong sign, wrong ratio,
+#       double-counted term) that a loose "some flexibility happened" check would miss.
+# ---------------------------------------------------------------------------
+
+
+def test_ramp_up_exactly_determines_a_forced_startup_trajectory():
+    """A demand equal to the ramp-limited maximum pins down a unique optimal schedule.
+
+    Standalone kiln, electric, eta_electric=1 and specific_heat_demand=1 so clinker_out
+    equals heat_out exactly. With ramp_up=5 and max_heat_out=20, the largest total
+    achievable over 6 hours starting from zero is 5+10+15+20+20+20=90 - and that total
+    is achievable in exactly one way. Setting demand=90 therefore leaves the solver no
+    freedom at all: the hourly schedule must match that trajectory exactly, regardless
+    of price (there is only one feasible point at the demand-equality boundary).
+    """
+    n = 6
+    components = {
+        "kiln": {
+            "max_heat_out": 20,
+            "specific_heat_demand": 1.0,
+            "fuel_type": "electricity",
+            "eta_electric": 1.0,
+            "ramp_up": 5,
+            "ramp_down": 20,
+            "initial_operational_status": 1,
+        }
+    }
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 10, 80, 10, 80, 10]),
+        demand=90,
+        plant_id="test_ramp_up_exact",
+    )
+    instance = solved_instance(plant)
+
+    expected = [5, 10, 15, 20, 20, 20]
+    actual = [pyo.value(instance.dsm_blocks["kiln"].heat_out[t]) for t in range(n)]
+    assert actual == pytest.approx(expected, abs=1e-5)
+    clinker = [pyo.value(instance.clinker_rate[t]) for t in range(n)]
+    assert clinker == pytest.approx(expected, abs=1e-5)
+
+
+def test_ramp_down_exactly_determines_a_forced_shutdown_trajectory():
+    """A steeply descending per-hour floor pins down a unique optimal schedule too.
+
+    Same standalone electric kiln, with ramp_down=5 the binding limit for decreases and
+    ramp_up=20 (== max) never limiting increases (nor the first step - ramp_down does
+    not apply there either, since there is no previous value to decrease from). The
+    first three hours sit flat at the plateau their floor demands; from hour 3 the
+    cheapest feasible choice is to shed exactly ramp_down per hour until the floor is
+    reached, giving the unique trajectory [20, 20, 20, 15, 10, 5].
+    """
+    n = 6
+    components = {
+        "kiln": {
+            "max_heat_out": 20,
+            "specific_heat_demand": 1.0,
+            "fuel_type": "electricity",
+            "eta_electric": 1.0,
+            "ramp_up": 20,
+            "ramp_down": 5,
+            "initial_operational_status": 1,
+        }
+    }
+    per_hour_min = [20.0, 20.0, 20.0, 15.0, 10.0, 5.0]
+    forecaster = make_forecaster(n=n, prices=[50] * n, clinker_demand=per_hour_min)
+    plant = make_plant(
+        components, forecaster, demand=0, plant_id="test_ramp_down_exact"
+    )
+    instance = solved_instance(plant)
+
+    expected = [20, 20, 20, 15, 10, 5]
+    actual = [pyo.value(instance.dsm_blocks["kiln"].heat_out[t]) for t in range(n)]
+    assert actual == pytest.approx(expected, abs=1e-5)
+
+
+def test_min_operating_and_down_steps_prevent_rapid_switching_on_a_thermal_stage():
+    """Alternating prices create constant pressure to switch; the run-length floor must hold.
+
+    A kiln with min_operating_steps=3 and min_down_steps=2, under a price that flips
+    cheap/expensive every hour, would - if the constraint did nothing - want to turn on
+    and off every other hour to chase the cheap ones. A per-horizon demand forces it to
+    run somewhere. The first hour is deliberately made expensive so the optimal on-block
+    does not start at t=0, where the shared min-up-time formulation has a known
+    horizon-boundary exemption (a start-up at the very first step predates the earliest
+    constraint window) - this test is about the steady-state mechanism, not that edge.
+    """
+    n = 12
+    components = {
+        "kiln": {
+            "max_heat_out": 10,
+            "min_heat_out": 3,
+            "specific_heat_demand": 1.0,
+            "fuel_type": "electricity",
+            "eta_electric": 1.0,
+            "ramp_up": 10,
+            "ramp_down": 10,
+            "min_operating_steps": 3,
+            "min_down_steps": 2,
+            "initial_operational_status": 0,
+        }
+    }
+    prices = [200, 10, 200, 10, 200, 10, 200, 10, 200, 10, 200, 10]
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=prices),
+        demand=30,
+        plant_id="test_min_up_down_kiln",
+    )
+    assert hasattr(plant.model.dsm_blocks["kiln"], "operational_status")
+    instance = solved_instance(plant)
+
+    status = [
+        round(pyo.value(instance.dsm_blocks["kiln"].operational_status[t]))
+        for t in range(n)
+    ]
+    for value, start, end in interior_runs(status):
+        run_length = end - start + 1
+        if value == 1:
+            assert run_length >= 3, (
+                f"on-run {start}-{end} shorter than min_operating_steps"
+            )
+        else:
+            assert run_length >= 2, f"off-run {start}-{end} shorter than min_down_steps"
+
+    total_clinker = sum(pyo.value(instance.clinker_rate[t]) for t in range(n))
+    assert total_clinker == pytest.approx(30, rel=1e-4)
+
+
+def test_min_operating_and_down_steps_prevent_rapid_switching_on_a_standalone_mill():
+    """Same run-length check, but for GrindingMill's own unit-commitment path.
+
+    min_power > 0 is what turns a GrindingMill into a unit-commitment block; this
+    exercises that path directly (no cement plant test did before), independent of the
+    thermal-stage formulation exercised above.
+    """
+    n = 12
+    components = {
+        "cement_mill": {
+            "max_power": 25,
+            "min_power": 5,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 1.0,
+            "ramp_up": 25,
+            "ramp_down": 25,
+            "min_operating_steps": 3,
+            "min_down_steps": 2,
+            "initial_operational_status": 0,
+        }
+    }
+    prices = [200, 10, 200, 10, 200, 10, 200, 10, 200, 10, 200, 10]
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=prices),
+        demand=60,
+        plant_id="test_min_up_down_mill",
+    )
+    assert hasattr(plant.model.dsm_blocks["cement_mill"], "operational_status")
+    instance = solved_instance(plant)
+
+    status = [
+        round(pyo.value(instance.dsm_blocks["cement_mill"].operational_status[t]))
+        for t in range(n)
+    ]
+    for value, start, end in interior_runs(status):
+        run_length = end - start + 1
+        if value == 1:
+            assert run_length >= 3, (
+                f"on-run {start}-{end} shorter than min_operating_steps"
+            )
+        else:
+            assert run_length >= 2, f"off-run {start}-{end} shorter than min_down_steps"
+
+
+def test_grinding_mill_efficiency_below_one_creates_a_real_mass_loss():
+    """With efficiency < 1, material_input must exceed material_output at every step.
+
+    Every existing mill test uses efficiency=1.0 (no mass loss), which never exercises
+    the ``material_input == material_output / efficiency`` relation for efficiency < 1.
+    """
+    n = 4
+    demand = 20
+    components = {
+        "cement_mill": {
+            "max_power": 25,
+            "min_power": 0,
+            "efficiency": 0.8,
+            "specific_electricity_consumption": 0.04,
+            "ramp_up": 25,
+            "ramp_down": 25,
+        }
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=demand, plant_id="test_mill_efficiency"
+    )
+    instance = solved_instance(plant)
+
+    mill = instance.dsm_blocks["cement_mill"]
+    for t in instance.time_steps:
+        output = pyo.value(mill.material_output[t])
+        assert pyo.value(mill.material_input[t]) == pytest.approx(
+            output / 0.8, rel=1e-6
+        )
+        if output > 1e-6:
+            assert pyo.value(mill.material_input[t]) > output + 1e-6
+
+    total_output = sum(pyo.value(mill.material_output[t]) for t in instance.time_steps)
+    assert total_output == pytest.approx(demand, rel=1e-4)
+
+
+def test_dual_hydrogen_burners_share_one_electrolyser_exactly():
+    """Calciner and kiln both hydrogen-fired, fed by a single electrolyser.
+
+    Verifies the full split - electrolyser production, the two burner draws, and the
+    unused slack - balances exactly, and that each burner's own hydrogen_in exactly
+    matches the routed amount, not just in aggregate.
+    """
+    n = 4
+    components = {
+        "calciner": {
+            "max_heat_out": 5,
+            "specific_heat_demand": 0.7,
+            "fuel_type": "hydrogen",
+            "eta_fossil": 0.9,
+            "calcination_emission_factor": 0.525,
+            "ramp_up": 5,
+            "ramp_down": 5,
+        },
+        "kiln": {
+            "max_heat_out": 20,
+            "specific_heat_demand": 1.7,
+            "fuel_type": "hydrogen",
+            "eta_fossil": 0.9,
+            "ramp_up": 20,
+            "ramp_down": 20,
+        },
+        "electrolyser": {
+            "max_power": 30,
+            "min_power": 0,
+            "efficiency": 0.7,
+            "ramp_up": 30,
+            "ramp_down": 30,
+        },
+    }
+    plant = make_plant(
+        components, make_forecaster(n=n), demand=10, plant_id="test_dual_h2"
+    )
+    instance = solved_instance(plant)
+
+    calciner = instance.dsm_blocks["calciner"]
+    kiln = instance.dsm_blocks["kiln"]
+    electrolyser = instance.dsm_blocks["electrolyser"]
+
+    for t in instance.time_steps:
+        h2_to_calciner = pyo.value(instance.h2_to_calciner[t])
+        h2_to_kiln = pyo.value(instance.h2_to_kiln[t])
+        h2_unutilised = pyo.value(instance.h2_unutilised[t])
+
+        assert pyo.value(calciner.hydrogen_in[t]) == pytest.approx(
+            h2_to_calciner, abs=1e-6
+        )
+        assert pyo.value(kiln.hydrogen_in[t]) == pytest.approx(h2_to_kiln, abs=1e-6)
+        assert pyo.value(electrolyser.hydrogen_out[t]) == pytest.approx(
+            h2_to_calciner + h2_to_kiln + h2_unutilised, abs=1e-6
+        )
+        assert pyo.value(electrolyser.hydrogen_out[t]) == pytest.approx(
+            pyo.value(electrolyser.power_in[t]) * 0.7, abs=1e-6
+        )
+        # Neither burner draws any fossil fuel while hydrogen-fired
+        assert pyo.value(calciner.fossil_in[t]) == pytest.approx(0.0, abs=1e-6)
+        assert pyo.value(kiln.fossil_in[t]) == pytest.approx(0.0, abs=1e-6)
+
+
+def test_thermal_storage_soc_balance_matches_the_exact_formula():
+    """Reconstruct soc[t] from the solved charge/discharge/efficiency values and compare.
+
+    Uses non-default efficiencies (efficiency_charge=0.9, efficiency_discharge=0.95,
+    storage_loss_rate=0.02) and an electric heater (eta_electric=0.97) that every prior
+    storage test left at their lossless defaults, so this is the first test to actually
+    exercise the loss terms in ``soc_balance_rule`` and ``electric_heater_charge``.
+    """
+    n = 6
+    components = {
+        "calciner": {
+            "max_heat_out": 5,
+            "specific_heat_demand": 0.7,
+            "fuel_type": "fossil",
+            "eta_fossil": 0.9,
+            "fossil_ng_share": 0.7,
+            "calcination_emission_factor": 0.525,
+            "ramp_up": 5,
+            "ramp_down": 5,
+        },
+        "thermal_storage": {
+            "capacity": 20,
+            "max_power_charge": 10,
+            "max_power_discharge": 20,
+            "ramp_up": 10,
+            "ramp_down": 20,
+            "initial_soc": 0.2,
+            "storage_type": "short-term_with_generator",
+            "eta_electric": 0.97,
+            "efficiency_charge": 0.9,
+            "efficiency_discharge": 0.95,
+            "storage_loss_rate": 0.02,
+        },
+    }
+    # Cheap power early to encourage charging, expensive gas throughout to encourage
+    # later discharging - gives the storage a reason to actually cycle.
+    prices = [5, 5, 5, 300, 300, 300]
+    forecaster = CementForecaster(
+        pd.date_range("2023-01-01", periods=n, freq="h"),
+        electricity_price=prices,
+        fuel_prices={
+            "natural_gas": [500] * n,
+            "coal": [500] * n,
+            "hydrogen": [500] * n,
+            "co2": [10] * n,
+        },
+    )
+    plant = make_plant(
+        components, forecaster, demand=6, plant_id="test_storage_formula"
+    )
+    instance = solved_instance(plant)
+
+    storage = instance.dsm_blocks["thermal_storage"]
+    capacity = 20.0
+    prev_soc_fraction = 0.2
+    for t in instance.time_steps:
+        power_in = pyo.value(storage.power_in[t])
+        charge = pyo.value(storage.charge[t])
+        discharge = pyo.value(storage.discharge[t])
+        soc = pyo.value(storage.soc[t])
+
+        # The electric heater's own conversion efficiency
+        assert charge == pytest.approx(power_in * 0.97, abs=1e-6)
+
+        prev_soc_abs = prev_soc_fraction * capacity
+        expected_soc = (
+            prev_soc_abs + 0.9 * charge - (1 / 0.95) * discharge - 0.02 * prev_soc_abs
+        )
+        assert soc == pytest.approx(expected_soc, abs=1e-5)
+        prev_soc_fraction = soc / capacity
+
+    # The storage actually cycled (charged in the cheap hours), not just sat idle
+    total_charge = sum(pyo.value(storage.charge[t]) for t in instance.time_steps)
+    assert total_charge > 1e-3
+
+
+def test_full_plant_golden_integration(cement_components):
+    """Every configured stage together: cross-check every link at every time step.
+
+    Isolated tests elsewhere verify each formula individually; this test's job is to
+    catch *interaction* bugs - e.g. cement_mill wiring breaking waste-heat recovery
+    indexing, or thermal storage double-counting into the calciner's heat balance -
+    that only show up when every optional component is present simultaneously.
+    """
+    n = 6
+    demand = 15
+    components = copy.deepcopy(cement_components)
+    components["thermal_storage"] = {
+        "capacity": 20,
+        "max_power_charge": 10,
+        "max_power_discharge": 20,
+        "ramp_up": 10,
+        "ramp_down": 20,
+        "initial_soc": 0,
+        "storage_type": "short-term_with_generator",
+        "eta_electric": 0.97,
+    }
+    components["cement_mill"] = {
+        "max_power": 25,
+        "min_power": 0,
+        "efficiency": 0.95,
+        "specific_electricity_consumption": 0.04,
+        "ramp_up": 25,
+        "ramp_down": 25,
+    }
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 60, 40, 20, 60, 80]),
+        demand=demand,
+        plant_id="test_golden",
+    )
+    instance = solved_instance(plant)
+
+    preheater = instance.dsm_blocks["preheater"]
+    calciner = instance.dsm_blocks["calciner"]
+    kiln = instance.dsm_blocks["kiln"]
+    storage = instance.dsm_blocks["thermal_storage"]
+    mill = instance.dsm_blocks["cement_mill"]
+
+    total_clinker = 0.0
+    for t in instance.time_steps:
+        clinker = pyo.value(kiln.clinker_out[t])
+        total_clinker += clinker
+
+        # Raw meal -> calciner -> kiln mass chain
+        assert pyo.value(calciner.clinker_out[t]) == pytest.approx(clinker, abs=1e-6)
+        assert pyo.value(preheater.raw_meal_out[t]) == pytest.approx(
+            clinker * RAW_MEAL_RATIO, abs=1e-6
+        )
+
+        # Waste heat recovery
+        recovered = clinker * WASTE_HEAT * WASTE_HEAT_UTILISATION
+        assert pyo.value(preheater.external_heat_in[t]) == pytest.approx(
+            recovered, abs=1e-6
+        )
+
+        # Calciner heat balance including the thermal storage. The storage is in
+        # "short-term_with_generator" mode, so it is charged from grid power (via
+        # power_in), not from the calciner's own burner heat - effective_heat_in
+        # therefore only adds the discharge, it does not subtract the charge.
+        discharge = pyo.value(storage.discharge[t])
+        assert pyo.value(calciner.effective_heat_in[t]) == pytest.approx(
+            pyo.value(calciner.heat_out[t]) + discharge, abs=1e-6
+        )
+
+        # Cement mill grinds exactly the clinker produced
+        assert pyo.value(mill.material_input[t]) == pytest.approx(clinker, abs=1e-6)
+        assert pyo.value(mill.material_output[t]) == pytest.approx(
+            clinker * 0.95, abs=1e-6
+        )
+
+        # Plant-level totals reconstructed from the components, independently of the
+        # constraints that are supposed to enforce them
+        expected_power = sum(
+            pyo.value(getattr(block, "power_in")[t])
+            for block in (preheater, calciner, kiln, storage, mill)
+        ) + sum(
+            pyo.value(getattr(block, "aux_power")[t])
+            for block in (preheater, calciner, kiln)
+        )
+        assert pyo.value(instance.total_power_input[t]) == pytest.approx(
+            expected_power, abs=1e-6
+        )
+
+        expected_cost = sum(
+            pyo.value(getattr(block, "operating_cost")[t])
+            for block in (preheater, calciner, kiln, storage, mill)
+        )
+        assert pyo.value(instance.variable_cost[t]) == pytest.approx(
+            expected_cost, abs=1e-6
+        )
+
+    assert total_clinker == pytest.approx(demand, rel=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# 3. Flexibility measures
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "flexibility_measure",
+    [
+        "cost_based_load_shift",
+        "congestion_management_flexibility",
+        "peak_load_shifting",
+        "renewable_utilisation",
+        "electricity_price_signal",
+    ],
+)
+def test_flexibility_measures_produce_a_flex_profile(
+    cement_components, flexibility_measure
+):
+    n = 6
+    components = copy.deepcopy(cement_components)
+    # An electric calciner gives the plant something to shift
+    components["calciner"]["fuel_type"] = "electricity"
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 60, 40, 20, 60, 80]),
+        flexibility_measure=flexibility_measure,
+        demand=20,
+        plant_id=f"test_flex_{flexibility_measure}",
+    )
+    plant.determine_optimal_operation_with_flex()
+
+    assert isinstance(plant.flex_power_requirement, FastSeries)
+    assert len(plant.flex_power_requirement) == n
+
+
+def test_peak_load_shifting_respects_the_peak_cap(cement_components):
+    n = 6
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 60, 40, 20, 60, 80]),
+        flexibility_measure="peak_load_shifting",
+        demand=20,
+        plant_id="test_peak_cap",
+    )
+    plant.determine_optimal_operation_with_flex()
+
+    instance = plant.model.create_instance()
+    instance = plant.switch_to_flex(instance)
+    plant.solver.solve(instance, tee=False)
+
+    cap = pyo.value(instance.peak_load_cap_value)
+    for t in instance.time_steps:
+        component_power = sum(
+            pyo.value(instance.dsm_blocks[block].power_in[t])
+            for block in instance.dsm_blocks
+            if hasattr(instance.dsm_blocks[block], "power_in")
+        ) + sum(
+            pyo.value(instance.dsm_blocks[block].aux_power[t])
+            for block in instance.dsm_blocks
+            if hasattr(instance.dsm_blocks[block], "aux_power")
+        )
+        assert component_power <= cap + 1e-4
+
+
+def test_peak_load_shifting_actually_lowers_a_former_peak_hour(cement_components):
+    """Not just "respects the cap" - the peak hour's dispatch must genuinely change.
+
+    Compares the flex dispatch against the unconstrained optimum directly: at least one
+    hour that exceeded the cap before flexibility was applied must be strictly below its
+    own former value after, proving the constraint is doing real work rather than
+    being vacuously satisfied because nothing ever exceeded the cap to begin with.
+    """
+    n = 6
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 60, 40, 20, 200, 80]),
+        flexibility_measure="peak_load_shifting",
+        demand=20,
+        plant_id="test_peak_shift_moves",
+    )
+    plant.determine_optimal_operation_without_flex()
+    baseline = [plant.opt_power_requirement.iloc[t] for t in range(n)]
+    cap = max(baseline) * (plant.peak_load_cap / 100)
+    former_peaks = [t for t, v in enumerate(baseline) if v > cap]
+    assert former_peaks, (
+        "test setup must actually produce a peak hour to shift away from"
+    )
+
+    plant.determine_optimal_operation_with_flex()
+    instance = plant.model.create_instance()
+    instance = plant.switch_to_flex(instance)
+    plant.solver.solve(instance, tee=False)
+
+    def component_power(t):
+        return sum(
+            pyo.value(instance.dsm_blocks[block].power_in[t])
+            for block in instance.dsm_blocks
+            if hasattr(instance.dsm_blocks[block], "power_in")
+        ) + sum(
+            pyo.value(instance.dsm_blocks[block].aux_power[t])
+            for block in instance.dsm_blocks
+            if hasattr(instance.dsm_blocks[block], "aux_power")
+        )
+
+    for t in former_peaks:
+        assert component_power(t) < baseline[t] - 1e-6
+        assert component_power(t) <= cap + 1e-4
+
+    # Total clinker demand is still met - the flexibility redistributes hours, it
+    # does not shrink production.
+    total_clinker = sum(pyo.value(instance.clinker_rate[t]) for t in range(n))
+    assert total_clinker == pytest.approx(20, rel=1e-3)
+
+
+def test_cost_based_load_shift_stays_within_the_exact_declared_tolerance(
+    cement_components,
+):
+    """The flex-solve's actual cost must respect the numeric tolerance exactly.
+
+    Computes the no-flex optimal cost precisely (``plant.total_cost``, the same value
+    the model itself uses as the tolerance's baseline), then checks the flex-solve's
+    realised cost against that exact number and the exact configured cost_tolerance -
+    not just "some tolerance was probably respected".
+    """
+    n = 6
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    tolerance = 10  # matches make_plant's own default cost_tolerance
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=[80, 60, 40, 20, 60, 80]),
+        flexibility_measure="cost_based_load_shift",
+        demand=20,
+        plant_id="test_cost_tolerance_exact",
+    )
+    plant.determine_optimal_operation_without_flex()
+    cost_opt = sum(plant.variable_cost_series.data)
+    assert plant.total_cost == pytest.approx(cost_opt, rel=1e-9)
+
+    plant.determine_optimal_operation_with_flex()
+    cost_flex = sum(plant.flex_variable_cost_series.data)
+
+    assert cost_flex <= cost_opt * (1 + tolerance / 100) + 1e-6
+
+
+# ---------------------------------------------------------------------------
+# 4. Rolling horizon
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def rh_config():
+    """Minimal rolling-horizon config: 4h look-ahead, 2h commit, 2h step."""
+    return {
+        "horizon_mode": "rolling_horizon",
+        "look_ahead_horizon": "4h",
+        "commit_horizon": "2h",
+        "rolling_step": "2h",
+    }
+
+
+def test_default_horizon_mode_is_full_horizon(cement_components):
+    plant = make_plant(cement_components, make_forecaster(n=6), setup=False)
+    assert plant.horizon_mode == "full_horizon"
+
+
+def test_rolling_horizon_config_is_parsed(cement_components, rh_config):
+    plant = make_plant(
+        cement_components,
+        make_forecaster(n=6),
+        setup=False,
+        dsm_optimisation_config=rh_config,
+    )
+    assert plant.horizon_mode == "rolling_horizon"
+    assert plant._parse_duration_to_steps("4h") == 4
+
+
+def _rh_plant(cement_components, rh_config, prices, demand=10, n=6, plant_id="test_rh"):
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    return make_plant(
+        components,
+        make_forecaster(n=n, prices=prices),
+        demand=demand,
+        plant_id=plant_id,
+        dsm_optimisation_config=rh_config,
+    )
+
+
+def test_rolling_window_defers_production_to_cheap_look_ahead_hours(
+    cement_components, rh_config
+):
+    """The committed hours stay idle when the look-ahead contains much cheaper hours."""
+    plant = _rh_plant(
+        cement_components,
+        rh_config,
+        prices=[200.0, 200.0, 200.0, 10.0, 10.0, 10.0],
+        plant_id="test_rh_window",
+    )
+
+    triggered = plant._check_and_reoptimize_rolling_window(
+        pd.Timestamp("2023-01-01 00:00")
+    )
+    assert triggered is True
+    # Window 0 looks ahead over steps 0-3 and commits steps 0-1
+    assert plant._rh_optimized_until_step == 2
+    assert all(
+        value == pytest.approx(0.0, abs=1e-4)
+        for value in plant._rh_full_horizon_production[:2]
+    )
+
+
+def test_rolling_window_tracks_remaining_demand(cement_components, rh_config):
+    """Production committed in earlier windows is deducted from the remaining demand."""
+    plant = _rh_plant(
+        cement_components,
+        rh_config,
+        prices=[10.0, 10.0, 200.0, 200.0, 200.0, 200.0],
+        demand=10,
+        plant_id="test_rh_demand",
+    )
+
+    plant._check_and_reoptimize_rolling_window(pd.Timestamp("2023-01-01 00:00"))
+    produced_first_window = sum(plant._rh_full_horizon_production[:2])
+    assert produced_first_window == pytest.approx(10, rel=1e-4)
+
+    plant._check_and_reoptimize_rolling_window(pd.Timestamp("2023-01-01 02:00"))
+    assert plant._rh_optimized_until_step == 4
+    assert plant._rh_window_remaining_demand == pytest.approx(
+        10 - produced_first_window, abs=1e-4
+    )
+    # Component-level results are recorded for the committed steps
+    assert len(plant._component_operations) == 4
+
+
+def test_rolling_window_carries_thermal_storage_state(cement_components, rh_config):
+    """Thermal storage fill levels are carried from one committed window into the next."""
+    components = copy.deepcopy(cement_components)
+    components["thermal_storage"] = {
+        "capacity": 20,
+        "max_power_charge": 10,
+        "max_power_discharge": 20,
+        "ramp_up": 10,
+        "ramp_down": 10,
+        "initial_soc": 0,
+        "storage_type": "short-term_with_generator",
+    }
+    plant = make_plant(
+        components,
+        make_forecaster(n=6, prices=[10.0] * 6),
+        demand=6,
+        plant_id="test_rh_state",
+        dsm_optimisation_config=rh_config,
+    )
+
+    plant._check_and_reoptimize_rolling_window(pd.Timestamp("2023-01-01 00:00"))
+    assert "soc" in plant._rh_init_states.get("thermal_storage", {})
+
+    soc = plant._rh_init_states["thermal_storage"]["soc"]
+    assert -1e-6 <= soc <= 1 + 1e-6
+
+
+def test_rolling_horizon_full_day_meets_demand_every_window(cement_components):
+    """Driving every window of a full 24h horizon must cover the whole day.
+
+    Uses per-timestep minimums together with a global demand equal to their sum, so a
+    solved model must both hit every hourly floor and hand back exactly the declared
+    total once all eight 3h-step windows (6h look-ahead, 3h commit) have committed.
+    Also checks the plant advances to the end of the horizon and that no window is left
+    uncommitted (a stalled ``_rh_optimized_until_step`` would mean a window failed).
+    """
+    n = 24
+    prices = [
+        30,
+        28,
+        27,
+        27,
+        29,
+        34,
+        45,
+        60,
+        72,
+        80,
+        78,
+        74,
+        70,
+        68,
+        70,
+        78,
+        88,
+        95,
+        90,
+        80,
+        68,
+        55,
+        44,
+        36,
+    ]
+    per_hour_min = [4.0] * n
+    total_demand = sum(per_hour_min)
+
+    components = copy.deepcopy(cement_components)
+    components["calciner"]["fuel_type"] = "electricity"
+    components["thermal_storage"] = {
+        "capacity": 20,
+        "max_power_charge": 10,
+        "max_power_discharge": 20,
+        "ramp_up": 10,
+        "ramp_down": 10,
+        "initial_soc": 0,
+        "storage_type": "short-term_with_generator",
+    }
+    forecaster = make_forecaster(n=n, prices=prices, clinker_demand=per_hour_min)
+    plant = make_plant(
+        components,
+        forecaster,
+        demand=total_demand,
+        plant_id="test_rh_full_day",
+        dsm_optimisation_config={
+            "horizon_mode": "rolling_horizon",
+            "look_ahead_horizon": "6h",
+            "commit_horizon": "3h",
+            "rolling_step": "3h",
+        },
+    )
+
+    timestamps = pd.date_range("2023-01-01", periods=n, freq="h")
+    for ts in timestamps[::3]:  # one trigger per 3h commit step -> 8 windows
+        plant._check_and_reoptimize_rolling_window(ts)
+
+    # The plant advanced through every window to the very end of the horizon.
+    assert plant._rh_optimized_until_step == n
+
+    # Every hour met its declared floor, across all eight committed windows.
+    shortfalls = [
+        (t, v)
+        for t, v in enumerate(plant._rh_full_horizon_production)
+        if v < per_hour_min[t] - 1e-3
+    ]
+    assert shortfalls == [], f"hours below their minimum: {shortfalls}"
+
+    # The cumulative committed production matches the declared total exactly.
+    total_produced = sum(plant._rh_full_horizon_production)
+    assert total_produced == pytest.approx(total_demand, rel=1e-3)
+
+    # Component-level results were recorded for every committed step.
+    assert len(plant._component_operations) == n
+
+    # The thermal storage state carried across all eight windows stayed a valid
+    # fraction of capacity (not just the state after the first hand-off).
+    soc = plant._rh_init_states["thermal_storage"]["soc"]
+    assert -1e-6 <= soc <= 1 + 1e-6
+
+
+def test_rolling_horizon_works_for_a_standalone_mill():
+    """A standalone cement mill (no kiln line) also converges under rolling horizon.
+
+    Mirrors ``test_rolling_horizon_full_day_meets_demand_every_window`` but for a
+    plant made of only a cement mill, proving the ``clinker_rate``-based
+    generalization holds under multi-window rolling horizon too, rather than being
+    correct only "by construction" in the full-horizon model.
+    """
+    n = 12
+    prices = [60, 55, 50, 45, 10, 10, 10, 45, 50, 55, 60, 65]
+    per_hour_min = [2.0] * n
+    total_demand = sum(per_hour_min)
+
+    components = {
+        "cement_mill": {
+            "max_power": 25,
+            "min_power": 0,
+            "efficiency": 1.0,
+            "specific_electricity_consumption": 0.04,
+            "ramp_up": 25,
+            "ramp_down": 25,
+        }
+    }
+    forecaster = make_forecaster(n=n, prices=prices, clinker_demand=per_hour_min)
+    plant = make_plant(
+        components,
+        forecaster,
+        demand=total_demand,
+        plant_id="test_rh_standalone_mill",
+        dsm_optimisation_config={
+            "horizon_mode": "rolling_horizon",
+            "look_ahead_horizon": "6h",
+            "commit_horizon": "3h",
+            "rolling_step": "3h",
+        },
+    )
+
+    timestamps = pd.date_range("2023-01-01", periods=n, freq="h")
+    for ts in timestamps[::3]:  # one trigger per 3h commit step -> 4 windows
+        plant._check_and_reoptimize_rolling_window(ts)
+
+    assert plant._rh_optimized_until_step == n
+
+    shortfalls = [
+        (t, v)
+        for t, v in enumerate(plant._rh_full_horizon_production)
+        if v < per_hour_min[t] - 1e-3
+    ]
+    assert shortfalls == [], f"hours below their minimum: {shortfalls}"
+
+    total_produced = sum(plant._rh_full_horizon_production)
+    assert total_produced == pytest.approx(total_demand, rel=1e-3)
+    assert len(plant._component_operations) == n
+
+
+def test_rolling_horizon_never_overproduces_once_demand_is_met():
+    """Once the global demand is fully met early, later windows must produce exactly zero.
+
+    The whole global demand is made cheap to satisfy entirely within the first window's
+    committed hours (hours 0-2, priced far below the rest of the horizon). The window
+    demand constraint (``sum(primary_output) <= remaining_demand``) then forces every
+    later window's remaining_demand to exactly 0, which - since production is
+    non-negative - forces every later hour's production to exactly 0 too, not just "on
+    average" zero.
+    """
+    n = 9
+    components = {
+        "kiln": {
+            "max_heat_out": 10,
+            "specific_heat_demand": 1.0,
+            "fuel_type": "electricity",
+            "eta_electric": 1.0,
+            "ramp_up": 10,
+            "ramp_down": 10,
+        }
+    }
+    prices = [10, 10, 10, 200, 200, 200, 200, 200, 200]
+    plant = make_plant(
+        components,
+        make_forecaster(n=n, prices=prices),
+        demand=10,
+        plant_id="test_rh_no_overproduction",
+        dsm_optimisation_config={
+            "horizon_mode": "rolling_horizon",
+            "look_ahead_horizon": "6h",
+            "commit_horizon": "3h",
+            "rolling_step": "3h",
+        },
+    )
+
+    timestamps = pd.date_range("2023-01-01", periods=n, freq="h")
+    for i, ts in enumerate(timestamps[::3]):
+        plant._check_and_reoptimize_rolling_window(ts)
+        if i == 0:
+            # The whole demand was cheap enough to clear in the first committed block.
+            produced_so_far = sum(plant._rh_full_horizon_production[:3])
+            assert produced_so_far == pytest.approx(10, rel=1e-4)
+        elif i == 1:
+            # _rh_window_remaining_demand reflects what was remaining as this window's
+            # solve started, i.e. it only shows the post-window0 value once window1
+            # actually runs.
+            assert plant._rh_window_remaining_demand == pytest.approx(0.0, abs=1e-6)
+
+    assert plant._rh_optimized_until_step == n
+    later_production = plant._rh_full_horizon_production[3:]
+    assert later_production == pytest.approx([0.0] * (n - 3), abs=1e-6)
+
+    total_produced = sum(plant._rh_full_horizon_production)
+    assert total_produced == pytest.approx(10, rel=1e-4)
+
+
+if __name__ == "__main__":
+    pytest.main(["-s", __file__])


### PR DESCRIPTION
### **User description**
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue

## Description

Adds a **cement plant** demand-side unit, modelled as a fuel-switchable kiln line, with full rolling-horizon support.

### New DSM unit: `CementPlant` (`assume/units/cement_plant.py`)

- Kiln line of **preheater**, **calciner**, and **kiln**, each independently fuel-switchable between electricity, a natural-gas/coal mix, or hydrogen (`ThermalProcessStage` base class + subclasses in `dst_components.py`).
- Waste heat recovered from the kiln reduces the fuel the preheater needs.
- Optional **electrolyser** producing hydrogen on site for the calciner/kiln burners, with the split between burners tracked explicitly.
- Optional **thermal storage** (`ThermalStorage`, new `short-term_with_generator` mode) acting as an electric-heater-charged buffer (E-TES) that displaces calciner burner heat in expensive hours, the plant's main source of demand-side flexibility.
- Optional **raw material mill** and **cement mill** (`GrindingMill`): electric grinding steps. A cement mill attached to a kiln line grinds that line's clinker as before; either mill with **no kiln line at all** runs as a standalone grinding operation, where the declared demand targets that mill's own ground tonnage directly instead of clinker.
- New `CementForecaster` (`assume/common/forecaster.py`)

### Rolling-horizon

- Fixed a bug where the rolling-horizon `min_demand` strategy detection hard-coded `steel_demand_per_timestep` instead of using the unit's own `_demand_attr_suffix`, so it silently fell back to the wrong (already-window-sliced) series for any non-steel-plant unit using the `min_demand` strategy in rolling-horizon mode.
- Added a generic `_component_power_expr()` fallback so the shared flexibility measures (`peak_load_shifting`, `renewable_utilisation`, etc.) work for any DSM unit's component set, not just steel-plant-shaped ones.

### Bug fix: ramp constraint at the first time step (`assume/units/dst_components.py`)

Found while stress-testing the new unit: the first time step of every ramp-limited quantity was capped by `min(ramp_up, ramp_down)` instead of just `ramp_up`, because `ramp_down_constraint`'s own first-step branch also applied an absolute cap (`value[0] <= ramp_down`) even though there is no previous value to decrease *from*. A tight `ramp_down` could therefore artificially choke off a legitimately high first-step value.

Fixed in all four places this exact pattern was duplicated: the shared `add_ramping_constraints` helper, `GenericStorage`'s inline charge/discharge ramps, `ChargingStation`'s inline ramps, and `Boiler`'s natural-gas/hydrogen-gas fuel paths. `ramp_down_constraint` now skips the first step entirely instead of applying a spurious cap.

### Tests

`tests/test_cement_plant.py`

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [x] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0


___

### **PR Type**
Enhancement, Bug fix, Tests, Documentation


___

### **Description**
- Add fuel-switchable cement plant DSM model

- Support mills, electrolyser, E-TES flexibility

- Add cement forecasts and CSV loading

- Cover operations with extensive tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  cfg["CSV unit configuration"]
  forecaster["CementForecaster"]
  plant["CementPlant DSM model"]
  components["Kiln line, mills, storage, electrolyser"]
  optimisation["Flex and rolling-horizon optimisation"]
  tests["Integration and behavior tests"]
  cfg -- "loads forecasts" --> forecaster
  forecaster -- "provides prices and demand" --> plant
  components -- "compose model" --> plant
  plant -- "solves schedules" --> optimisation
  optimisation -- "validated by" --> tests
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>test_cement_plant.py</strong><dd><code>Add comprehensive cement plant model tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-eb8115de94ba78e9d0439d04db206b4bfed381b6845b255e50ef9e237dfe60d0">+1634/-0</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td><strong>dst_components.py</strong><dd><code>Add cement components and storage generator mode</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-7ee765becfc6fdf116d655899f3c9e4d77c094b6192829775ba75c6f461b129b">+782/-21</a></td>

</tr>

<tr>
  <td><strong>forecaster.py</strong><dd><code>Add dedicated cement plant forecaster</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-9e3d450a0ad0d08812b308dcbbf1e232b784fc92ab699c3b5e75dba23e1de7f8">+126/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Register cement plant unit type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-f0c45feea84ac010c89317cd6d5201145ab420a9cf8df0302c330ba830e65c6f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cement_plant.py</strong><dd><code>Implement cement plant DSM unit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-e57231dbdb0a411ccb72bd25132cd9acefd41b98519338e033c3934996b0e076">+670/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>loader_csv.py</strong><dd><code>Load cement plant forecast inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-0dfddc944404e0303344c49eccf4b01cc2c44a07837d1b7a02de13097e408ca2">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>dsm_load_shift.py</strong><dd><code>Generalize DSM flexibility and rolling horizon</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-1e2b24c660acfc2b602e2550b4b714ff2b59b334fa12f604d6635a56d9a07186">+80/-45</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>demand_side_agent.rst</strong><dd><code>Document cement plant demand-side unit</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-4f9b0eb451a42d9e98d4085628cfccff01a105406f802e9a602d420f61e49dd0">+77/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>release_notes.rst</strong><dd><code>Add cement plant release notes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-eb36f1b6f2ee2691f609c07d32a8d977e4052a9e47d0ec94a241c6fc001a5d5c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>unit_forecasts.rst</strong><dd><code>Document cement forecast configuration fields</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/assume-framework/assume/pull/845/files#diff-d521dad11610d6ed384d6fda8d03aa92bcfc1ac8741b5b95189a711fbabba6ae">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

