### PR TITLE
Split cashflow and reward

### DIFF
--- a/assume/common/base.py
+++ b/assume/common/base.py
@@ -156,21 +156,21 @@ class BaseUnit:
                 accepted_price
             )
 
-    def calculate_cashflow_and_reward(
+    def calculate_reward(
         self,
         marketconfig: MarketConfig,
         orderbook: Orderbook,
     ) -> None:
         """
-        Calculates the cashflow and the reward for the given unit.
+        Calculates the reward for the given unit.
+
+        This is called once the delivery period of the orders has been executed,
+        so that the reward can be based on the actual dispatch of the unit.
 
         Args:
             marketconfig (MarketConfig): The market configuration.
             orderbook (Orderbook): The orderbook.
         """
-
-        product_type = marketconfig.product_type
-        self.calculate_cashflow(product_type, orderbook)
 
         self.bidding_strategies[marketconfig.market_id].calculate_reward(
             unit=self,
@@ -201,7 +201,9 @@ class BaseUnit:
             self.calculate_marginal_cost(t, product_data[idx])
             for idx, t in enumerate(self.index[start:end])
         ]
-        generation_costs = np.abs(marginal_costs * product_data)
+        generation_costs = np.abs(
+            marginal_costs * product_data
+        )  # TODO: generation costs need to be the integral of the marginal costs over the power output, not just the product of the two. This is a simplification and may not accurately reflect the true generation costs for partial efficiencies or step-wise mc functions.
         self.outputs[f"{product_type}_generation_costs"].loc[start:end] = (
             generation_costs
         )

--- a/assume/common/market_objects.py
+++ b/assume/common/market_objects.py
@@ -154,6 +154,19 @@ class MarketConfig:
             )
         )
 
+    @property
+    def last_opening(self) -> datetime:
+        """
+        The last opening which actually opens, which is the difference between the market
+        end and the length of the longest product plus the delivery time of the products.
+        An opening whose products would be delivered after the market end is skipped.
+        """
+        return self.opening_hours._until - max(
+            market_product.duration * market_product.count
+            + market_product.first_delivery
+            for market_product in self.market_products
+        )
+
     def __post_init__(self):
         """
         Post-initialization checks for checks on failing initializations.

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -11,6 +11,7 @@ from operator import itemgetter
 from mango import Role, create_acl, sender_addr
 from mango.messages.message import Performatives
 
+from assume.common.fast_pandas import FastIndex
 from assume.common.forecaster import UnitsOperatorForecaster
 from assume.common.market_objects import (
     ClearingMessage,
@@ -24,6 +25,8 @@ from assume.common.market_objects import (
 )
 from assume.common.utils import (
     aggregate_step_amount,
+    create_rrule,
+    datetime2timestamp,
     timestamp2datetime,
 )
 from assume.strategies import (
@@ -43,9 +46,11 @@ class UnitsOperator(Role):
     Attributes:
         available_markets (list[MarketConfig]): The available markets.
         registered_markets (dict[str, MarketConfig]): The registered markets.
-        last_sent_dispatch (int): The last sent dispatch.
+        last_sent_market_dispatch (dict[str, int]): The last sent market dispatch, per product type.
+        last_executed_dispatch (int): The timestamp of the last executed dispatch.
         portfolio_strategies (UnitOperatorStrategy): The portfolio strategy.
-        valid_orders (defaultdict): The valid orders.
+        valid_orders (defaultdict): The valid orders, per product type.
+        pending_orders (defaultdict): The orders awaiting the end of their delivery period, per market.
         units (dict[str, BaseUnit]): The units.
         id (str): The id of the agent.
         context (Context): The context of the agent.
@@ -67,7 +72,10 @@ class UnitsOperator(Role):
 
         self.available_markets = available_markets
         self.registered_markets: dict[str, MarketConfig] = {}
-        self.last_sent_dispatch = defaultdict(lambda: 0)
+
+        self.last_sent_market_dispatch = defaultdict(lambda: 0)
+        self.last_executed_dispatch = 0
+
         self.forecaster = forecaster
 
         self.portfolio_strategies = portfolio_strategies
@@ -77,8 +85,10 @@ class UnitsOperator(Role):
                     UnitsOperatorDirectStrategy()
                 )
 
-        # valid_orders per product_type
+        # valid_orders per product_type, used for the market dispatch export at clearing (before delivery)
         self.valid_orders = defaultdict(list)
+        # pending_orders per market_id awaiting the end of their delivery period to calculate reward based on actual dispatch
+        self.pending_orders = defaultdict(list)
         self.units: dict[str, BaseUnit] = {}
 
     def setup(self):
@@ -107,6 +117,21 @@ class UnitsOperator(Role):
             lambda content, meta: content.get("context") == "data_request",
         )
 
+    @property
+    def simulation_index(self) -> FastIndex | None:
+        """
+        The shared simulation index, taken from the operator forecaster if one is
+        given and from any of the managed units otherwise.
+
+        Returns:
+            FastIndex | None: The simulation index, or None if the operator has no units.
+        """
+        if self.forecaster is not None:
+            return self.forecaster.index
+        if self.units:
+            return next(iter(self.units.values())).index
+        return None
+
     def on_ready(self):
         super().on_ready()
         self.id = self.context.aid
@@ -122,6 +147,18 @@ class UnitsOperator(Role):
             self.store_units(),
             1,  # register after time was updated for the first time
         )
+
+        # execute the dispatch once per time step, independent of the markets.
+        index = self.simulation_index
+        if index is not None:
+            self.context.schedule_recurrent_task(
+                self.execute_dispatch,
+                create_rrule(
+                    start=index.start + index.freq,
+                    end=index.end,
+                    freq=index.freq,
+                ),
+            )
 
     async def store_units(self) -> None:
         db_addr = self.context.data.get("output_agent_addr")
@@ -241,11 +278,14 @@ class UnitsOperator(Role):
         marketconfig = self.registered_markets[content["market_id"]]
         self.valid_orders[marketconfig.product_type].extend(orderbook)
         self.set_unit_dispatch(orderbook, marketconfig)
-        self.write_actual_dispatch(marketconfig.product_type)
 
-        # now once we have the market results and the dispatch has been set
-        # we can calculate the cashflow and reward for the units
-        self.calculate_unit_cashflow_and_reward(orderbook, marketconfig)
+        # the cashflow is fully determined by the clearing result and can be booked now
+        self.calculate_unit_cashflow(orderbook, marketconfig)
+
+        # the reward, in contrast, depends on the dispatch that is actually realized
+        self.pending_orders[marketconfig.market_id].extend(orderbook)
+
+        self.write_market_dispatch(marketconfig.product_type)
 
     def handle_registration_feedback(
         self, content: RegistrationMessage, meta: MetaDict
@@ -326,11 +366,14 @@ class UnitsOperator(Role):
                 orderbook=orderbook,
             )
 
-    def calculate_unit_cashflow_and_reward(
+    def calculate_unit_cashflow(
         self, orderbook: Orderbook, marketconfig: MarketConfig
     ) -> None:
         """
