### PR TITLE
fix loss of the last ``train_freq`` window during learning

### DIFF
--- a/assume/world.py
+++ b/assume/world.py
@@ -848,6 +848,10 @@ class World:
                     else:
                         self.clock.set_time(end_ts)
                     prev_delta = delta
+
+                # tasks which fire at exactly end_ts need to be awaited before shutdown
+                await asyncio.sleep(0)
+                await tasks_complete_or_sleeping(c, except_sources=[])
             else:
                 # real-time mode
                 while self.clock.time < end_ts:

--- a/assume/world.py
+++ b/assume/world.py
@@ -848,10 +848,6 @@ class World:
                     else:
                         self.clock.set_time(end_ts)
                     prev_delta = delta
-
-                # tasks which fire at exactly end_ts need to be awaited before shutdown
-                await asyncio.sleep(0)
-                await tasks_complete_or_sleeping(c, except_sources=[])
             else:
                 # real-time mode
                 while self.clock.time < end_ts:
@@ -859,6 +855,11 @@ class World:
                     await asyncio.sleep(1)
                     delta = self.clock.time - time
                     pbar.update(delta)
+
+            # tasks which fire at exactly end_ts need to be awaited before shutdown
+            await asyncio.sleep(0)
+            await tasks_complete_or_sleeping(c, except_sources=[])
+
             pbar.close()
 
     def run(self):

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -59,6 +59,7 @@ Upcoming Release
   - **Fix errors in portfolio learning strategies**: The ``min_max_rescale`` function was missing from ``utils.py``, causing an ``ImportError`` in ``portfolio_learning_strategies.py``. Resolved by extending ``min_max_scale`` to cover the rescaling use case. And fix minor construction bug for observation space.
   - **Skip torch seeding when torch is installed but not used**: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
   - **Fix bug in redispatch mechanism**: Fixed the bug in redispatch evaluation due to PyPSA's version upgrade. In ``PyPSA >= 0.35.2`` (released in February 2025) the sign of load was not taken into account correctly & since the fixed EOM dispatch was modelled as a load with positive sign which was resulting in incorrect redispatch amounts.
+  - **Fix loss of the last ``train_freq`` window during learning**: Tasks scheduled at exactly the simulation end were started by the run loop but never awaited, because tasks registered with ``src="no_wait"`` are excluded from mango's termination detection. The run loop now drains all remaining tasks before shutting the container down.
 
 0.6.0 - (18th March 2026)
 =========================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #851 

## Description
At the final timestep during a learning episode, premature shutdown of the container led to loss of training data which was not stored in the outputs or the buffer. Now, all remaining tasks are completed before shutdown. 

## Checklist
- [x] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added (if applicable)
- [ ] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes
@maurerle do you know if anything changes with newer mango-agents versions that could have introduced a new default behavior? I was really surprised to observe missing data for the final``train_freq`` period. 