### PR TITLE
Balancing markets query wrong forecaster

### DIFF
--- a/assume/strategies/flexable.py
+++ b/assume/strategies/flexable.py
@@ -312,7 +312,7 @@ class CapacityHeuristicBalancingPosStrategy(MinMaxStrategy):
             )
             # Specific revenue if power was offered on the energy market
             specific_revenue = get_specific_revenue(
-                price_forecast=unit.forecaster.price[market_config.market_id],
+                price_forecast=unit.forecaster.price["EOM"],
                 marginal_cost=marginal_cost,
                 t=start,
                 foresight=self.foresight,
@@ -423,7 +423,7 @@ class CapacityHeuristicBalancingNegStrategy(MinMaxStrategy):
 
             # Specific revenue if power was offered on the energy market
             specific_revenue = get_specific_revenue(
-                price_forecast=unit.forecaster.price[market_config.market_id],
+                price_forecast=unit.forecaster.price["EOM"],
                 marginal_cost=marginal_cost,
                 t=start,
                 foresight=self.foresight,

--- a/assume/strategies/flexable_storage.py
+++ b/assume/strategies/flexable_storage.py
@@ -298,7 +298,7 @@ class StorageCapacityHeuristicBalancingPosStrategy(MinMaxChargeStrategy):
                 marginal_cost=marginal_cost,
                 t=start,
                 foresight=self.foresight,
-                price_forecast=unit.forecaster.price[market_config.market_id],
+                price_forecast=unit.forecaster.price["EOM"],
             )
 
             # if specific revenue is positive, bid specific_revenue

--- a/docs/source/release_notes.rst
+++ b/docs/source/release_notes.rst
@@ -59,6 +59,7 @@ Upcoming Release
   - **Fix errors in portfolio learning strategies**: The ``min_max_rescale`` function was missing from ``utils.py``, causing an ``ImportError`` in ``portfolio_learning_strategies.py``. Resolved by extending ``min_max_scale`` to cover the rescaling use case. And fix minor construction bug for observation space.
   - **Skip torch seeding when torch is installed but not used**: Irrelevant seeding was performed and a warning was thrown about deterministic PyTorch behavior, even though simulation does not use RL. This is fixed by only setting the PyTorch seeds when learning is active.
   - **Fix bug in redispatch mechanism**: Fixed the bug in redispatch evaluation due to PyPSA's version upgrade. In ``PyPSA >= 0.35.2`` (released in February 2025) the sign of load was not taken into account correctly & since the fixed EOM dispatch was modelled as a load with positive sign which was resulting in incorrect redispatch amounts.
+  - **Fix bug in flexable balancing market strategies**: Flexables balancing market strategies queried ``get_specific_revenue`` with forecasted market prices from their own markets instead of from the "EOM" market.
 
 0.6.0 - (18th March 2026)
 =========================


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: ASSUME Developers

SPDX-License-Identifier: AGPL-3.0-or-later
-->

## Description
Removes a bug where the balancing market strategies: 
- StorageCapacityHeuristicBalancingPosStrategy
- CapacityHeuristicBalancingPosStrategy
- CapacityHeuristicBalancingNegStrategy

try to calculate potential revenues on the EOM market, but query their own balancing market instead.

## Checklist
- [ ] Documentation updated (docstrings, READMEs, user guides, inline comments, `docs` folder updates, etc.)
- [ ] New unit/integration tests added (if applicable)
- [x] Changes noted in release notes (if any)
- [x] Consent to release this PR's code under the GNU Affero General Public License v3.0