-        Feeds the current market result back to the units.
+        Books the cashflow of the given market result in the units.
+
+        The cashflow follows directly from the accepted prices and volumes and is
+        therefore known as soon as the market is cleared.
 
         Args:
             orderbook (Orderbook): The orderbook of the market.
@@ -338,51 +381,114 @@ class UnitsOperator(Role):
         """
         orderbook.sort(key=itemgetter("unit_id"))
         for unit_id, orders in groupby(orderbook, itemgetter("unit_id")):
-            unit_orders = list(orders)
-            self.units[unit_id].calculate_cashflow_and_reward(
-                marketconfig=marketconfig,
-                orderbook=unit_orders,
+            self.units[unit_id].calculate_cashflow(
+                product_type=marketconfig.product_type,
+                orderbook=list(orders),
             )
 
-        # Calculate reward for the portfolio strategy
-        self.portfolio_strategies.get(marketconfig.market_id).calculate_reward(
-            units_operator=self,
-            marketconfig=marketconfig,
-            orderbook=orderbook,
-        )
-
-    def get_actual_dispatch(
-        self, product_type: str, last: datetime
-    ) -> tuple[list[tuple[datetime, float, str, str]], list[dict]]:
+    def calculate_unit_reward(self, execute_until: datetime) -> None:
         """
-        Retrieves the actual dispatch since the last dispatch and commits it in the unit.
-        We calculate the series of the actual market results dataframe with accepted bids.
-        And the unit_dispatch for all units taken care of in the UnitsOperator.
+        Calculates the reward of all orders whose delivery period has ended.
+
+        This is called from execute_dispatch, so the reward is based on the dispatch
+        that was actually realized, including the contribution of all markets that
+        cleared for the respective delivery period.
 
         Args:
-            product_type (str): The product type for which this is done
-            last (datetime.datetime): the last date until which the dispatch was already sent
+            execute_until (datetime.datetime): The last time step which will be executed.
+        """
+        freq = self.simulation_index.freq
 
-        Returns:
-            tuple[list[tuple[datetime, float, str, str]], list[dict]]: market_dispatch and unit_dispatch dataframes
+        # find all orders due for execution because their delivery period has ended
+        due: dict[str, Orderbook] = {}
+        for market_id, orders in list(self.pending_orders.items()):
+            delivered = [
+                order for order in orders if order["end_time"] - freq <= execute_until
+            ]
+            if delivered:
+                due[market_id] = delivered
+                self.pending_orders[market_id] = [
+                    order
+                    for order in orders
+                    if order["end_time"] - freq > execute_until
+                ]
+
+        for market_id, orders in due.items():
+            marketconfig = self.registered_markets[market_id]
+
+            orders.sort(key=itemgetter("unit_id"))
+            for unit_id, unit_orders in groupby(orders, itemgetter("unit_id")):
+                self.units[unit_id].calculate_reward(
+                    marketconfig=marketconfig,
+                    orderbook=list(unit_orders),
+                )
+
+            # Calculate reward for the portfolio strategy
+            self.portfolio_strategies.get(market_id).calculate_reward(
+                units_operator=self,
+                marketconfig=marketconfig,
+                orderbook=orders,
+            )
+
+    async def execute_dispatch(self) -> None:
+        """
+        Executes the dispatch of all units for the time steps which have passed since
+        the last execution, exports it and calculates the reward of every product
+        whose delivery period ended in the meantime.
         """
         now = timestamp2datetime(self.context.current_timestamp)
-        # add one second to exclude the first time stamp, because it is already executed in the last step
-        start = timestamp2datetime(last + 1)
+        execute_until = now - self.simulation_index.freq
 
-        market_dispatch = aggregate_step_amount(
-            orderbook=self.valid_orders[product_type],
-            begin=timestamp2datetime(last),
-            end=now,
-            groupby=["market_id", "unit_id"],
-        )
+        last_ts = self.last_executed_dispatch
+        self.last_executed_dispatch = datetime2timestamp(execute_until)
 
+        try:
+            # add one second to exclude the first time stamp,
+            # because it is already executed in the last step
+            actual_dispatch = self.get_actual_dispatch(
+                timestamp2datetime(last_ts + 1), execute_until
+            )
+            self.write_actual_dispatch(actual_dispatch)
+
+            # now that the dispatch is realized, the reward of every product whose
+            # delivery period has been executed can be calculated
+            self.calculate_unit_reward(execute_until)
+        except (
+            AttributeError,
+            NameError,
+            TypeError,
+        ):  # TODO: check if this is intended error behavior
+            # these indicate a coding error rather than a problem with the data,
+            # so they must not be hidden in the log
+            raise
+        except Exception:
+            # any other exception escaping here would stop the recurrent task,
+            # which would silently disable the dispatch for the rest of the run
+            logger.exception("error while executing the dispatch at %s", now)
+
+    def get_actual_dispatch(self, start: datetime, end: datetime) -> list[dict]:
+        """
+        Retrieves the actual dispatch of all units in the given time range and commits
+        it in the unit. This checks the feasibility of the planned dispatch and adjusts
+        it to the closest feasible one if needed, so it has to happen once the time
+        range has passed and all markets for it have cleared.
+
+        The actual dispatch is the volume a unit really dispatched across all of the
+        markets it participated in, which is why this is independent of the product
+        type and can only be determined after the delivery period.
+
+        Args:
+            start (datetime.datetime): The start of the range to execute.
+            end (datetime.datetime): The end of the range to execute, inclusive.
+
+        Returns:
+            list[dict]: the unit_dispatch dataframes
+        """
         unit_dispatch = []
         for unit_id, unit in self.units.items():
-            current_dispatch = unit.execute_current_dispatch(start, now)
-            end = now
+            current_dispatch = unit.execute_current_dispatch(start, end)
             dispatch = {"power": current_dispatch}
-            unit.calculate_generation_cost(start, now, "energy")
+            unit.calculate_generation_cost(start, end, "energy")
             valid_outputs = [
                 "soc",
                 "cashflow",
@@ -399,25 +505,71 @@ class UnitsOperator(Role):
             dispatch["unit"] = unit_id
             unit_dispatch.append(dispatch)
 
-        return market_dispatch, unit_dispatch
+        return unit_dispatch
 
-    def write_actual_dispatch(self, product_type: str) -> None:
+    def get_market_dispatch(
+        self, product_type: str, last: datetime, now: datetime
+    ) -> list[tuple[datetime, float, str, str]]:
         """
-        Sends the actual aggregated dispatch curve to the output agent.
+        Aggregates the accepted orders of the given product type into the dispatch
+        per market and unit.
+
+        Args:
+            product_type (str): The product type for which this is done.
+            last (datetime.datetime): The last date until which the dispatch was already sent.
+            now (datetime.datetime): The current time.
+
+        Returns:
+            list[tuple[datetime, float, str, str]]: the market_dispatch dataframe
+        """
+        return aggregate_step_amount(
+            orderbook=self.valid_orders[product_type],
+            begin=last,
+            end=now,
+            groupby=["market_id", "unit_id"],
+        )
+
+    def write_actual_dispatch(self, actual_dispatch: list[dict]) -> None:
+        """
+        Sends the actual dispatch of the units to the output agent.
+
+        Args:
+            actual_dispatch (list[dict]): The unit dispatch dataframes.
+
+        """
+        db_addr = self.context.data.get("output_agent_addr")
+        if db_addr and actual_dispatch:
+            self.context.schedule_instant_message(
+                receiver_addr=db_addr,
+                content={
+                    "context": "write_results",
+                    "type": "unit_dispatch",
+                    "data": actual_dispatch,
+                },
+            )
+
+    def write_market_dispatch(self, product_type: str) -> None:
+        """
+        Sends the aggregated market dispatch curve of the given product type to the
+        output agent.
 
         Args:
             product_type (str): The type of the product.
         """
 
-        last = self.last_sent_dispatch[product_type]
-        if self.context.current_timestamp == last:
+        last = self.last_sent_market_dispatch[product_type]
+        if self.context.current_timestamp == last:  # TODO: do we still need that?
             # stop if we exported at this time already
             return
-        self.last_sent_dispatch[product_type] = self.context.current_timestamp
-
-        market_dispatch, unit_dispatch = self.get_actual_dispatch(product_type, last)
+        self.last_sent_market_dispatch[product_type] = self.context.current_timestamp
 
         now = timestamp2datetime(self.context.current_timestamp)
+        market_dispatch = self.get_market_dispatch(
+            product_type, timestamp2datetime(last), now
+        )
+
+        # orders have to be kept until their closing delta has been aggregated,
+        # which only happens in the export following their end_time
         self.valid_orders[product_type] = list(
             filter(
                 lambda x: x["end_time"] > now,
@@ -435,15 +587,6 @@ class UnitsOperator(Role):
                     "data": market_dispatch,
                 },
             )
-            if unit_dispatch:
-                self.context.schedule_instant_message(
-                    receiver_addr=db_addr,
-                    content={
-                        "context": "write_results",
-                        "type": "unit_dispatch",
-                        "data": unit_dispatch,
-                    },
-                )
 
     async def submit_bids(self, opening: OpeningMessage, meta: MetaDict) -> None:
         """

--- a/assume/common/units_operator.py
+++ b/assume/common/units_operator.py
@@ -46,10 +46,10 @@ class UnitsOperator(Role):
     Attributes:
         available_markets (list[MarketConfig]): The available markets.
         registered_markets (dict[str, MarketConfig]): The registered markets.
-        last_sent_market_dispatch (dict[str, int]): The last sent market dispatch, per product type.
+        last_sent_market_dispatch (dict[str, int]): The time until which the market dispatch was sent, per market.
         last_executed_dispatch (int): The timestamp of the last executed dispatch.
         portfolio_strategies (UnitOperatorStrategy): The portfolio strategy.
-        valid_orders (defaultdict): The valid orders, per product type.
+        valid_orders (defaultdict): The valid orders, per market.
         pending_orders (defaultdict): The orders awaiting the end of their delivery period, per market.
         units (dict[str, BaseUnit]): The units.
         id (str): The id of the agent.
@@ -85,7 +85,7 @@ class UnitsOperator(Role):
                     UnitsOperatorDirectStrategy()
                 )
 
-        # valid_orders per product_type, used for the market dispatch export at clearing (before delivery)
+        # valid_orders per market_id, used for the market dispatch export at clearing (before delivery)
         self.valid_orders = defaultdict(list)
         # pending_orders per market_id awaiting the end of their delivery period to calculate reward based on actual dispatch
         self.pending_orders = defaultdict(list)
@@ -276,7 +276,7 @@ class UnitsOperator(Role):
             order["market_id"] = content["market_id"]
 
         marketconfig = self.registered_markets[content["market_id"]]
-        self.valid_orders[marketconfig.product_type].extend(orderbook)
+        self.valid_orders[marketconfig.market_id].extend(orderbook)
         self.set_unit_dispatch(orderbook, marketconfig)
 
         # the cashflow is fully determined by the clearing result and can be booked now
@@ -285,7 +285,7 @@ class UnitsOperator(Role):
         # the reward, in contrast, depends on the dispatch that is actually realized
         self.pending_orders[marketconfig.market_id].extend(orderbook)
 
-        self.write_market_dispatch(marketconfig.product_type)
+        self.write_market_dispatch(marketconfig)
 
     def handle_registration_feedback(
         self, content: RegistrationMessage, meta: MetaDict
@@ -508,24 +508,24 @@ class UnitsOperator(Role):
         return unit_dispatch
 
     def get_market_dispatch(
-        self, product_type: str, last: datetime, now: datetime
+        self, market_id: str, last: datetime, until: datetime
     ) -> list[tuple[datetime, float, str, str]]:
         """
-        Aggregates the accepted orders of the given product type into the dispatch
-        per market and unit.
+        Aggregates the accepted orders of the given market into the dispatch per unit.
 
         Args:
-            product_type (str): The product type for which this is done.
+            market_id (str): The market for which this is done.
             last (datetime.datetime): The last date until which the dispatch was already sent.
-            now (datetime.datetime): The current time.
+            until (datetime.datetime): The date up to which the dispatch is
+                aggregated, exclusive.
 
         Returns:
             list[tuple[datetime, float, str, str]]: the market_dispatch dataframe
         """
         return aggregate_step_amount(
-            orderbook=self.valid_orders[product_type],
+            orderbook=self.valid_orders[market_id],
             begin=last,
-            end=now,
+            end=until,
             groupby=["market_id", "unit_id"],
         )
 
@@ -548,32 +548,45 @@ class UnitsOperator(Role):
                 },
             )
 
-    def write_market_dispatch(self, product_type: str) -> None:
+    def write_market_dispatch(self, marketconfig: MarketConfig) -> None:
         """
-        Sends the aggregated market dispatch curve of the given product type to the
-        output agent.
+        Sends the aggregated market dispatch curve of the given market to the output agent.
+        This has to be called at a clearing of the given market, as the dispatch which is
+        final by now is derived from the opening this clearing belongs to.
 
         Args:
-            product_type (str): The type of the product.
+            marketconfig (MarketConfig): The market configuration.
         """
 
-        last = self.last_sent_market_dispatch[product_type]
-        if self.context.current_timestamp == last:  # TODO: do we still need that?
-            # stop if we exported at this time already
-            return
-        self.last_sent_market_dispatch[product_type] = self.context.current_timestamp
-
         now = timestamp2datetime(self.context.current_timestamp)
-        market_dispatch = self.get_market_dispatch(
-            product_type, timestamp2datetime(last), now
+        # the clearing belongs to the opening one opening duration ago, and an opening
+        # after the last possible one is never scheduled by the market
+        next_opening = marketconfig.opening_hours.after(
+            now - marketconfig.opening_duration
         )
+        if next_opening is not None and next_opening <= marketconfig.last_opening:
+            until = now
+        else:
+            # no export follows which could aggregate the rest, so the dispatch is final
+            # until the market end. The closing delta there lies beyond the simulation
+            # and is excluded by the aggregation.
+            until = marketconfig.opening_hours._until
+
+        market_id = marketconfig.market_id
+        last = timestamp2datetime(self.last_sent_market_dispatch[market_id])
+        if until <= last:
+            # stop if nothing became final since the last export
+            return
+        self.last_sent_market_dispatch[market_id] = datetime2timestamp(until)
+
+        market_dispatch = self.get_market_dispatch(market_id, last, until)
 
         # orders have to be kept until their closing delta has been aggregated,
         # which only happens in the export following their end_time
-        self.valid_orders[product_type] = list(
+        self.valid_orders[market_id] = list(
             filter(
-                lambda x: x["end_time"] > now,
-                self.valid_orders[product_type],
+                lambda x: x["end_time"] > until,
+                self.valid_orders[market_id],
             )
         )
 

--- a/assume/common/utils.py
+++ b/assume/common/utils.py
@@ -440,8 +440,11 @@ def datetime2timestamp(datetime: datetime):
     return calendar.timegm(datetime.utctimetuple())
 
 
-def create_rrule(start, end, freq):
-    freq, interval = convert_to_rrule_freq(freq)
+def create_rrule(start, end, freq: str | timedelta):
+    if isinstance(freq, timedelta):
+        freq, interval = convert_timedelta_to_rrule_freq(freq)
+    else:
+        freq, interval = convert_str_to_rrule_freq(freq)
 
     recurrency_rule = rr.rrule(
         freq=freq,
@@ -454,7 +457,32 @@ def create_rrule(start, end, freq):
     return recurrency_rule
 
 
-def convert_to_rrule_freq(string: str) -> tuple[int, int]:
+def convert_timedelta_to_rrule_freq(freq: timedelta) -> tuple[int, int]:
+    """
+    Convert a timedelta to a rrule frequency and interval.
+
+    The coarsest matching unit is used, as a SECONDLY rule with a large interval
+    is far more expensive for dateutil to iterate than an equivalent HOURLY one.
+
+    Args:
+        freq (timedelta): The frequency to be converted. Must be positive.
+
+    Returns:
+        tuple[int, int]: The rrule frequency and interval.
+    """
+
+    seconds = int(freq.total_seconds())
+    if seconds <= 0:
+        raise ValueError(f"Frequency '{freq}' must be a positive timedelta.")
+
+    if seconds % 3600 == 0:
+        return rr.HOURLY, seconds // 3600
+    if seconds % 60 == 0:
+        return rr.MINUTELY, seconds // 60
+    return rr.SECONDLY, seconds
+
+
+def convert_str_to_rrule_freq(string: str) -> tuple[int, int]:
     """
     Convert a string to a rrule frequency and interval.
 

--- a/assume/markets/base_market.py
+++ b/assume/markets/base_market.py
@@ -53,13 +53,7 @@ class MarketMechanism:
     def __init__(self, marketconfig: MarketConfig):
         super().__init__()
         self.marketconfig = marketconfig
-        # calculate last possible market opening as the difference between the market end
-        # and the length of the longest product plus the delivery time of the products
-        self.last_market_opening = marketconfig.opening_hours._until - max(
-            market_product.duration * market_product.count
-            + market_product.first_delivery
-            for market_product in marketconfig.market_products
-        )
+        self.last_market_opening = marketconfig.last_opening
 
     def clear(
         self, orderbook: Orderbook, market_products: list[MarketProduct]

--- a/assume/reinforcement_learning/learning_role.py
+++ b/assume/reinforcement_learning/learning_role.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
+import asyncio
 import logging
 from collections import defaultdict
 from datetime import datetime
@@ -229,6 +230,9 @@ class Learning(Role):
         self.rl_strats[strategy.unit_id] = strategy
 
     async def store_to_buffer_and_update(self) -> None:
+        # wait for rewards to be added to cache
+        await asyncio.sleep(0)
+
         # Atomic dict operations - create new references
         current_obs = self.all_obs
         current_actions = self.all_actions

--- a/assume/scenario/loader_csv.py
+++ b/assume/scenario/loader_csv.py
@@ -36,7 +36,7 @@ from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.utils import (
     adjust_unit_operator_for_learning,
     confirm_learning_save_path,
-    convert_to_rrule_freq,
+    convert_str_to_rrule_freq,
     load_index_file,
     normalize_availability,
     set_random_seed,
@@ -340,7 +340,7 @@ def make_market_config(
     Returns:
     MarketConfig: The market config.
     """
-    freq, interval = convert_to_rrule_freq(market_params["opening_frequency"])
+    freq, interval = convert_str_to_rrule_freq(market_params["opening_frequency"])
     start = market_params.get("start_date")
     end = market_params.get("end_date")
     if start:

--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -226,7 +226,9 @@ class EnergyHeuristicFlexableStrategy(MinMaxStrategy):
 
             output = unit.outputs[product_type].at[start]
             marginal_cost = unit.calculate_marginal_cost(start, output)
-            costs[i] += marginal_cost * output
+            costs[i] += (
+                marginal_cost * output
+            )  # TODO: only base the costs on the actual market contribution (accepted volume)
 
             if output != 0 and op_time < 0:
                 start_up_cost = unit.get_starting_costs(op_time)
@@ -235,11 +237,13 @@ class EnergyHeuristicFlexableStrategy(MinMaxStrategy):
         profit -= costs
 
         # store results in unit outputs which are written to database by unit operator
-        unit.outputs["profit"].loc[products_index] = profit
-        unit.outputs["total_costs"].loc[products_index] = costs
+        unit.outputs["profit"].loc[products_index] += profit
+        unit.outputs["total_costs"].loc[products_index] += costs
 
         # update average operation time
-        update_avg_op_time(unit, product_type, products_index[0], products_index[-1])
+        update_avg_op_time(
+            unit, product_type, products_index[0], products_index[-1]
+        )  # TODO: check if this needs to be moved to the cashflow calculation?
 
 
 class CapacityHeuristicBalancingPosStrategy(MinMaxStrategy):

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -203,18 +203,21 @@ class StorageEnergyHeuristicFlexableStrategy(MinMaxChargeStrategy):
             end_excl = order["end_time"] - unit.index.freq
 
             # Extract outputs and costs in one step
-            outputs = unit.outputs[product_type].loc[start:end_excl]
+            outputs = unit.outputs[product_type].loc[
+                start:end_excl
+            ]  # TODO: use accepted volume (and price?) from orderbook
             costs = np.where(
                 outputs != 0,
                 np.abs(outputs)
                 * np.array([unit.calculate_marginal_cost(start, x) for x in outputs]),
-                0,
+                0,  # TODO: check if this is correct for step-wise marginal costs, shouldn't it be the area under the curve?
             )
 
-            unit.outputs["profit"].loc[start:end_excl] = (
-                unit.outputs[f"{product_type}_cashflow"].loc[start:end_excl] - costs
+            unit.outputs["profit"].loc[start:end_excl] += (
+                unit.outputs[f"{product_type}_cashflow"].loc[start:end_excl]
+                - costs  # TODO: only use market cashflow?
             )
-            unit.outputs["total_costs"].loc[start:end_excl] = costs
+            unit.outputs["total_costs"].loc[start:end_excl] += costs
 
 
 class StorageCapacityHeuristicBalancingPosStrategy(MinMaxChargeStrategy):

--- a/assume/strategies/learning_strategies.py
+++ b/assume/strategies/learning_strategies.py
@@ -595,7 +595,7 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
         end_excl = end - unit.index.freq
 
         # Depending on how the unit calculates marginal costs, retrieve cost values.
-        marginal_cost = unit.calculate_marginal_cost(
+        marginal_cost = unit.calculate_marginal_cost(  # TODO: check what about step-wise mc or partial efficiencies?
             start, unit.outputs[product_type].at[start]
         )
         market_clearing_price = orderbook[0]["accepted_price"]
@@ -617,13 +617,16 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
 
             # Calculate profit as income minus operational cost for this event.
             order_income = market_clearing_price * accepted_volume * duration
-            order_cost = marginal_cost * accepted_volume * duration
+            order_cost = (
+                marginal_cost * accepted_volume * duration
+            )  # TODO: move outside loop, because costs are overall and need to be attributed to markets
 
             # Accumulate income and operational cost for all orders.
             income += order_income
             operational_cost += order_cost
 
         # Consideration of start-up costs, divided evenly between upward and downward regulation events.
+        # TODO: Finer grade (warm, hot, cold start costs) and allocation based on overall dispatch across multiple markets?
         if (
             unit.outputs[product_type].at[start] != 0
             and unit.outputs[product_type].at[start - unit.index.freq] == 0
@@ -648,7 +651,7 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
         # profit_scale= 0.1
 
         profit_scale = 1
-        profit = min(profit, profit_scale * abs(profit))
+        reward = min(profit, profit_scale * abs(profit))
 
         # Opportunity cost: The income lost due to not operating at full capacity.
         opportunity_cost = (
@@ -673,7 +676,7 @@ class EnergyLearningStrategy(TorchLearningStrategy, MinMaxStrategy):
         # scaling factor to normalize the reward to the range [-1,1]
         scaling = 1 / (self.max_bid_price * unit.max_power)
         regret = regret_scale * opportunity_cost
-        reward = scaling * (profit - regret)
+        reward = scaling * (reward - regret)
 
         # Store results in unit outputs
         # Note: these are not learning-specific results but stored for all units for analysis

--- a/assume/strategies/portfolio_learning_strategies.py
+++ b/assume/strategies/portfolio_learning_strategies.py
@@ -498,22 +498,31 @@ class PortfolioLearningStrategy(TorchLearningStrategy, UnitOperatorStrategy):
                 clearing_price = order.get("accepted_price", 0)
                 accepted_volume = order.get("accepted_volume", 0)
 
-                marginal_cost = unit.calculate_marginal_cost(
-                    start, unit.outputs[product_type].at[start]
+                marginal_cost = (
+                    unit.calculate_marginal_cost(  # TODO: check about step-wise mc
+                        start, unit.outputs[product_type].at[start]
+                    )
                 )
 
                 # Compute profits
-                unit_profit = (clearing_price - marginal_cost) * accepted_volume
+                unit_profit = (
+                    clearing_price - marginal_cost
+                ) * accepted_volume  # TODO: maybe move out of loop?
                 tot_profits += unit_profit
 
                 # Compute competitive profits
-                comp_volume = 0 if comp_price < marginal_cost else order["volume"]
+                comp_volume = (
+                    0 if comp_price < marginal_cost else order["volume"]
+                )  # TODO: why not accepted volume?
                 unit_comp_profit = (comp_price - marginal_cost) * comp_volume
                 comp_profits += unit_comp_profit
 
                 scaled_accepted_vol += accepted_volume * scaling_factor
 
         reward = (tot_profits - comp_profits) * scaling_factor
+
+        # TODO: are the unit profits not stored anywhere?
+        # here's no unit.outputs["profit"] and no unit.outputs["total_costs"] or for the unit_operator except for the RL results
 
         if self.learning_mode:
             self.learning_role.add_reward_to_cache(

--- a/assume/world.py
+++ b/assume/world.py
@@ -848,6 +848,10 @@ class World:
                     else:
                         self.clock.set_time(end_ts)
                     prev_delta = delta
+
+                # tasks which fire at exactly end_ts need to be awaited before shutdown
+                await asyncio.sleep(0)
+                await tasks_complete_or_sleeping(c, except_sources=[])
             else:
                 # real-time mode
                 while self.clock.time < end_ts:

--- a/assume/world.py
+++ b/assume/world.py
@@ -848,10 +848,6 @@ class World:
                     else:
                         self.clock.set_time(end_ts)
                     prev_delta = delta
-
-                # tasks which fire at exactly end_ts need to be awaited before shutdown
-                await asyncio.sleep(0)
-                await tasks_complete_or_sleeping(c, except_sources=[])
             else:
                 # real-time mode
                 while self.clock.time < end_ts:
@@ -859,6 +855,11 @@ class World:
                     await asyncio.sleep(1)
                     delta = self.clock.time - time
                     pbar.update(delta)
+
+            # tasks which fire at exactly end_ts need to be awaited before shutdown
+            await asyncio.sleep(0)
+            await tasks_complete_or_sleeping(c, except_sources=[])
+
             pbar.close()
 
     def run(self):

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -59,6 +59,7 @@ Upcoming Release
   - **Fix errors in portfolio learning strategies**: The ``min_max_rescale`` function was missing from ``utils.py``, causing an ``ImportError`` in ``portfolio_learning_strategies.py``. Resolved by extending ``min_max_scale`` to cover the rescaling use case. And fix minor construction bug for observation space.
   - **Skip torch seeding when torch is installed but not used**: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
   - **Fix bug in redispatch mechanism**: Fixed the bug in redispatch evaluation due to PyPSA's version upgrade. In ``PyPSA >= 0.35.2`` (released in February 2025) the sign of load was not taken into account correctly & since the fixed EOM dispatch was modelled as a load with positive sign which was resulting in incorrect redispatch amounts.
+  - **Fix loss of the last ``train_freq`` window during learning**: Tasks scheduled at exactly the simulation end were started by the run loop but never awaited, because tasks registered with ``src="no_wait"`` are excluded from mango's termination detection. The run loop now drains all remaining tasks before shutting the container down.
 
 0.6.0 - (18th March 2026)
 =========================

--- a/tests/test_baseunit.py
+++ b/tests/test_baseunit.py
@@ -111,7 +111,8 @@ def test_calculate_bids(base_unit, mock_market_config):
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
-    base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
+    base_unit.calculate_cashflow(mock_market_config.product_type, orderbook)
+    base_unit.calculate_reward(mock_market_config, orderbook)
 
     # we apply the dispatch plan of 10 MW
     assert base_unit.outputs["energy"][start] == 10
@@ -122,7 +123,8 @@ def test_calculate_bids(base_unit, mock_market_config):
     # we somehow sold an additional 10 MW
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
-    base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
+    base_unit.calculate_cashflow(mock_market_config.product_type, orderbook)
+    base_unit.calculate_reward(mock_market_config, orderbook)
 
     # the final output should be 10+10
     assert base_unit.outputs["energy"][start] == 20
@@ -159,7 +161,8 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
     base_unit.calculate_marginal_cost = lambda *x: 10
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
-    base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
+    base_unit.calculate_cashflow(mock_market_config.product_type, orderbook)
+    base_unit.calculate_reward(mock_market_config, orderbook)
 
     assert base_unit.outputs["energy"][index[0]] == 10
     assert base_unit.outputs["energy_generation_costs"][index[0]] == 100
@@ -170,7 +173,8 @@ def test_calculate_multi_bids(base_unit, mock_market_config):
 
     base_unit.set_dispatch_plan(mock_market_config, orderbook)
     base_unit.calculate_generation_cost(index[0], index[1], "energy")
-    base_unit.calculate_cashflow_and_reward(mock_market_config, orderbook)
+    base_unit.calculate_cashflow(mock_market_config.product_type, orderbook)
+    base_unit.calculate_reward(mock_market_config, orderbook)
 
     # should be correctly applied for the sum, even if different hours are applied
     assert base_unit.outputs["energy"][index[0]] == 20

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -16,7 +16,7 @@ from assume.common.fast_pandas import FastIndex
 from assume.common.forecaster import DemandForecaster, PowerplantForecaster
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.units_operator import UnitsOperator
-from assume.common.utils import datetime2timestamp
+from assume.common.utils import datetime2timestamp, timestamp2datetime
 from assume.strategies.naive_strategies import EnergyNaiveStrategy
 from assume.strategies.portfolio_strategies import (
     UnitsOperatorDirectStrategy,
@@ -90,12 +90,35 @@ async def test_set_unit_dispatch(units_operator: UnitsOperator):
     assert units_operator.units["testdemand"].outputs["energy"].max() == 500
 
 
+async def test_write_market_dispatch(units_operator: UnitsOperator):
+    units_operator.write_market_dispatch("energy")
+    assert units_operator.last_sent_market_dispatch["energy"] > 0
+    assert units_operator.last_sent_market_dispatch["test"] == 0
+    units_operator.write_market_dispatch("test")
+    assert units_operator.last_sent_market_dispatch["test"] > 0
+
+
 async def test_write_actual_dispatch(units_operator: UnitsOperator):
-    units_operator.write_actual_dispatch("energy")
-    assert units_operator.last_sent_dispatch["energy"] > 0
-    assert units_operator.last_sent_dispatch["test"] == 0
-    units_operator.write_actual_dispatch("test")
-    assert units_operator.last_sent_dispatch["test"] > 0
+    sent = []
+    units_operator.context.schedule_instant_message = lambda receiver_addr, content: (
+        sent.append(content)
+    )
+
+    # without an output agent nothing is written
+    units_operator.write_actual_dispatch([{"unit": "testdemand"}])
+    assert sent == []
+
+    units_operator.context.data["output_agent_addr"] = "output_agent"
+
+    # an empty dispatch is not worth a message either
+    units_operator.write_actual_dispatch([])
+    assert sent == []
+
+    units_operator.write_actual_dispatch([{"unit": "testdemand"}])
+    assert len(sent) == 1
+    # the message type is the name of the database table it is written to
+    assert sent[0]["type"] == "unit_dispatch"
+    assert sent[0]["data"] == [{"unit": "testdemand"}]
 
 
 async def test_independent_bids_portfolio(units_operator: UnitsOperator):
@@ -118,30 +141,258 @@ async def test_get_actual_dispatch(units_operator: UnitsOperator):
 
     last = clock.time
     clock.set_time(clock.time + 3600)
-    # WHEN actual_dispatch is called
-    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    # WHEN the actual dispatch is retrieved
+    unit_dfs = units_operator.get_actual_dispatch(
+        timestamp2datetime(last + 1), timestamp2datetime(clock.time)
+    )
     # THEN resulting unit dispatch dataframe contains one row
     # which is for the current time - as we must know our current dispatch
     assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
     assert len(unit_dfs[0]["time"]) == 1
-    assert len(market_dispatch) == 0
 
     # WHEN another hour passes
     last = clock.time
     clock.set_time(clock.time + 3600)
 
     # THEN resulting unit dispatch dataframe contains only one row with current dispatch
-    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    unit_dfs = units_operator.get_actual_dispatch(
+        timestamp2datetime(last + 1), timestamp2datetime(clock.time)
+    )
     assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
     assert len(unit_dfs[0]["time"]) == 1
-    assert len(market_dispatch) == 0
 
     last = clock.time
     clock.set_time(clock.time + 3600)
 
-    market_dispatch, unit_dfs = units_operator.get_actual_dispatch("energy", last)
+    unit_dfs = units_operator.get_actual_dispatch(
+        timestamp2datetime(last + 1), timestamp2datetime(clock.time)
+    )
     assert datetime2timestamp(unit_dfs[0]["time"][0]) == clock.time
     assert len(unit_dfs[0]["time"]) == 1
+
+
+def make_order(unit_id="testdemand", market_id="EOM", hours=1):
+    return {
+        "start_time": start,
+        "end_time": start + rd(hours=hours),
+        "volume": -1000,
+        "accepted_volume": -1000,
+        "price": 50,
+        "accepted_price": 50,
+        "agent_addr": "gen1",
+        "unit_id": unit_id,
+        "market_id": market_id,
+        "only_hours": None,
+    }
+
+
+def track_rewards(units_operator: UnitsOperator, unit_id="testdemand"):
+    """Replaces the unit's reward calculation by a call recorder."""
+    rewarded = []
+    strategy = units_operator.units[unit_id].bidding_strategies["EOM"]
+    strategy.calculate_reward = lambda unit, marketconfig, orderbook: rewarded.append(
+        orderbook
+    )
+    return rewarded
+
+
+async def test_cashflow_is_booked_at_clearing(units_operator: UnitsOperator):
+    marketconfig = units_operator.available_markets[0]
+    units_operator.registered_markets[marketconfig.market_id] = marketconfig
+    unit = units_operator.units["testdemand"]
+    rewarded = track_rewards(units_operator)
+
+    units_operator.handle_market_feedback(
+        {
+            "context": "clearing",
+            "market_id": "EOM",
+            "accepted_orders": [make_order()],
+            "rejected_orders": [],
+        },
+        {},
+    )
+
+    # the cashflow follows from the clearing result and is booked right away
+    assert unit.outputs["energy_cashflow"].at[start] == -1000 * 50
+    # the reward is deferred until the delivery period has been executed
+    assert rewarded == []
+    assert len(units_operator.pending_orders["EOM"]) == 1
+
+
+async def test_reward_is_calculated_after_delivery(units_operator: UnitsOperator):
+    marketconfig = units_operator.available_markets[0]
+    units_operator.registered_markets[marketconfig.market_id] = marketconfig
+    rewarded = track_rewards(units_operator)
+
+    units_operator.handle_market_feedback(
+        {
+            "context": "clearing",
+            "market_id": "EOM",
+            "accepted_orders": [make_order()],
+            "rejected_orders": [],
+        },
+        {},
+    )
+
+    # the time step of the product has not been executed yet
+    units_operator.calculate_unit_reward(start - rd(hours=1))
+    assert rewarded == []
+    assert len(units_operator.pending_orders["EOM"]) == 1
+
+    # the product [start, start + 1h) covers the single time step `start`,
+    # so it is complete once that step has been executed
+    units_operator.calculate_unit_reward(start)
+    assert len(rewarded) == 1
+    assert units_operator.pending_orders["EOM"] == []
+
+    # and it is not rewarded a second time
+    units_operator.calculate_unit_reward(start + rd(hours=1))
+    assert len(rewarded) == 1
+
+
+async def test_multi_step_product_is_rewarded_once_fully_executed(
+    units_operator: UnitsOperator,
+):
+    """
+    A multi-step product is rewarded over its whole span, so it must not be rewarded
+    before every one of its time steps has been executed.
+    """
+    marketconfig = units_operator.available_markets[0]
+    units_operator.registered_markets[marketconfig.market_id] = marketconfig
+    rewarded = track_rewards(units_operator)
+
+    units_operator.handle_market_feedback(
+        {
+            "context": "clearing",
+            "market_id": "EOM",
+            "accepted_orders": [make_order(hours=4)],
+            "rejected_orders": [],
+        },
+        {},
+    )
+
+    # [start, start + 4h) covers the time steps start .. start + 3h
+    for execute_until in (start, start + rd(hours=1), start + rd(hours=2)):
+        units_operator.calculate_unit_reward(execute_until)
+        assert rewarded == [], f"rewarded too early at {execute_until}"
+
+    units_operator.calculate_unit_reward(start + rd(hours=3))
+    assert len(rewarded) == 1
+    assert units_operator.pending_orders["EOM"] == []
+
+
+async def test_rewarded_order_stays_in_market_dispatch(units_operator: UnitsOperator):
+    """
+    The reward drains its own order store, so the market dispatch export keeps
+    aggregating the orders until their closing delta has been written.
+    """
+    marketconfig = units_operator.available_markets[0]
+    units_operator.registered_markets[marketconfig.market_id] = marketconfig
+    track_rewards(units_operator)
+
+    units_operator.handle_market_feedback(
+        {
+            "context": "clearing",
+            "market_id": "EOM",
+            "accepted_orders": [make_order()],
+            "rejected_orders": [],
+        },
+        {},
+    )
+    units_operator.calculate_unit_reward(start)
+
+    # the closing delta at end_time is only aggregated by the export after it
+    market_dispatch = units_operator.get_market_dispatch(
+        "energy", start + rd(hours=1), start + rd(hours=2)
+    )
+    assert len(market_dispatch) == 1
+
+
+async def test_execute_dispatch_trails_by_one_time_step(units_operator: UnitsOperator):
+    """
+    The delivery period of a product can start in the very time step in which its
+    market clears, and the clearing is not ordered against this task, so the
+    execution has to stay one time step behind the current time.
+    """
+    clock = units_operator.context.context.clock
+    calls = []
+
+    def record(start, end):
+        calls.append((start, end))
+        return []
+
+    units_operator.get_actual_dispatch = record
+
+    last = units_operator.last_executed_dispatch
+    clock.set_time(clock.time + 3600)
+    await units_operator.execute_dispatch()
+
+    now = timestamp2datetime(clock.time)
+    execute_until = now - units_operator.simulation_index.freq
+
+    # the executed range starts right after the previously executed one and ends one
+    # time step before now, so no time step is executed twice or executed too early
+    assert calls[0] == (timestamp2datetime(last + 1), execute_until)
+    assert units_operator.last_executed_dispatch == datetime2timestamp(execute_until)
+
+
+async def test_dispatch_of_the_clearing_time_step_is_not_executed_early(
+    units_operator: UnitsOperator,
+):
+    """
+    Regression test: with opening_duration == first_delivery the product delivering
+    [T, T+1h) is cleared at T. Executing time step T at T would run before that
+    clearing was handled.
+    """
+    marketconfig = units_operator.available_markets[0]
+    units_operator.registered_markets[marketconfig.market_id] = marketconfig
+    rewarded = track_rewards(units_operator)
+
+    clock = units_operator.context.context.clock
+    clock.set_time(datetime2timestamp(start))
+
+    calls = []
+
+    def record(range_start, range_end):
+        calls.append((range_start, range_end))
+        return []
+
+    units_operator.get_actual_dispatch = record
+    units_operator.last_executed_dispatch = datetime2timestamp(start - rd(hours=1))
+
+    # the market clears at `start` for the product delivering [start, start + 1h)
+    units_operator.handle_market_feedback(
+        {
+            "context": "clearing",
+            "market_id": "EOM",
+            "accepted_orders": [make_order()],
+            "rejected_orders": [],
+        },
+        {},
+    )
+
+    # executing at `start` must not touch the time step `start` yet
+    await units_operator.execute_dispatch()
+    assert calls[-1][1] == start - rd(hours=1)
+    assert rewarded == []
+
+    # one time step later it is executed and the product is rewarded
+    clock.set_time(datetime2timestamp(start + rd(hours=1)))
+    await units_operator.execute_dispatch()
+    assert calls[-1][1] == start
+    assert len(rewarded) == 1
+
+
+async def test_get_market_dispatch(units_operator: UnitsOperator):
+    clock = units_operator.context.context.clock
+
+    last = clock.time
+    clock.set_time(clock.time + 3600)
+
+    market_dispatch = units_operator.get_market_dispatch(
+        "energy", timestamp2datetime(last), timestamp2datetime(clock.time)
+    )
+    # no orders were cleared, so nothing is dispatched
     assert len(market_dispatch) == 0
 
 

--- a/tests/test_units_operator.py
+++ b/tests/test_units_operator.py
@@ -91,11 +91,9 @@ async def test_set_unit_dispatch(units_operator: UnitsOperator):
 
 
 async def test_write_market_dispatch(units_operator: UnitsOperator):
-    units_operator.write_market_dispatch("energy")
-    assert units_operator.last_sent_market_dispatch["energy"] > 0
+    units_operator.write_market_dispatch(units_operator.available_markets[0])
+    assert units_operator.last_sent_market_dispatch["EOM"] > 0
     assert units_operator.last_sent_market_dispatch["test"] == 0
-    units_operator.write_market_dispatch("test")
-    assert units_operator.last_sent_market_dispatch["test"] > 0
 
 
 async def test_write_actual_dispatch(units_operator: UnitsOperator):
@@ -303,7 +301,7 @@ async def test_rewarded_order_stays_in_market_dispatch(units_operator: UnitsOper
 
     # the closing delta at end_time is only aggregated by the export after it
     market_dispatch = units_operator.get_market_dispatch(
-        "energy", start + rd(hours=1), start + rd(hours=2)
+        "EOM", start + rd(hours=1), start + rd(hours=2)
     )
     assert len(market_dispatch) == 1
 
@@ -390,7 +388,7 @@ async def test_get_market_dispatch(units_operator: UnitsOperator):
     clock.set_time(clock.time + 3600)
 
     market_dispatch = units_operator.get_market_dispatch(
-        "energy", timestamp2datetime(last), timestamp2datetime(clock.time)
+        "EOM", timestamp2datetime(last), timestamp2datetime(clock.time)
     )
     # no orders were cleared, so nothing is dispatched
     assert len(market_dispatch) == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,9 @@ from assume.common.fast_pandas import FastIndex, FastSeries
 from assume.common.market_objects import MarketConfig, MarketProduct
 from assume.common.utils import (
     aggregate_step_amount,
-    convert_to_rrule_freq,
+    convert_str_to_rrule_freq,
+    convert_timedelta_to_rrule_freq,
+    create_rrule,
     datetime2timestamp,
     get_available_products,
     get_products_index,
@@ -39,16 +41,34 @@ from .utils import create_orderbook
 
 
 def test_convert_rrule():
-    freq, interval = convert_to_rrule_freq("1h")
+    freq, interval = convert_str_to_rrule_freq("1h")
     assert freq == rr.HOURLY
     assert interval == 1
 
     with pytest.raises(ValueError):
-        freq, interval = convert_to_rrule_freq("h")
+        freq, interval = convert_str_to_rrule_freq("h")
 
-    freq, interval = convert_to_rrule_freq("99d")
+    freq, interval = convert_str_to_rrule_freq("99d")
     assert freq == rr.DAILY
     assert interval == 99
+
+
+def test_convert_timedelta_rrule():
+    # the coarsest matching unit is used, as a SECONDLY rule with a large
+    # interval is much more expensive for dateutil to iterate
+    assert convert_timedelta_to_rrule_freq(timedelta(hours=1)) == (rr.HOURLY, 1)
+    assert convert_timedelta_to_rrule_freq(timedelta(hours=4)) == (rr.HOURLY, 4)
+    assert convert_timedelta_to_rrule_freq(timedelta(minutes=15)) == (rr.MINUTELY, 15)
+    assert convert_timedelta_to_rrule_freq(timedelta(seconds=90)) == (rr.SECONDLY, 90)
+
+    with pytest.raises(ValueError):
+        convert_timedelta_to_rrule_freq(timedelta(0))
+
+
+def test_create_rrule_with_timedelta():
+    start = datetime(2020, 1, 1)
+    rule = create_rrule(start, start + timedelta(hours=3), timedelta(hours=1))
+    assert list(rule) == [start + timedelta(hours=i) for i in range(4)]
 
 
 def test_reproducability_with_seed():


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Related Issue
Closes #<issue‑number>
Also fixes missing final time step of "market_dispatch" outputs.

## Description

Splits the cashflow from the reward calculation and decouples the export of the *market*
dispatch from the execution of the *actual* dispatch. This enables reward calculation based on final feasibility and supports the implementation of multi-market RL strategies. 

Until now, `write_actual_dispatch` was triggered by every market clearing and did three things at
once: aggregate the accepted orders per market, execute the units' dispatch and calculate cashflow
and reward. That coupling meant the executed dispatch (and with it the reward) depended on expectations about the future delivery, e.g. if starting-costs need to be attributed to the reward of the market. 

**Cashflow vs. reward**

- `BaseUnit.calculate_cashflow_and_reward` is split into `calculate_cashflow` and
  `calculate_reward`. The cashflow follows directly from the accepted prices and volumes, so it is
  booked immediately at clearing. The reward depends on the dispatch that is actually realized, so
  it is deferred.
- `UnitsOperator` keeps the orders of every market in `pending_orders` until their delivery period
  has ended; `calculate_unit_reward` then computes the unit and portfolio rewards on the basis of
  the dispatch actually realized across *all* markets that cleared for that delivery period.
- Because profits and costs can now receive contributions from several markets for the same time
  step, the heuristic strategies (`flexable`, `flexable_storage`) accumulate into
  `unit.outputs["profit"]` / `["total_costs"]` instead of overwriting them.

**Market dispatch vs. actual dispatch**

- `execute_dispatch` is scheduled as a recurrent task on the simulation index, so the units'
  dispatch is executed exactly once per time step, independent of any market. It writes the
  `unit_dispatch` output and triggers the reward calculation for all delivery periods that have
  passed. 
- `write_market_dispatch` stays at the clearing and is now tracked **per market** rather than per
  product type (the aggregation groups by `market_id` anyway). At the last clearing of a market it
  aggregates up to the market end, so the results of the final clearing are exported as well. It therefore fixes the missing final timestep in the `market_dispatch` output.

**Supporting changes**

- The last possible market opening moves from `MarketMechanism.last_market_opening` to a
  `MarketConfig.last_opening` property, so the units operator can use it to detect the final
  clearing.
- `create_rrule` accepts a `timedelta` in addition to a frequency string;
  `convert_to_rrule_freq` is renamed to `convert_str_to_rrule_freq` and complemented by
  `convert_timedelta_to_rrule_freq`, which picks the coarsest matching unit (`HOURLY` /
  `MINUTELY` / `SECONDLY`) so that iterating the rule stays cheap.
- `Learning.store_to_buffer_and_update` yields once before reading the caches, since the rewards
  are now written after the delivery period.

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added -> but need to be revised
- [ ] Changes noted in release notes (if any)
- [ ] Consent to release this PR's code under the GNU Affero General Public License v3.0

## Additional Notes (optional)
Several `TODO`s are added where the current cost/reward attribution is questionable now that a unit
can be active on several markets at once (generation costs as the product instead of the integral
of the marginal cost, start-up cost allocation across markets, costs based on dispatch instead of
accepted volume, missing profit outputs in the portfolio learning strategy). 

Tests still need to be reviewed and potentially added.

There are also multiple other `TODO`s that need to be investigated before converting this into a review-ready PR .

